### PR TITLE
feat(metrics): keep read_bytes_count unchanged and add experimental_read_bytes_count and transition tracking

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,3 +1,46 @@
-# GCSFuse Metrics
+# Cloud Storage FUSE Metrics Reference Guide
 
-For instructions on how to enable and use Cloud Storage FUSE metrics, refer to the metrics guide at <https://cloud.google.com/storage/docs/cloud-storage-fuse/metrics>.
+For instructions on how to enable and export Cloud Storage FUSE metrics, refer to the official Google Cloud metrics guide at <https://cloud.google.com/storage/docs/cloud-storage-fuse/metrics>.
+
+This document provides a detailed technical reference for the **experimental client-side metrics** introduced in the `read-split` tracking branches to monitor GCS reader lifetimes, strategy transitions, and connection preemption cancellations.
+
+---
+
+## Experimental GCS Metrics
+
+These metrics are prefixed with `gcs/experimental_` and are designed to capture connection preemption telemetries to help align GCSFuse client-side connection states with GCS server-side request logs.
+
+### 1. `gcs/experimental_reader_cancellation_count`
+
+* **Metric Type**: Cumulative Integer Counter (`int_counter`)
+* **Description**: Tracks the cumulative number of times an in-flight open GCS object reader connection is aborted or explicitly closed before the requested GCS byte range has been fully read. Each preemption registers as an aborted/cancelled request in GCS server-side logs; this metric maps the client-side preemption trigger directly to those telemetry cancellations.
+* **Attributes**:
+  * **`reason`** (string): Identifies the direct trigger of the GCS stream preemption cancellation:
+    * **`"canceled"`**: The calling FUSE kernel context was explicitly canceled (e.g., manual read preemption, SIGINT, client interrupt, or aborted threads).
+    * **`"deadline_exceeded"`**: The calling context expired because of a read timeout or deadline breach.
+    * **`"inactive_timeout"`**: The background inactivity monitoring loop explicitly reclaimed and closed the idle connection because no read operations were seen during the timeout window.
+    * **`"seek"`**: A FUSE offset jump (seek) within the sequential read strategy required closing the active GCS HTTP stream before it was fully read to realign the offset.
+    * **`"sequential_to_random"`**: The classifier transitioned the active read strategy from sequential to random access, preempting and closing the active RangeReader sequential connection.
+    * **`"explicit_close"`**: The client explicitly closed/released the local file handle before consuming the full prefetch range requested from GCS.
+    * **`"forced_recreate"`**: GCSFuse forced the recreation/refresh of the active range reader before the GCS stream range was fully read.
+    * **`"unknown"`**: A fallback indicator for untracked socket closures.
+
+---
+
+## Experimental Read Operation Metrics
+
+These metrics are prefixed with `read/experimental_` and monitor read strategy heuristics, seeking behaviors, and runtime strategy modifications.
+
+### 1. `read/experimental_read_type_transitions_count`
+
+* **Metric Type**: Cumulative Integer Counter (`int_counter`)
+* **Description**: Tracks the cumulative number of read strategy state-transitions (from sequential-to-random or random-to-sequential) executed by the adaptive read strategy classifier.
+* **Attributes**:
+  * **`transition_type`** (string): The direction of the strategy transition:
+    * **`"sequential_to_random"`**: Transitioned from sequential prefetch reads to random-access reads.
+    * **`"random_to_sequential"`**: Transitioned from random-access reads back to sequential prefetch access.
+  * **`reason`** (string): The concrete read pattern heuristic that triggered the transition:
+    * **`"initial_offset_non_zero"`**: The first read request arrived at a non-zero starting offset, causing GCSFuse to initialize the read strategy as random access.
+    * **`"backward_seek"`**: A backward jump in read offset triggered a random-access state.
+    * **`"forward_seek"`**: A forward jump beyond the sequential prefetch window (8MB) triggered a random-access state.
+    * **`"average_read_size_large_enough"`**: The average block read size successfully crossed the prefetch window limit (8MB), triggering a switch back to sequential prefetch access.

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -312,7 +312,7 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (res
 	defer func() {
 		dur := time.Since(start)
 		p.metricHandle.BufferedReadReadLatency(ctx, dur)
-		p.metricHandle.GcsReadBytesCount(int64(bytesRead))
+		p.metricHandle.GcsReadBytesCount(int64(bytesRead), metrics.ReadTypeNames[req.ReadType])
 
 		if err == nil || errors.Is(err, io.EOF) {
 			logger.Tracef("%.13v -> ReadAt(): Ok(%v)", reqID, dur)

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -312,7 +312,8 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (res
 	defer func() {
 		dur := time.Since(start)
 		p.metricHandle.BufferedReadReadLatency(ctx, dur)
-		p.metricHandle.GcsReadBytesCount(int64(bytesRead), metrics.ReadTypeNames[req.ReadType])
+		p.metricHandle.GcsReadBytesCount(int64(bytesRead))
+		p.metricHandle.GcsExperimentalReadBytesCount(int64(bytesRead), metrics.ReadTypeNames[req.ReadType])
 
 		if err == nil || errors.Is(err, io.EOF) {
 			logger.Tracef("%.13v -> ReadAt(): Ok(%v)", reqID, dur)

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -142,7 +142,7 @@ func (t *BufferedReaderTest) SetupTest() {
 	t.workerPool.Start()
 	t.metricHandle = metrics.NewNoopMetrics()
 	t.ctx = context.Background()
-	t.readTypeClassifier = gcsx.NewReadTypeClassifier(1, 0)
+	t.readTypeClassifier = gcsx.NewReadTypeClassifier(1, 0, nil)
 }
 
 func (t *BufferedReaderTest) TearDownTest() {
@@ -1563,7 +1563,7 @@ func (t *BufferedReaderTest) TestReadAtResumesAfterFallbackWhenReadBecomesSequen
 		GlobalMaxBlocksSem: t.globalMaxBlocksSem,
 		WorkerPool:         t.workerPool,
 		MetricHandle:       t.metricHandle,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(1, 0),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(1, 0, nil),
 	})
 	reader.randomReadsThreshold = 2
 	require.NoError(t.T(), err)

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -142,7 +142,7 @@ func (t *BufferedReaderTest) SetupTest() {
 	t.workerPool.Start()
 	t.metricHandle = metrics.NewNoopMetrics()
 	t.ctx = context.Background()
-	t.readTypeClassifier = gcsx.NewReadTypeClassifier(1, 0, nil)
+	t.readTypeClassifier = gcsx.NewReadTypeClassifier(1, 0, metrics.NewNoopMetrics())
 }
 
 func (t *BufferedReaderTest) TearDownTest() {
@@ -1563,7 +1563,7 @@ func (t *BufferedReaderTest) TestReadAtResumesAfterFallbackWhenReadBecomesSequen
 		GlobalMaxBlocksSem: t.globalMaxBlocksSem,
 		WorkerPool:         t.workerPool,
 		MetricHandle:       t.metricHandle,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(1, 0, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(1, 0, metrics.NewNoopMetrics()),
 	})
 	reader.randomReadsThreshold = 2
 	require.NoError(t.T(), err)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -323,8 +323,9 @@ func (job *Job) downloadObjectToFile(cacheFile *os.File) (err error) {
 	for start < end {
 		if newReader == nil {
 			newReaderLimit = min(start+sequentialReadSize, end)
+			cancelCtx := metrics.ContextWithReadType(job.cancelCtx, metrics.ReadTypeNames[metrics.ReadTypeSequential])
 			newReader, err = job.bucket.NewReaderWithReadHandle(
-				job.cancelCtx,
+				cancelCtx,
 				&gcs.ReadObjectRequest{
 					Name:       job.object.Name,
 					Generation: job.object.Generation,

--- a/internal/cache/file/downloader/parallel_downloads_job.go
+++ b/internal/cache/file/downloader/parallel_downloads_job.go
@@ -34,6 +34,7 @@ import (
 //
 // This function doesn't take locks and can be executed parallely.
 func (job *Job) downloadRange(ctx context.Context, dstWriter io.Writer, start, end int64, readHandle []byte, rangeMap map[int64]int64) ([]byte, error) {
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeNames[metrics.ReadTypeParallel])
 	newReader, err := job.bucket.NewReaderWithReadHandle(
 		ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/cache/file/downloader/sparse_downloads_job.go
+++ b/internal/cache/file/downloader/sparse_downloads_job.go
@@ -203,6 +203,7 @@ func (job *Job) downloadSparseRange(ctx context.Context, start, end uint64) erro
 	}
 
 	// Create GCS reader for the specific range
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeNames[metrics.ReadTypeRandom])
 	newReader, err := job.bucket.NewReaderWithReadHandle(
 		ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -335,9 +335,9 @@ func TestGCSMetrics_WithFileCache(t *testing.T) {
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/reader_count",
 		attribute.NewSet(attribute.String("io_method", "closed")),
 		1)
-	// gcs/read_bytes_count - 0 attributes
+	// gcs/read_bytes_count - Sequential
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
-		attribute.NewSet(),
+		attribute.NewSet(attribute.String("read_type", "Sequential")),
 		int64(len(content)))
 
 	// Second Read - Should hit cache
@@ -365,7 +365,7 @@ func TestGCSMetrics_WithFileCache(t *testing.T) {
 		attribute.NewSet(attribute.String("io_method", "closed")),
 		1)
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
-		attribute.NewSet(),
+		attribute.NewSet(attribute.String("read_type", "Sequential")),
 		int64(len(content)))
 }
 
@@ -430,7 +430,7 @@ func TestGCSMetrics_ParallelDownloads(t *testing.T) {
 		5)
 	// Verify read bytes count
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
-		attribute.NewSet(),
+		attribute.NewSet(attribute.String("read_type", "Parallel")),
 		int64(fileSize))
 }
 

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -335,8 +335,12 @@ func TestGCSMetrics_WithFileCache(t *testing.T) {
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/reader_count",
 		attribute.NewSet(attribute.String("io_method", "closed")),
 		1)
-	// gcs/read_bytes_count - Sequential
+	// gcs/read_bytes_count - 0 attributes
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
+		attribute.NewSet(),
+		int64(len(content)))
+	// gcs/experimental_read_bytes_count - Sequential
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_bytes_count",
 		attribute.NewSet(attribute.String("read_type", "Sequential")),
 		int64(len(content)))
 
@@ -365,6 +369,9 @@ func TestGCSMetrics_WithFileCache(t *testing.T) {
 		attribute.NewSet(attribute.String("io_method", "closed")),
 		1)
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
+		attribute.NewSet(),
+		int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_bytes_count",
 		attribute.NewSet(attribute.String("read_type", "Sequential")),
 		int64(len(content)))
 }
@@ -430,6 +437,9 @@ func TestGCSMetrics_ParallelDownloads(t *testing.T) {
 		5)
 	// Verify read bytes count
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
+		attribute.NewSet(),
+		int64(fileSize))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_bytes_count",
 		attribute.NewSet(attribute.String("read_type", "Parallel")),
 		int64(fileSize))
 }

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -304,6 +304,7 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, inclu
 
 // Open a reader for the generation of object we care about.
 func (f *FileInode) openReader(ctx context.Context) (io.ReadCloser, error) {
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeSequentialAttr)
 	rc, err := f.bucket.NewReaderWithReadHandle(
 		ctx,
 		&gcs.ReadObjectRequest{

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -226,7 +226,8 @@ func TestReadFile_BufferedReadMetrics(t *testing.T) {
 
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeBufferedAttr))), int64(len(content)))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeSequentialAttr))), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeSequentialAttr))), int64(len(content)))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "buffered_read/read_latency", attribute.NewSet(), uint64(1))
 }
 
@@ -604,7 +605,8 @@ func TestReadFile_KernelMRDReaderMetrics(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(1))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/request_count", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), int64(1))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "gcs/request_latencies", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), uint64(1))
 }
@@ -699,6 +701,9 @@ func TestReadFile_GCSReaderRandomReadMetrics(t *testing.T) {
 
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(4))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(30))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+		attribute.NewSet(attribute.String("reason", string(metrics.ReasonInitialOffsetNonZeroAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
+		1)
 }
 
 func TestGetInodeAttributes_Metrics(t *testing.T) {

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -1664,3 +1664,144 @@ func TestStreamingWrites_Fallback_ConcurrencyLimitBreached(t *testing.T) {
 	attrs := attribute.NewSet(attribute.String("write_fallback_reason", "concurrency_limit_breached"))
 	metrics.VerifyCounterMetric(t, ctx, reader, "fs/streaming_write_fallback_count", attrs, 1, metrics.Subset())
 }
+
+func TestReadFile_GCSReaderBackwardSeekTransition(t *testing.T) {
+	ctx := context.Background()
+	params := defaultServerConfigParams()
+	params.enableNewReader = true
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, params, false)
+	server = wrappers.WithMonitoring(server, mh)
+	fileName := "test.txt"
+	content := "test content with 30 bytes"
+	createWithContents(ctx, t, bucket, fileName, content)
+	lookupOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   fileName,
+	}
+	err := server.LookUpInode(ctx, lookupOp)
+	require.NoError(t, err, "LookUpInode")
+	openOp := &fuseops.OpenFileOp{
+		Inode: lookupOp.Entry.Child,
+	}
+	err = server.OpenFile(ctx, openOp)
+	require.NoError(t, err, "OpenFile")
+
+	// First read: offset 0, read 5 bytes.
+	readOp := &fuseops.ReadFileOp{
+		Inode:  lookupOp.Entry.Child,
+		Handle: openOp.Handle,
+		Offset: 0,
+		Dst:    make([]byte, 5),
+	}
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+
+	// Second read: offset 2, read 5 bytes. Backward seek!
+	readOp.Offset = 2
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+	waitForMetricsProcessing()
+
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+		attribute.NewSet(attribute.String("reason", string(metrics.ReasonBackwardSeekAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
+		1)
+}
+
+func TestReadFile_GCSReaderForwardSeekTransition(t *testing.T) {
+	ctx := context.Background()
+	params := defaultServerConfigParams()
+	params.enableNewReader = true
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, params, false)
+	server = wrappers.WithMonitoring(server, mh)
+	fileName := "test.txt"
+	// Create a 9MB file to allow forward seek beyond maxReadSize (8MB)
+	fileSize := 9 * 1024 * 1024
+	content := string(make([]byte, fileSize))
+	createWithContents(ctx, t, bucket, fileName, content)
+	lookupOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   fileName,
+	}
+	err := server.LookUpInode(ctx, lookupOp)
+	require.NoError(t, err, "LookUpInode")
+	openOp := &fuseops.OpenFileOp{
+		Inode: lookupOp.Entry.Child,
+	}
+	err = server.OpenFile(ctx, openOp)
+	require.NoError(t, err, "OpenFile")
+
+	// First read: offset 0, read 5 bytes.
+	readOp := &fuseops.ReadFileOp{
+		Inode:  lookupOp.Entry.Child,
+		Handle: openOp.Handle,
+		Offset: 0,
+		Dst:    make([]byte, 5),
+	}
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+
+	// Second read: offset 8.5MB (8912896), read 5 bytes. Forward seek!
+	readOp.Offset = 8912896
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+	waitForMetricsProcessing()
+
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+		attribute.NewSet(attribute.String("reason", string(metrics.ReasonForwardSeekAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
+		1)
+}
+
+func TestReadFile_GCSReaderRandomToSequentialTransition(t *testing.T) {
+	ctx := context.Background()
+	params := defaultServerConfigParams()
+	params.enableNewReader = true
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, params, false)
+	server = wrappers.WithMonitoring(server, mh)
+	fileName := "test.txt"
+	// Create a 10MB file
+	fileSize := 10 * 1024 * 1024
+	content := string(make([]byte, fileSize))
+	createWithContents(ctx, t, bucket, fileName, content)
+	lookupOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   fileName,
+	}
+	err := server.LookUpInode(ctx, lookupOp)
+	require.NoError(t, err, "LookUpInode")
+	openOp := &fuseops.OpenFileOp{
+		Inode: lookupOp.Entry.Child,
+	}
+	err = server.OpenFile(ctx, openOp)
+	require.NoError(t, err, "OpenFile")
+
+	// First read: offset 100 (non-zero). Starts as Random.
+	readOp := &fuseops.ReadFileOp{
+		Inode:  lookupOp.Entry.Child,
+		Handle: openOp.Handle,
+		Offset: 100,
+		Dst:    make([]byte, 5),
+	}
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+
+	// Contiguous reads: 9 contiguous reads of 1MB each.
+	// This will increment totalReadBytes to 9MB + 5 bytes without triggering seeks.
+	// At the start of the 9th read, averageReadBytes will cross 8MB threshold, triggering transition to Sequential.
+	chunkSize := 1 * 1024 * 1024 // 1MB
+	var nextOffset int64 = 105
+	for i := 0; i < 9; i++ {
+		readOp.Offset = nextOffset
+		readOp.Dst = make([]byte, chunkSize)
+		err = server.ReadFile(ctx, readOp)
+		require.NoError(t, err, "ReadFile")
+		nextOffset += int64(readOp.BytesRead)
+	}
+	waitForMetricsProcessing()
+
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+		attribute.NewSet(attribute.String("reason", string(metrics.ReasonInitialOffsetNonZeroAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
+		1)
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+		attribute.NewSet(attribute.String("reason", string(metrics.ReasonAverageReadSizeLargeEnoughAttr)), attribute.String("transition_type", string(metrics.TransitionTypeRandomToSequentialAttr))),
+		1)
+}

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -226,7 +226,7 @@ func TestReadFile_BufferedReadMetrics(t *testing.T) {
 
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeBufferedAttr))), int64(len(content)))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeSequentialAttr))), int64(len(content)))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "buffered_read/read_latency", attribute.NewSet(), uint64(1))
 }
 
@@ -604,7 +604,7 @@ func TestReadFile_KernelMRDReaderMetrics(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(1))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/request_count", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), int64(1))
 	metrics.VerifyHistogramMetric(t, ctx, reader, "gcs/request_latencies", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), uint64(1))
 }

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -701,7 +701,7 @@ func TestReadFile_GCSReaderRandomReadMetrics(t *testing.T) {
 
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(4))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(30))
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+	metrics.VerifyCounterMetric(t, ctx, reader, "read/experimental_read_type_transitions_count",
 		attribute.NewSet(attribute.String("reason", string(metrics.ReasonInitialOffsetNonZeroAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
 		1)
 }
@@ -1702,7 +1702,7 @@ func TestReadFile_GCSReaderBackwardSeekTransition(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	waitForMetricsProcessing()
 
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+	metrics.VerifyCounterMetric(t, ctx, reader, "read/experimental_read_type_transitions_count",
 		attribute.NewSet(attribute.String("reason", string(metrics.ReasonBackwardSeekAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
 		1)
 }
@@ -1746,7 +1746,7 @@ func TestReadFile_GCSReaderForwardSeekTransition(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	waitForMetricsProcessing()
 
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+	metrics.VerifyCounterMetric(t, ctx, reader, "read/experimental_read_type_transitions_count",
 		attribute.NewSet(attribute.String("reason", string(metrics.ReasonForwardSeekAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
 		1)
 }
@@ -1798,10 +1798,10 @@ func TestReadFile_GCSReaderRandomToSequentialTransition(t *testing.T) {
 	}
 	waitForMetricsProcessing()
 
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+	metrics.VerifyCounterMetric(t, ctx, reader, "read/experimental_read_type_transitions_count",
 		attribute.NewSet(attribute.String("reason", string(metrics.ReasonInitialOffsetNonZeroAttr)), attribute.String("transition_type", string(metrics.TransitionTypeSequentialToRandomAttr))),
 		1)
-	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/experimental_read_type_transitions_count",
+	metrics.VerifyCounterMetric(t, ctx, reader, "read/experimental_read_type_transitions_count",
 		attribute.NewSet(attribute.String("reason", string(metrics.ReasonAverageReadSizeLargeEnoughAttr)), attribute.String("transition_type", string(metrics.TransitionTypeRandomToSequentialAttr))),
 		1)
 }

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -86,7 +86,7 @@ func (t *gcsReaderTest) SetupTest() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 0, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 0, metrics.NewNoopMetrics()),
 	})
 	t.ctx = context.Background()
 }
@@ -111,7 +111,7 @@ func (t *gcsReaderTest) Test_NewGCSReader() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics()),
 	})
 
 	assert.Equal(t.T(), object, gcsReader.object)
@@ -304,7 +304,7 @@ func (t *gcsReaderTest) Test_ReadAt_PropagatesCancellation() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}},
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics()),
 	})
 	// Set up a blocking reader
 	finishRead := make(chan struct{})
@@ -446,7 +446,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 13*MiB, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 13*MiB, metrics.NewNoopMetrics()),
 	})
 	t.gcsReader.rangeReader.reader = nil
 	t.gcsReader.mrr.isMRDInUse.Store(false)
@@ -500,7 +500,7 @@ func (t *gcsReaderTest) Test_ReadAt_ShortReadRetry() {
 				TraceHandle:        tracing.NewNoopTracer(),
 				MrdWrapper:         nil,
 				Config:             nil,
-				ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, nil),
+				ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, metrics.NewNoopMetrics()),
 			})
 			t.object.Size = 200
 			t.mockBucket.On("BucketType", mock.Anything).Return(tc.bucketType)
@@ -530,7 +530,7 @@ func (t *gcsReaderTest) Test_ReadAt_ParallelRandomReads() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, nil),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, metrics.NewNoopMetrics()),
 	})
 
 	// Setup

--- a/internal/gcsx/client_readers/gcs_reader_test.go
+++ b/internal/gcsx/client_readers/gcs_reader_test.go
@@ -86,7 +86,7 @@ func (t *gcsReaderTest) SetupTest() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 0),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 0, nil),
 	})
 	t.ctx = context.Background()
 }
@@ -111,7 +111,7 @@ func (t *gcsReaderTest) Test_NewGCSReader() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
 	})
 
 	assert.Equal(t.T(), object, gcsReader.object)
@@ -304,7 +304,7 @@ func (t *gcsReaderTest) Test_ReadAt_PropagatesCancellation() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}},
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
 	})
 	// Set up a blocking reader
 	finishRead := make(chan struct{})
@@ -446,7 +446,7 @@ func (t *gcsReaderTest) Test_ReadAt_ValidateZonalRandomReads() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 13*MiB),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 13*MiB, nil),
 	})
 	t.gcsReader.rangeReader.reader = nil
 	t.gcsReader.mrr.isMRDInUse.Store(false)
@@ -500,7 +500,7 @@ func (t *gcsReaderTest) Test_ReadAt_ShortReadRetry() {
 				TraceHandle:        tracing.NewNoopTracer(),
 				MrdWrapper:         nil,
 				Config:             nil,
-				ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1),
+				ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, nil),
 			})
 			t.object.Size = 200
 			t.mockBucket.On("BucketType", mock.Anything).Return(tc.bucketType)
@@ -530,7 +530,7 @@ func (t *gcsReaderTest) Test_ReadAt_ParallelRandomReads() {
 		TraceHandle:        tracing.NewNoopTracer(),
 		MrdWrapper:         nil,
 		Config:             nil,
-		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1),
+		ReadTypeClassifier: gcsx.NewReadTypeClassifier(int64(sequentialReadSizeInMb), 1, nil),
 	})
 
 	// Setup

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -71,6 +71,9 @@ func NewRangeReader(object *gcs.MinObject, bucket gcs.Bucket, config *cfg.Config
 	if traceHandle == nil {
 		traceHandle = tracing.NewNoopTracer()
 	}
+	if metricHandle == nil {
+		metricHandle = metrics.NewNoopMetrics()
+	}
 
 	return &RangeReader{
 		object:       object,
@@ -103,14 +106,33 @@ func (rr *RangeReader) checkInvariants() {
 func (rr *RangeReader) destroy() {
 	// Close out the reader, if we have one.
 	if rr.reader != nil {
-		rr.closeReader()
+		rr.closeReader("destroy", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
 }
 
 // closeReader fetches the readHandle before closing the reader instance.
-func (rr *RangeReader) closeReader() {
+func (rr *RangeReader) closeReader(caller string, readType int64) {
+	if rr.reader != nil && rr.start < rr.limit {
+		var reason metrics.Reason
+		switch caller {
+		case "destroy":
+			reason = metrics.ReasonExplicitCloseAttr
+		case "force_create":
+			reason = metrics.ReasonForcedRecreateAttr
+		case "invalidation":
+			if readType == metrics.ReadTypeRandom {
+				reason = metrics.ReasonSequentialToRandomAttr
+			} else {
+				reason = metrics.ReasonSeekAttr
+			}
+		default:
+			reason = metrics.ReasonUnknownAttr
+		}
+		rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
+	}
+
 	rr.readHandle = rr.reader.ReadHandle()
 	err := rr.reader.Close()
 	if err != nil {
@@ -125,7 +147,7 @@ func (rr *RangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (
 	)
 
 	if req.ForceCreateReader && rr.reader != nil {
-		rr.closeReader()
+		rr.closeReader("force_create", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -162,7 +184,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 		err = fmt.Errorf("reader returned extra bytes: %d", rr.start-rr.limit)
 
 		// Don't attempt to reuse the reader when it's malfunctioning.
-		rr.closeReader()
+		rr.closeReader("malfunction", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -173,7 +195,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 
 	// Are we finished with this reader now?
 	if rr.start == rr.limit {
-		rr.closeReader()
+		rr.closeReader("normal", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -223,6 +245,16 @@ func (rr *RangeReader) readFull(ctx context.Context, p []byte) (int, error) {
 					return
 
 				default:
+					var reason metrics.Reason
+					switch {
+					case errors.Is(ctx.Err(), context.Canceled):
+						reason = metrics.ReasonCanceledAttr
+					case errors.Is(ctx.Err(), context.DeadlineExceeded):
+						reason = metrics.ReasonDeadlineExceededAttr
+					default:
+						reason = metrics.ReasonUnknownAttr
+					}
+					rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 					rr.cancel()
 				}
 			}
@@ -250,7 +282,8 @@ func (rr *RangeReader) startRead(ctx context.Context, start int64, end int64, re
 				Start: uint64(start),
 				Limit: uint64(end),
 			},
-			rr.config.Read.InactiveStreamTimeout)
+			rr.config.Read.InactiveStreamTimeout,
+			rr.metricHandle)
 	} else {
 		rr.reader, err = rr.bucket.NewReaderWithReadHandle(
 			ctx,
@@ -324,13 +357,14 @@ func (rr *RangeReader) skipBytes(offset int64) {
 // Parameters:
 //   - startOffset: the starting byte position of the requested read.
 //   - endOffset: the ending byte position of the requested read.
-func (rr *RangeReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64) {
+//   - readType: the strategy of the incoming read operation.
+func (rr *RangeReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64, readType int64) {
 	// If we have an existing reader, but it's positioned at the wrong place,
 	// clean it up and throw it away.
 	// We will also clean up the existing reader if it can't serve the entire request.
 	dataToRead := math.Min(float64(endOffset), float64(rr.object.Size))
 	if rr.reader != nil && (rr.start != startOffset || int64(dataToRead) > rr.limit) {
-		rr.closeReader()
+		rr.closeReader("invalidation", readType)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -344,7 +378,7 @@ func (rr *RangeReader) readFromExistingReader(ctx context.Context, req *gcsx.GCS
 	// Since we are reading from an existing reader, we only need to read what was requested.
 	endOffset := min(req.Offset + int64(len(req.Buffer)))
 
-	rr.invalidateReaderIfMisalignedOrTooSmall(req.Offset, endOffset)
+	rr.invalidateReaderIfMisalignedOrTooSmall(req.Offset, endOffset, req.ReadType)
 	if rr.reader != nil {
 		return rr.readFromRangeReader(ctx, req.Buffer, req.Offset, endOffset, req.ReadType)
 	}

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -62,9 +62,11 @@ type RangeReader struct {
 	readHandle []byte
 	cancel     func()
 
-	config       *cfg.Config
-	metricHandle metrics.MetricHandle
-	traceHandle  tracing.TraceHandle
+	config              *cfg.Config
+	metricHandle        metrics.MetricHandle
+	traceHandle         tracing.TraceHandle
+	connectionReadBytes int64
+	preemptionReason    metrics.Reason
 }
 
 func NewRangeReader(object *gcs.MinObject, bucket gcs.Bucket, config *cfg.Config, metricHandle metrics.MetricHandle, traceHandle tracing.TraceHandle) *RangeReader {
@@ -115,22 +117,26 @@ func (rr *RangeReader) destroy() {
 // closeReader fetches the readHandle before closing the reader instance.
 func (rr *RangeReader) closeReader(caller string, readType int64) {
 	if rr.reader != nil && rr.start < rr.limit {
-		var reason metrics.Reason
-		switch caller {
-		case "destroy":
-			reason = metrics.ReasonExplicitCloseAttr
-		case "force_create":
-			reason = metrics.ReasonForcedRecreateAttr
-		case "invalidation":
-			if readType == metrics.ReadTypeRandom {
-				reason = metrics.ReasonSequentialToRandomAttr
-			} else {
-				reason = metrics.ReasonSeekAttr
+		reason := rr.preemptionReason
+		if reason == "" {
+			switch caller {
+			case "destroy":
+				reason = metrics.ReasonExplicitCloseAttr
+			case "force_create":
+				reason = metrics.ReasonForcedRecreateAttr
+			case "invalidation":
+				if readType == metrics.ReadTypeRandom {
+					reason = metrics.ReasonSequentialToRandomAttr
+				} else {
+					reason = metrics.ReasonSeekAttr
+				}
+			default:
+				reason = metrics.ReasonUnknownAttr
 			}
-		default:
-			reason = metrics.ReasonUnknownAttr
+			rr.preemptionReason = reason
+			rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 		}
-		rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
+		rr.metricHandle.GcsExperimentalReaderCancellationBytesCount(rr.connectionReadBytes, reason)
 	}
 
 	rr.readHandle = rr.reader.ReadHandle()
@@ -178,6 +184,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 	var n int
 	n, err = rr.readFull(ctx, p)
 	rr.start += int64(n)
+	rr.connectionReadBytes += int64(n)
 
 	// Sanity check.
 	if rr.start > rr.limit {
@@ -254,6 +261,7 @@ func (rr *RangeReader) readFull(ctx context.Context, p []byte) (int, error) {
 					default:
 						reason = metrics.ReasonUnknownAttr
 					}
+					rr.preemptionReason = reason
 					rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 					rr.cancel()
 				}
@@ -322,6 +330,8 @@ func (rr *RangeReader) startRead(ctx context.Context, start int64, end int64, re
 	rr.cancel = cancel
 	rr.start = start
 	rr.limit = end
+	rr.connectionReadBytes = 0
+	rr.preemptionReason = ""
 
 	requestedDataSize := end - start
 	metrics.CaptureGCSReadMetrics(rr.metricHandle, metrics.ReadTypeNames[readType], requestedDataSize)

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -237,6 +237,7 @@ func (rr *RangeReader) readFull(ctx context.Context, p []byte) (int, error) {
 // from GCS defined by SequentialReadSizeMb flag to serve future read requests.
 func (rr *RangeReader) startRead(ctx context.Context, start int64, end int64, readType int64) error {
 	ctx, cancel := context.WithCancel(rr.traceHandle.PropagateTraceContext(context.Background(), ctx))
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeNames[readType])
 	var err error
 
 	if rr.config != nil && rr.config.Read.InactiveStreamTimeout > 0 {

--- a/internal/gcsx/client_readers/range_reader.go
+++ b/internal/gcsx/client_readers/range_reader.go
@@ -62,11 +62,10 @@ type RangeReader struct {
 	readHandle []byte
 	cancel     func()
 
-	config              *cfg.Config
-	metricHandle        metrics.MetricHandle
-	traceHandle         tracing.TraceHandle
-	connectionReadBytes int64
-	preemptionReason    metrics.Reason
+	config           *cfg.Config
+	metricHandle     metrics.MetricHandle
+	traceHandle      tracing.TraceHandle
+	preemptionReason metrics.Reason
 }
 
 func NewRangeReader(object *gcs.MinObject, bucket gcs.Bucket, config *cfg.Config, metricHandle metrics.MetricHandle, traceHandle tracing.TraceHandle) *RangeReader {
@@ -108,14 +107,14 @@ func (rr *RangeReader) checkInvariants() {
 func (rr *RangeReader) destroy() {
 	// Close out the reader, if we have one.
 	if rr.reader != nil {
-		rr.closeReader("destroy", metrics.ReadTypeUnknown)
+		rr.closeReader(context.Background(), "destroy", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
 }
 
 // closeReader fetches the readHandle before closing the reader instance.
-func (rr *RangeReader) closeReader(caller string, readType int64) {
+func (rr *RangeReader) closeReader(ctx context.Context, caller string, readType int64) {
 	if rr.reader != nil && rr.start < rr.limit {
 		reason := rr.preemptionReason
 		if reason == "" {
@@ -136,7 +135,8 @@ func (rr *RangeReader) closeReader(caller string, readType int64) {
 			rr.preemptionReason = reason
 			rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 		}
-		rr.metricHandle.GcsExperimentalReaderCancellationBytesCount(rr.connectionReadBytes, reason)
+		unreadBytes := rr.limit - rr.start
+		rr.metricHandle.GcsExperimentalReaderCancellationUnreadBytes(ctx, unreadBytes, reason)
 	}
 
 	rr.readHandle = rr.reader.ReadHandle()
@@ -153,7 +153,7 @@ func (rr *RangeReader) ReadAt(ctx context.Context, req *gcsx.GCSReaderRequest) (
 	)
 
 	if req.ForceCreateReader && rr.reader != nil {
-		rr.closeReader("force_create", metrics.ReadTypeUnknown)
+		rr.closeReader(ctx, "force_create", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -184,14 +184,13 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 	var n int
 	n, err = rr.readFull(ctx, p)
 	rr.start += int64(n)
-	rr.connectionReadBytes += int64(n)
 
 	// Sanity check.
 	if rr.start > rr.limit {
 		err = fmt.Errorf("reader returned extra bytes: %d", rr.start-rr.limit)
 
 		// Don't attempt to reuse the reader when it's malfunctioning.
-		rr.closeReader("malfunction", metrics.ReadTypeUnknown)
+		rr.closeReader(ctx, "malfunction", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -202,7 +201,7 @@ func (rr *RangeReader) readFromRangeReader(ctx context.Context, p []byte, offset
 
 	// Are we finished with this reader now?
 	if rr.start == rr.limit {
-		rr.closeReader("normal", metrics.ReadTypeUnknown)
+		rr.closeReader(ctx, "normal", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -330,7 +329,6 @@ func (rr *RangeReader) startRead(ctx context.Context, start int64, end int64, re
 	rr.cancel = cancel
 	rr.start = start
 	rr.limit = end
-	rr.connectionReadBytes = 0
 	rr.preemptionReason = ""
 
 	requestedDataSize := end - start
@@ -368,13 +366,13 @@ func (rr *RangeReader) skipBytes(offset int64) {
 //   - startOffset: the starting byte position of the requested read.
 //   - endOffset: the ending byte position of the requested read.
 //   - readType: the strategy of the incoming read operation.
-func (rr *RangeReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64, readType int64) {
+func (rr *RangeReader) invalidateReaderIfMisalignedOrTooSmall(ctx context.Context, startOffset, endOffset int64, readType int64) {
 	// If we have an existing reader, but it's positioned at the wrong place,
 	// clean it up and throw it away.
 	// We will also clean up the existing reader if it can't serve the entire request.
 	dataToRead := math.Min(float64(endOffset), float64(rr.object.Size))
 	if rr.reader != nil && (rr.start != startOffset || int64(dataToRead) > rr.limit) {
-		rr.closeReader("invalidation", readType)
+		rr.closeReader(ctx, "invalidation", readType)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -388,7 +386,7 @@ func (rr *RangeReader) readFromExistingReader(ctx context.Context, req *gcsx.GCS
 	// Since we are reading from an existing reader, we only need to read what was requested.
 	endOffset := min(req.Offset + int64(len(req.Buffer)))
 
-	rr.invalidateReaderIfMisalignedOrTooSmall(req.Offset, endOffset, req.ReadType)
+	rr.invalidateReaderIfMisalignedOrTooSmall(ctx, req.Offset, endOffset, req.ReadType)
 	if rr.reader != nil {
 		return rr.readFromRangeReader(ctx, req.Buffer, req.Offset, endOffset, req.ReadType)
 	}

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -375,7 +375,7 @@ func (t *rangeReaderTest) Test_invalidateReaderIfMisalignedOrTooSmall() {
 		t.Run(tt.name, func() {
 			tt.readerSetup()
 
-			t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(tt.offset, tt.offset+int64(tt.bufferSize), metrics.ReadTypeSequential)
+			t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(context.Background(), tt.offset, tt.offset+int64(tt.bufferSize), metrics.ReadTypeSequential)
 
 			if tt.expectReaderNil {
 				assert.Nil(t.T(), t.rangeReader.reader, "rangeReader.reader should be nil")
@@ -705,8 +705,8 @@ func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellation
 	m.Called(inc, reason)
 }
 
-func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
-	m.Called(inc, reason)
+func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellationUnreadBytes(ctx context.Context, value int64, reason metrics.Reason) {
+	m.Called(ctx, value, reason)
 }
 
 func (t *rangeReaderTest) Test_ReadAt_SkipBytes() {
@@ -749,7 +749,7 @@ func (t *rangeReaderTest) Test_ReadAt_CancellationRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(1024), metrics.ReasonCanceledAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(2), metrics.ReasonCanceledAttr).Return().Once()
 
 	// Initialize RangeReader with our mock metrics handle
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
@@ -786,8 +786,6 @@ func (t *rangeReaderTest) Test_ReadAt_CancellationRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
-	// Set successful connection read bytes prior to preemption close
-	t.rangeReader.connectionReadBytes = 1024
 	t.rangeReader.destroy()
 	mh.AssertExpectations(t.T())
 }
@@ -796,7 +794,7 @@ func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(2048), metrics.ReasonDeadlineExceededAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(2), metrics.ReasonDeadlineExceededAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
 
@@ -830,8 +828,6 @@ func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
-	// Set successful connection read bytes prior to preemption close
-	t.rangeReader.connectionReadBytes = 2048
 	t.rangeReader.destroy()
 	mh.AssertExpectations(t.T())
 }
@@ -839,7 +835,7 @@ func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
 func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(512), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonExplicitCloseAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -848,7 +844,6 @@ func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
-	t.rangeReader.connectionReadBytes = 512
 	t.rangeReader.cancel = func() {}
 
 	// Act: destroy it
@@ -861,7 +856,7 @@ func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(256), metrics.ReasonSeekAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonSeekAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -870,11 +865,10 @@ func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
-	t.rangeReader.connectionReadBytes = 256
 	t.rangeReader.cancel = func() {}
 
 	// Act: invalidate it with a misaligned seek jump under sequential readType
-	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeSequential)
+	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(context.Background(), 4, 6, metrics.ReadTypeSequential)
 
 	assert.Nil(t.T(), t.rangeReader.reader)
 	mh.AssertExpectations(t.T())
@@ -883,7 +877,7 @@ func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 func (t *rangeReaderTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonSequentialToRandomAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonSequentialToRandomAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -892,11 +886,10 @@ func (t *rangeReaderTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetr
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
-	t.rangeReader.connectionReadBytes = 128
 	t.rangeReader.cancel = func() {}
 
 	// Act: invalidate it with a misaligned seek jump under random readType (sequential to random transition)
-	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeRandom)
+	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(context.Background(), 4, 6, metrics.ReadTypeRandom)
 
 	assert.Nil(t.T(), t.rangeReader.reader)
 	mh.AssertExpectations(t.T())

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -705,6 +705,10 @@ func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellation
 	m.Called(inc, reason)
 }
 
+func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
 func (t *rangeReaderTest) Test_ReadAt_SkipBytes() {
 	offset := int64(0)
 	size := int64(20)
@@ -745,7 +749,7 @@ func (t *rangeReaderTest) Test_ReadAt_CancellationRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(1024), metrics.ReasonCanceledAttr).Return().Once()
 
 	// Initialize RangeReader with our mock metrics handle
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
@@ -782,6 +786,8 @@ func (t *rangeReaderTest) Test_ReadAt_CancellationRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
+	// Set successful connection read bytes prior to preemption close
+	t.rangeReader.connectionReadBytes = 1024
 	t.rangeReader.destroy()
 	mh.AssertExpectations(t.T())
 }
@@ -790,7 +796,7 @@ func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForRangeCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(2048), metrics.ReasonDeadlineExceededAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
 
@@ -824,13 +830,16 @@ func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
+	// Set successful connection read bytes prior to preemption close
+	t.rangeReader.connectionReadBytes = 2048
 	t.rangeReader.destroy()
 	mh.AssertExpectations(t.T())
 }
 
 func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(512), metrics.ReasonExplicitCloseAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -839,6 +848,7 @@ func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
+	t.rangeReader.connectionReadBytes = 512
 	t.rangeReader.cancel = func() {}
 
 	// Act: destroy it
@@ -850,7 +860,8 @@ func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
 
 func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(256), metrics.ReasonSeekAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -859,6 +870,7 @@ func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
+	t.rangeReader.connectionReadBytes = 256
 	t.rangeReader.cancel = func() {}
 
 	// Act: invalidate it with a misaligned seek jump under sequential readType
@@ -870,7 +882,8 @@ func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
 
 func (t *rangeReaderTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetric() {
 	mh := &mockMetricHandleForRangeCancellation{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonSequentialToRandomAttr).Return().Once()
 
 	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
 
@@ -879,6 +892,7 @@ func (t *rangeReaderTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetr
 	t.rangeReader.reader = rc
 	t.rangeReader.start = 2
 	t.rangeReader.limit = 6
+	t.rangeReader.connectionReadBytes = 128
 	t.rangeReader.cancel = func() {}
 
 	// Act: invalidate it with a misaligned seek jump under random readType (sequential to random transition)

--- a/internal/gcsx/client_readers/range_reader_test.go
+++ b/internal/gcsx/client_readers/range_reader_test.go
@@ -375,7 +375,7 @@ func (t *rangeReaderTest) Test_invalidateReaderIfMisalignedOrTooSmall() {
 		t.Run(tt.name, func() {
 			tt.readerSetup()
 
-			t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(tt.offset, tt.offset+int64(tt.bufferSize))
+			t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(tt.offset, tt.offset+int64(tt.bufferSize), metrics.ReadTypeSequential)
 
 			if tt.expectReaderNil {
 				assert.Nil(t.T(), t.rangeReader.reader, "rangeReader.reader should be nil")
@@ -694,4 +694,196 @@ func (t *rangeReaderTest) Test_ReadAt_ForceCreateReader() {
 	secondReader := t.rangeReader.reader
 	assert.NotEqual(t.T(), firstReader, secondReader)
 	t.mockBucket.AssertExpectations(t.T())
+}
+
+type mockMetricHandleForRangeCancellation struct {
+	metrics.MetricHandle
+	mock.Mock
+}
+
+func (m *mockMetricHandleForRangeCancellation) GcsExperimentalReaderCancellationCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
+func (t *rangeReaderTest) Test_ReadAt_SkipBytes() {
+	offset := int64(0)
+	size := int64(20)
+	content := []byte("abcdefghijklmnopqrst")
+
+	// Create initial reader
+	r := &fake.FakeReader{ReadCloser: getReadCloser(content)}
+	t.mockNewReaderWithHandleCallForTestBucket(uint64(offset), uint64(offset+size), r)
+
+	// First read request (read 5 bytes starting at offset 0)
+	buf1 := make([]byte, 5)
+	resp1, err1 := t.rangeReader.ReadAt(t.ctx, &gcsx.GCSReaderRequest{
+		Buffer:    buf1,
+		Offset:    0,
+		EndOffset: 20,
+		ReadInfo:  &gcsx.ReadInfo{},
+	})
+	t.Require().NoError(err1)
+	t.Equal(5, resp1.Size)
+	t.Equal(content[:5], buf1)
+	t.Equal(int64(5), t.rangeReader.start)
+
+	// Second read request (read 5 bytes starting at offset 10 - forward seek skip of 5 bytes!)
+	buf2 := make([]byte, 5)
+	resp2, err2 := t.rangeReader.ReadAt(t.ctx, &gcsx.GCSReaderRequest{
+		Buffer:    buf2,
+		Offset:    10,
+		EndOffset: 20,
+		ReadInfo:  &gcsx.ReadInfo{},
+	})
+	t.Require().NoError(err2)
+	t.Equal(5, resp2.Size)
+	t.Equal(content[10:15], buf2)
+	t.Equal(int64(15), t.rangeReader.start) // start should be 15 now!
+}
+
+func (t *rangeReaderTest) Test_ReadAt_CancellationRecordsMetric() {
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForRangeCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+
+	// Initialize RangeReader with our mock metrics handle
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
+
+	// Set up a blocking reader
+	finishRead := make(chan struct{})
+	blocking := &blockingReader{c: finishRead}
+	rc := io.NopCloser(blocking)
+
+	t.rangeReader.reader = &fake.FakeReader{ReadCloser: rc}
+	t.rangeReader.start = 0
+	t.rangeReader.limit = 2
+
+	cancelCalled := make(chan struct{})
+	t.rangeReader.cancel = func() { close(cancelCalled) }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	readReturned := make(chan struct{})
+
+	go func() {
+		_, _ = t.rangeReader.ReadAt(ctx, &gcsx.GCSReaderRequest{
+			Buffer:    make([]byte, 2),
+			Offset:    0,
+			EndOffset: 2,
+			ReadInfo:  &gcsx.ReadInfo{},
+		})
+		close(readReturned)
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	<-cancelCalled
+	close(finishRead)
+	<-readReturned
+
+	t.rangeReader.destroy()
+	mh.AssertExpectations(t.T())
+}
+
+func (t *rangeReaderTest) Test_ReadAt_DeadlineExceededRecordsMetric() {
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForRangeCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}, mh, tracing.NewNoopTracer())
+
+	// Set up a blocking reader
+	finishRead := make(chan struct{})
+	blocking := &blockingReader{c: finishRead}
+	rc := io.NopCloser(blocking)
+
+	t.rangeReader.reader = &fake.FakeReader{ReadCloser: rc}
+	t.rangeReader.start = 0
+	t.rangeReader.limit = 2
+
+	cancelCalled := make(chan struct{})
+	t.rangeReader.cancel = func() { close(cancelCalled) }
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	readReturned := make(chan struct{})
+
+	go func() {
+		_, _ = t.rangeReader.ReadAt(ctx, &gcsx.GCSReaderRequest{
+			Buffer:    make([]byte, 2),
+			Offset:    0,
+			EndOffset: 2,
+			ReadInfo:  &gcsx.ReadInfo{},
+		})
+		close(readReturned)
+	}()
+
+	<-cancelCalled
+	close(finishRead)
+	<-readReturned
+
+	t.rangeReader.destroy()
+	mh.AssertExpectations(t.T())
+}
+
+func (t *rangeReaderTest) Test_Destroy_PartiallyReadReaderRecordsMetric() {
+	mh := &mockMetricHandleForRangeCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return()
+
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
+
+	// Simulate an active, partially read reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	t.rangeReader.reader = rc
+	t.rangeReader.start = 2
+	t.rangeReader.limit = 6
+	t.rangeReader.cancel = func() {}
+
+	// Act: destroy it
+	t.rangeReader.destroy()
+
+	assert.Nil(t.T(), t.rangeReader.reader)
+	mh.AssertExpectations(t.T())
+}
+
+func (t *rangeReaderTest) Test_invalidateReader_SeekRecordsMetric() {
+	mh := &mockMetricHandleForRangeCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return()
+
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
+
+	// Simulate an active, partially read reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	t.rangeReader.reader = rc
+	t.rangeReader.start = 2
+	t.rangeReader.limit = 6
+	t.rangeReader.cancel = func() {}
+
+	// Act: invalidate it with a misaligned seek jump under sequential readType
+	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeSequential)
+
+	assert.Nil(t.T(), t.rangeReader.reader)
+	mh.AssertExpectations(t.T())
+}
+
+func (t *rangeReaderTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetric() {
+	mh := &mockMetricHandleForRangeCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return()
+
+	t.rangeReader = NewRangeReader(t.object, t.mockBucket, nil, mh, tracing.NewNoopTracer())
+
+	// Simulate an active, partially read reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	t.rangeReader.reader = rc
+	t.rangeReader.start = 2
+	t.rangeReader.limit = 6
+	t.rangeReader.cancel = func() {}
+
+	// Act: invalidate it with a misaligned seek jump under random readType (sequential to random transition)
+	t.rangeReader.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeRandom)
+
+	assert.Nil(t.T(), t.rangeReader.reader)
+	mh.AssertExpectations(t.T())
 }

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 )
 
@@ -71,6 +72,8 @@ type InactiveTimeoutReader struct {
 
 	// Flag set by Read and reset by the monitor goroutine to track activity within the timeout window.
 	isActive bool
+
+	metricHandle metrics.MetricHandle
 }
 
 var (
@@ -84,22 +87,29 @@ var (
 //
 // If the timeout duration is zero, it returns (nil, ErrZeroInactivityTimeout) as a zero timeout
 // defeats the purpose of this wrapper.
-func NewInactiveTimeoutReader(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, byteRange gcs.ByteRange, timeout time.Duration) (gcs.StorageReader, error) {
-	return NewInactiveTimeoutReaderWithClock(ctx, bucket, object, readHandle, byteRange, timeout, clock.RealClock{})
+func NewInactiveTimeoutReader(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, byteRange gcs.ByteRange, timeout time.Duration, metricHandle metrics.MetricHandle) (gcs.StorageReader, error) {
+	if metricHandle == nil {
+		metricHandle = metrics.NewNoopMetrics()
+	}
+	return NewInactiveTimeoutReaderWithClock(ctx, bucket, object, readHandle, byteRange, timeout, clock.RealClock{}, metricHandle)
 }
 
-func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, byteRange gcs.ByteRange, timeout time.Duration, clock clock.Clock) (gcs.StorageReader, error) {
+func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, object *gcs.MinObject, readHandle []byte, byteRange gcs.ByteRange, timeout time.Duration, clock clock.Clock, metricHandle metrics.MetricHandle) (gcs.StorageReader, error) {
 	if timeout == 0 {
 		return nil, ErrZeroInactivityTimeout
 	}
+	if metricHandle == nil {
+		metricHandle = metrics.NewNoopMetrics()
+	}
 
 	itr := &InactiveTimeoutReader{
-		object:     object,
-		bucket:     bucket,
-		reqRange:   byteRange,
-		readHandle: readHandle,
-		mu:         locker.New("InactiveTimeoutReader: "+object.Name, func() {}),
-		isActive:   false,
+		object:       object,
+		bucket:       bucket,
+		reqRange:     byteRange,
+		readHandle:   readHandle,
+		mu:           locker.New("InactiveTimeoutReader: "+object.Name, func() {}),
+		isActive:     false,
+		metricHandle: metricHandle,
 	}
 	itr.ctx, itr.cancel = context.WithCancel(ctx)
 
@@ -241,5 +251,6 @@ func (itr *InactiveTimeoutReader) closeGCSReader() {
 	if err := itr.gcsReader.Close(); err != nil {
 		logger.Warnf("Error closing inactive reader for object %q: %v", itr.object.Name, err)
 	}
+	itr.metricHandle.GcsExperimentalReaderCancellationCount(1, metrics.ReasonInactiveTimeoutAttr)
 	itr.gcsReader = nil
 }

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -73,8 +73,7 @@ type InactiveTimeoutReader struct {
 	// Flag set by Read and reset by the monitor goroutine to track activity within the timeout window.
 	isActive bool
 
-	metricHandle        metrics.MetricHandle
-	connectionReadBytes uint64
+	metricHandle metrics.MetricHandle
 }
 
 var (
@@ -166,12 +165,10 @@ func (itr *InactiveTimeoutReader) Read(p []byte) (n int, err error) {
 		if itr.gcsReader, err = itr.createGCSReader(); err != nil {
 			return 0, err
 		}
-		itr.connectionReadBytes = 0
 	}
 
 	n, err = itr.gcsReader.Read(p)
 	itr.seen += uint64(n)
-	itr.connectionReadBytes += uint64(n)
 	return n, err
 }
 
@@ -255,6 +252,7 @@ func (itr *InactiveTimeoutReader) closeGCSReader() {
 		logger.Warnf("Error closing inactive reader for object %q: %v", itr.object.Name, err)
 	}
 	itr.metricHandle.GcsExperimentalReaderCancellationCount(1, metrics.ReasonInactiveTimeoutAttr)
-	itr.metricHandle.GcsExperimentalReaderCancellationBytesCount(int64(itr.connectionReadBytes), metrics.ReasonInactiveTimeoutAttr)
+	unreadBytes := int64(itr.reqRange.Limit - itr.reqRange.Start - itr.seen)
+	itr.metricHandle.GcsExperimentalReaderCancellationUnreadBytes(itr.ctx, unreadBytes, metrics.ReasonInactiveTimeoutAttr)
 	itr.gcsReader = nil
 }

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -73,7 +73,8 @@ type InactiveTimeoutReader struct {
 	// Flag set by Read and reset by the monitor goroutine to track activity within the timeout window.
 	isActive bool
 
-	metricHandle metrics.MetricHandle
+	metricHandle        metrics.MetricHandle
+	connectionReadBytes uint64
 }
 
 var (
@@ -165,10 +166,12 @@ func (itr *InactiveTimeoutReader) Read(p []byte) (n int, err error) {
 		if itr.gcsReader, err = itr.createGCSReader(); err != nil {
 			return 0, err
 		}
+		itr.connectionReadBytes = 0
 	}
 
 	n, err = itr.gcsReader.Read(p)
 	itr.seen += uint64(n)
+	itr.connectionReadBytes += uint64(n)
 	return n, err
 }
 
@@ -252,5 +255,6 @@ func (itr *InactiveTimeoutReader) closeGCSReader() {
 		logger.Warnf("Error closing inactive reader for object %q: %v", itr.object.Name, err)
 	}
 	itr.metricHandle.GcsExperimentalReaderCancellationCount(1, metrics.ReasonInactiveTimeoutAttr)
+	itr.metricHandle.GcsExperimentalReaderCancellationBytesCount(int64(itr.connectionReadBytes), metrics.ReasonInactiveTimeoutAttr)
 	itr.gcsReader = nil
 }

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -387,8 +387,8 @@ func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancella
 	m.Called(inc, reason)
 }
 
-func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
-	m.Called(inc, reason)
+func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancellationUnreadBytes(ctx context.Context, value int64, reason metrics.Reason) {
+	m.Called(ctx, value, reason)
 }
 
 func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecordsMetric() {
@@ -414,7 +414,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecords
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellationTestSuite{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonInactiveTimeoutAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonInactiveTimeoutAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(17), metrics.ReasonInactiveTimeoutAttr).Return().Once()
 
 	// Setup InactiveTimeoutReader
 	var err error
@@ -422,8 +422,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecords
 	s.Require().Nil(err)
 
 	itr := s.reader.(*InactiveTimeoutReader)
-	itr.isActive = false          // Simulate inactivity
-	itr.connectionReadBytes = 128 // Set successful connection bytes
+	itr.isActive = false // Simulate inactivity
 
 	// Act
 	itr.handleTimeout()

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -96,7 +97,7 @@ func (s *InactiveTimeoutReaderTestSuite) setupReader() {
 
 	var err error
 	// Use NewInactiveTimeoutReader directly as NewStorageReaderWithInactiveTimeout is deprecated.
-	s.reader, err = NewInactiveTimeoutReaderWithClock(s.ctx, s.mockBucket, s.object, s.readHandle, gcs.ByteRange{Start: uint64(0), Limit: s.object.Size}, s.timeout, s.simulatedClock)
+	s.reader, err = NewInactiveTimeoutReaderWithClock(s.ctx, s.mockBucket, s.object, s.readHandle, gcs.ByteRange{Start: uint64(0), Limit: s.object.Size}, s.timeout, s.simulatedClock, metrics.NewNoopMetrics())
 	time.Sleep(5 * time.Millisecond) // Allow time to schedule and create a timer.
 	s.Require().Nil(err)
 	s.Require().NotNil(s.reader)
@@ -115,7 +116,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_NewInactiveTimeoutReader_InitialRe
 			req.Range.Limit == 100
 	})).Return(nil, initialErr).Once()
 
-	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, gcs.ByteRange{Start: 0, Limit: 100}, s.timeout)
+	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, gcs.ByteRange{Start: 0, Limit: 100}, s.timeout, metrics.NewNoopMetrics())
 
 	s.Error(err)
 	s.ErrorIs(err, initialErr) // Should be the exact error from the bucket
@@ -125,7 +126,7 @@ func (s *InactiveTimeoutReaderTestSuite) Test_NewInactiveTimeoutReader_ZeroTimeo
 	s.initialData = []byte("zero timeout")
 	s.timeout = 0 // Zero timeout
 
-	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, gcs.ByteRange{Start: 0, Limit: 100}, s.timeout)
+	_, err := NewInactiveTimeoutReader(s.ctx, s.mockBucket, s.object, []byte{}, gcs.ByteRange{Start: 0, Limit: 100}, s.timeout, metrics.NewNoopMetrics())
 
 	s.Error(err)
 	s.ErrorIs(err, ErrZeroInactivityTimeout)
@@ -375,4 +376,53 @@ func (s *InactiveTimeoutReaderTestSuite) TestRaceCondition() {
 	}()
 
 	wg.Wait()
+}
+
+type mockMetricHandleForCancellationTestSuite struct {
+	metrics.MetricHandle
+	mock.Mock
+}
+
+func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancellationCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
+func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecordsMetric() {
+	s.initialData = []byte("simple close test")
+	s.timeout = 50 * time.Millisecond
+	s.object.Size = uint64(len(s.initialData))
+
+	// Setup expectations for MockBucket
+	readCloser := getReadCloser(s.initialData)
+	s.initialFakeReader = &fake.FakeReader{ReadCloser: readCloser, Handle: s.readHandle}
+	readObjectRequest := &gcs.ReadObjectRequest{
+		Name:       s.object.Name,
+		Generation: s.object.Generation,
+		Range: &gcs.ByteRange{
+			Start: uint64(0),
+			Limit: s.object.Size,
+		},
+		ReadCompressed: s.object.HasContentEncodingGzip(),
+		ReadHandle:     s.readHandle,
+	}
+	s.mockBucket.On("NewReaderWithReadHandle", mock.Anything, readObjectRequest).Return(s.initialFakeReader, nil).Times(1)
+
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellationTestSuite{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonInactiveTimeoutAttr).Return()
+
+	// Setup InactiveTimeoutReader
+	var err error
+	s.reader, err = NewInactiveTimeoutReaderWithClock(s.ctx, s.mockBucket, s.object, s.readHandle, gcs.ByteRange{Start: uint64(0), Limit: s.object.Size}, s.timeout, s.simulatedClock, mh)
+	s.Require().Nil(err)
+
+	itr := s.reader.(*InactiveTimeoutReader)
+	itr.isActive = false // Simulate inactivity
+
+	// Act
+	itr.handleTimeout()
+
+	// Assert
+	s.Nil(itr.gcsReader)
+	mh.AssertExpectations(s.T())
 }

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -387,6 +387,10 @@ func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancella
 	m.Called(inc, reason)
 }
 
+func (m *mockMetricHandleForCancellationTestSuite) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
 func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecordsMetric() {
 	s.initialData = []byte("simple close test")
 	s.timeout = 50 * time.Millisecond
@@ -409,7 +413,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecords
 
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellationTestSuite{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonInactiveTimeoutAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonInactiveTimeoutAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonInactiveTimeoutAttr).Return().Once()
 
 	// Setup InactiveTimeoutReader
 	var err error
@@ -417,7 +422,8 @@ func (s *InactiveTimeoutReaderTestSuite) Test_handleTimeout_InactiveCloseRecords
 	s.Require().Nil(err)
 
 	itr := s.reader.(*InactiveTimeoutReader)
-	itr.isActive = false // Simulate inactivity
+	itr.isActive = false          // Simulate inactivity
+	itr.connectionReadBytes = 128 // Set successful connection bytes
 
 	// Act
 	itr.handleTimeout()

--- a/internal/gcsx/kernel_readers/kernel_mrd_reader.go
+++ b/internal/gcsx/kernel_readers/kernel_mrd_reader.go
@@ -98,7 +98,7 @@ func (kmr *KernelMRDReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (
 	var bytesRead int
 	defer func() {
 		metrics.CaptureGCSReadMetrics(kmr.metrics, metrics.ReadTypeParallelAttr, int64(bytesRead))
-		kmr.metrics.GcsReadBytesCount(int64(bytesRead))
+		kmr.metrics.GcsReadBytesCount(int64(bytesRead), metrics.ReadTypeParallelAttr)
 	}()
 
 	var err error

--- a/internal/gcsx/kernel_readers/kernel_mrd_reader.go
+++ b/internal/gcsx/kernel_readers/kernel_mrd_reader.go
@@ -98,7 +98,8 @@ func (kmr *KernelMRDReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (
 	var bytesRead int
 	defer func() {
 		metrics.CaptureGCSReadMetrics(kmr.metrics, metrics.ReadTypeParallelAttr, int64(bytesRead))
-		kmr.metrics.GcsReadBytesCount(int64(bytesRead), metrics.ReadTypeParallelAttr)
+		kmr.metrics.GcsReadBytesCount(int64(bytesRead))
+		kmr.metrics.GcsExperimentalReadBytesCount(int64(bytesRead), metrics.ReadTypeParallelAttr)
 	}()
 
 	var err error

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -112,6 +112,9 @@ func NewRandomReader(o *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb i
 	if traceHandle == nil {
 		traceHandle = tracing.NewNoopTracer()
 	}
+	if metricHandle == nil {
+		metricHandle = metrics.NewNoopMetrics()
+	}
 
 	return &randomReader{
 		object:                o,
@@ -442,7 +445,7 @@ func (rr *randomReader) Destroy() {
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		if rr.reader != nil {
-			rr.closeReader()
+			rr.closeReader("destroy", metrics.ReadTypeUnknown)
 		}
 		rr.reader = nil
 		rr.cancel = nil
@@ -485,6 +488,16 @@ func (rr *randomReader) readFull(
 					return
 
 				default:
+					var reason metrics.Reason
+					switch {
+					case errors.Is(ctx.Err(), context.Canceled):
+						reason = metrics.ReasonCanceledAttr
+					case errors.Is(ctx.Err(), context.DeadlineExceeded):
+						reason = metrics.ReasonDeadlineExceededAttr
+					default:
+						reason = metrics.ReasonUnknownAttr
+					}
+					rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 					rr.cancel()
 				}
 			}
@@ -515,7 +528,8 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 				Start: uint64(start),
 				Limit: uint64(end),
 			},
-			rr.config.Read.InactiveStreamTimeout)
+			rr.config.Read.InactiveStreamTimeout,
+			rr.metricHandle)
 	} else {
 		rr.reader, err = rr.bucket.NewReaderWithReadHandle(
 			ctx,
@@ -685,13 +699,13 @@ func (rr *randomReader) skipBytes(offset int64) {
 // for the requested offset and length. If the reader is misaligned (not at the requested
 // offset) or cannot serve the full request within its limit, it is closed and discarded.
 // LOCKS_REQUIRED (rr.mu)
-func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64) {
+func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64, readType int64) {
 	// If we have an existing reader, but it's positioned at the wrong place,
 	// clean it up and throw it away.
 	// We will also clean up the existing reader if it can't serve the entire request.
 	dataToRead := math.Min(float64(endOffset), float64(rr.object.Size))
 	if rr.reader != nil && (rr.start != startOffset || int64(dataToRead) > rr.limit) {
-		rr.closeReader()
+		rr.closeReader("invalidation", readType)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -703,7 +717,7 @@ func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endO
 // LOCKS_REQUIRED (rr.mu)
 func (rr *randomReader) readFromExistingRangeReader(ctx context.Context, p []byte, offset int64) (n int, err error) {
 	rr.skipBytes(offset)
-	rr.invalidateReaderIfMisalignedOrTooSmall(offset, offset+int64(len(p)))
+	rr.invalidateReaderIfMisalignedOrTooSmall(offset, offset+int64(len(p)), rr.readType.Load())
 	if rr.reader != nil {
 		return rr.readFromRangeReader(ctx, p, offset, offset+int64(len(p)), rr.readType.Load())
 	}
@@ -734,7 +748,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 		err = fmt.Errorf("Reader returned extra bytes: %d", rr.start-rr.limit)
 
 		// Don't attempt to reuse the reader when it's behaving wackily.
-		rr.closeReader()
+		rr.closeReader("malfunction", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -745,7 +759,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 
 	// Are we finished with this reader now?
 	if rr.start == rr.limit {
-		rr.closeReader()
+		rr.closeReader("normal", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -791,7 +805,24 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 
 // closeReader fetches the readHandle before closing the reader instance.
 // LOCKS_REQUIRED (rr.mu)
-func (rr *randomReader) closeReader() {
+func (rr *randomReader) closeReader(caller string, readType int64) {
+	if rr.reader != nil && rr.start < rr.limit {
+		var reason metrics.Reason
+		switch caller {
+		case "destroy":
+			reason = metrics.ReasonExplicitCloseAttr
+		case "invalidation":
+			if readType == metrics.ReadTypeRandom {
+				reason = metrics.ReasonSequentialToRandomAttr
+			} else {
+				reason = metrics.ReasonSeekAttr
+			}
+		default:
+			reason = metrics.ReasonUnknownAttr
+		}
+		rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
+	}
+
 	rr.readHandle = rr.reader.ReadHandle()
 	err := rr.reader.Close()
 	if err != nil {

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -191,6 +191,9 @@ type randomReader struct {
 
 	config *cfg.Config
 
+	connectionReadBytes int64
+	preemptionReason    metrics.Reason
+
 	// Specifies the next expected offset for the reads. Used to distinguish between
 	// sequential and random reads.
 	expectedOffset atomic.Int64
@@ -497,6 +500,7 @@ func (rr *randomReader) readFull(
 					default:
 						reason = metrics.ReasonUnknownAttr
 					}
+					rr.preemptionReason = reason
 					rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 					rr.cancel()
 				}
@@ -566,6 +570,8 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	rr.cancel = cancel
 	rr.start = start
 	rr.limit = end
+	rr.connectionReadBytes = 0
+	rr.preemptionReason = ""
 
 	requestedDataSize := end - start
 	metrics.CaptureGCSReadMetrics(rr.metricHandle, metrics.ReadTypeNames[readType], requestedDataSize)
@@ -741,6 +747,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 	// it as possible.
 	n, err = rr.readFull(ctx, p)
 	rr.start += int64(n)
+	rr.connectionReadBytes += int64(n)
 	rr.totalReadBytes.Add(uint64(n))
 
 	// Sanity check.
@@ -807,20 +814,24 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 // LOCKS_REQUIRED (rr.mu)
 func (rr *randomReader) closeReader(caller string, readType int64) {
 	if rr.reader != nil && rr.start < rr.limit {
-		var reason metrics.Reason
-		switch caller {
-		case "destroy":
-			reason = metrics.ReasonExplicitCloseAttr
-		case "invalidation":
-			if readType == metrics.ReadTypeRandom {
-				reason = metrics.ReasonSequentialToRandomAttr
-			} else {
-				reason = metrics.ReasonSeekAttr
+		reason := rr.preemptionReason
+		if reason == "" {
+			switch caller {
+			case "destroy":
+				reason = metrics.ReasonExplicitCloseAttr
+			case "invalidation":
+				if readType == metrics.ReadTypeRandom {
+					reason = metrics.ReasonSequentialToRandomAttr
+				} else {
+					reason = metrics.ReasonSeekAttr
+				}
+			default:
+				reason = metrics.ReasonUnknownAttr
 			}
-		default:
-			reason = metrics.ReasonUnknownAttr
+			rr.preemptionReason = reason
+			rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 		}
-		rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
+		rr.metricHandle.GcsExperimentalReaderCancellationBytesCount(rr.connectionReadBytes, reason)
 	}
 
 	rr.readHandle = rr.reader.ReadHandle()

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -191,8 +191,7 @@ type randomReader struct {
 
 	config *cfg.Config
 
-	connectionReadBytes int64
-	preemptionReason    metrics.Reason
+	preemptionReason metrics.Reason
 
 	// Specifies the next expected offset for the reads. Used to distinguish between
 	// sequential and random reads.
@@ -448,7 +447,7 @@ func (rr *randomReader) Destroy() {
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		if rr.reader != nil {
-			rr.closeReader("destroy", metrics.ReadTypeUnknown)
+			rr.closeReader(context.Background(), "destroy", metrics.ReadTypeUnknown)
 		}
 		rr.reader = nil
 		rr.cancel = nil
@@ -570,7 +569,6 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	rr.cancel = cancel
 	rr.start = start
 	rr.limit = end
-	rr.connectionReadBytes = 0
 	rr.preemptionReason = ""
 
 	requestedDataSize := end - start
@@ -705,13 +703,13 @@ func (rr *randomReader) skipBytes(offset int64) {
 // for the requested offset and length. If the reader is misaligned (not at the requested
 // offset) or cannot serve the full request within its limit, it is closed and discarded.
 // LOCKS_REQUIRED (rr.mu)
-func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endOffset int64, readType int64) {
+func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(ctx context.Context, startOffset, endOffset int64, readType int64) {
 	// If we have an existing reader, but it's positioned at the wrong place,
 	// clean it up and throw it away.
 	// We will also clean up the existing reader if it can't serve the entire request.
 	dataToRead := math.Min(float64(endOffset), float64(rr.object.Size))
 	if rr.reader != nil && (rr.start != startOffset || int64(dataToRead) > rr.limit) {
-		rr.closeReader("invalidation", readType)
+		rr.closeReader(ctx, "invalidation", readType)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -723,7 +721,7 @@ func (rr *randomReader) invalidateReaderIfMisalignedOrTooSmall(startOffset, endO
 // LOCKS_REQUIRED (rr.mu)
 func (rr *randomReader) readFromExistingRangeReader(ctx context.Context, p []byte, offset int64) (n int, err error) {
 	rr.skipBytes(offset)
-	rr.invalidateReaderIfMisalignedOrTooSmall(offset, offset+int64(len(p)), rr.readType.Load())
+	rr.invalidateReaderIfMisalignedOrTooSmall(ctx, offset, offset+int64(len(p)), rr.readType.Load())
 	if rr.reader != nil {
 		return rr.readFromRangeReader(ctx, p, offset, offset+int64(len(p)), rr.readType.Load())
 	}
@@ -747,7 +745,6 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 	// it as possible.
 	n, err = rr.readFull(ctx, p)
 	rr.start += int64(n)
-	rr.connectionReadBytes += int64(n)
 	rr.totalReadBytes.Add(uint64(n))
 
 	// Sanity check.
@@ -755,7 +752,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 		err = fmt.Errorf("Reader returned extra bytes: %d", rr.start-rr.limit)
 
 		// Don't attempt to reuse the reader when it's behaving wackily.
-		rr.closeReader("malfunction", metrics.ReadTypeUnknown)
+		rr.closeReader(ctx, "malfunction", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 		rr.start = -1
@@ -766,7 +763,7 @@ func (rr *randomReader) readFromRangeReader(ctx context.Context, p []byte, offse
 
 	// Are we finished with this reader now?
 	if rr.start == rr.limit {
-		rr.closeReader("normal", metrics.ReadTypeUnknown)
+		rr.closeReader(ctx, "normal", metrics.ReadTypeUnknown)
 		rr.reader = nil
 		rr.cancel = nil
 	}
@@ -812,7 +809,7 @@ func (rr *randomReader) readFromMultiRangeReader(ctx context.Context, p []byte, 
 
 // closeReader fetches the readHandle before closing the reader instance.
 // LOCKS_REQUIRED (rr.mu)
-func (rr *randomReader) closeReader(caller string, readType int64) {
+func (rr *randomReader) closeReader(ctx context.Context, caller string, readType int64) {
 	if rr.reader != nil && rr.start < rr.limit {
 		reason := rr.preemptionReason
 		if reason == "" {
@@ -831,7 +828,8 @@ func (rr *randomReader) closeReader(caller string, readType int64) {
 			rr.preemptionReason = reason
 			rr.metricHandle.GcsExperimentalReaderCancellationCount(1, reason)
 		}
-		rr.metricHandle.GcsExperimentalReaderCancellationBytesCount(rr.connectionReadBytes, reason)
+		unreadBytes := rr.limit - rr.start
+		rr.metricHandle.GcsExperimentalReaderCancellationUnreadBytes(ctx, unreadBytes, reason)
 	}
 
 	rr.readHandle = rr.reader.ReadHandle()

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -503,6 +503,7 @@ func (rr *randomReader) readFull(
 func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, readType int64) (err error) {
 	// Begin the read.
 	ctx, cancel := context.WithCancel(rr.traceHandle.PropagateTraceContext(context.Background(), ctx))
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeNames[readType])
 
 	if rr.config != nil && rr.config.Read.InactiveStreamTimeout > 0 {
 		rr.reader, err = NewInactiveTimeoutReader(

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -1260,6 +1260,10 @@ func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationCount
 	m.Called(inc, reason)
 }
 
+func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
 func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
 	// Set up a reader that will block until we tell it to return.
 	finishRead := make(chan struct{})
@@ -1267,7 +1271,8 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
 
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(1024), metrics.ReasonCanceledAttr).Return().Once()
 
 	// Initialize custom random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1305,6 +1310,10 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
+	// Set successful connection read bytes prior to preemption close
+	wrapped.connectionReadBytes = 1024
+	wrapped.Destroy()
+
 	// Assert: verify that metrics were tracked exactly as expected!
 	mh.AssertExpectations(t.T())
 }
@@ -1316,7 +1325,8 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric()
 
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return()
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(2048), metrics.ReasonDeadlineExceededAttr).Return().Once()
 
 	// Initialize custom random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1349,6 +1359,10 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric()
 	close(finishRead)
 	<-readReturned
 
+	// Set successful connection read bytes prior to preemption close
+	wrapped.connectionReadBytes = 2048
+	wrapped.Destroy()
+
 	// Assert: verify that metrics were tracked exactly as expected!
 	mh.AssertExpectations(t.T())
 }
@@ -1356,8 +1370,9 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric()
 func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
-	// Expect ReasonSeekAttr to be called because readType is sequential on seek realignment!
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return()
+	// Expect ReasonSeekAttr and ReasonSeekAttr bytes to be called!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(256), metrics.ReasonSeekAttr).Return().Once()
 
 	// Initialize random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1369,6 +1384,7 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecords
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
+	wrapped.connectionReadBytes = 256
 	wrapped.cancel = func() {}
 	wrapped.readType.Store(metrics.ReadTypeSequential)
 
@@ -1383,8 +1399,9 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecords
 func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
-	// Expect ReasonSequentialToRandomAttr to be called because readType is Random!
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return()
+	// Expect ReasonSequentialToRandomAttr and ReasonSequentialToRandomAttr bytes to be called!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(512), metrics.ReasonSequentialToRandomAttr).Return().Once()
 
 	// Initialize random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1396,13 +1413,14 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRe
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
+	wrapped.connectionReadBytes = 512
 	wrapped.cancel = func() {}
 	wrapped.readType.Store(metrics.ReadTypeRandom)
 
 	// Act: trigger invalidation by passing a different/misaligned starting offset (e.g., offset 4) and target Random readType
 	wrapped.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeRandom)
 
-	// Assert: connection closed and cancellation metric verified!
+	// Assert: verify that metrics were tracked exactly as expected!
 	assert.Nil(t.T(), wrapped.reader)
 	mh.AssertExpectations(t.T())
 }
@@ -1410,8 +1428,9 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRe
 func (t *RandomReaderStretchrTest) Test_Destroy_PartiallyReadSequentialReaderRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
-	// Expect ReasonExplicitCloseAttr to be called because GCS reader is destroyed before fully consumed!
-	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return()
+	// Expect ReasonExplicitCloseAttr and ReasonExplicitCloseAttr bytes to be called!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonExplicitCloseAttr).Return().Once()
 
 	// Initialize random reader
 	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
@@ -1422,6 +1441,7 @@ func (t *RandomReaderStretchrTest) Test_Destroy_PartiallyReadSequentialReaderRec
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
+	wrapped.connectionReadBytes = 128
 	wrapped.cancel = func() {}
 
 	// Act: destroy the reader

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -1250,3 +1250,184 @@ func (t *RandomReaderStretchrTest) Test_ReadAt_WithAndWithoutReadConfig() {
 		})
 	}
 }
+
+type mockMetricHandleForCancellation struct {
+	metrics.MetricHandle
+	mock.Mock
+}
+
+func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationCount(inc int64, reason metrics.Reason) {
+	m.Called(inc, reason)
+}
+
+func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
+	// Set up a reader that will block until we tell it to return.
+	finishRead := make(chan struct{})
+	rc := io.NopCloser(&blockingReader{finishRead})
+
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return()
+
+	// Initialize custom random reader
+	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
+	wrapped := rr.(*randomReader)
+	wrapped.reader = &fake.FakeReader{ReadCloser: rc}
+	wrapped.start = 1
+	wrapped.limit = 4
+	wrapped.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
+
+	// Snoop on when cancel is called.
+	cancelCalled := make(chan struct{})
+	wrapped.cancel = func() { close(cancelCalled) }
+
+	// Start a read in the background using a context that we control.
+	readReturned := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+
+	go func() {
+		buf := make([]byte, 2)
+		_, _ = wrapped.ReadAt(ctx, buf, 1)
+		close(readReturned)
+	}()
+
+	// Wait a bit to ensure goroutine is blocking on the read
+	time.Sleep(10 * time.Millisecond)
+
+	// Act: cancel the context
+	cancel()
+
+	// Wait for background cancellation processing to complete
+	<-cancelCalled
+
+	// Clean up blocking read
+	close(finishRead)
+	<-readReturned
+
+	// Assert: verify that metrics were tracked exactly as expected!
+	mh.AssertExpectations(t.T())
+}
+
+func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric() {
+	// Set up a reader that will block until we tell it to return.
+	finishRead := make(chan struct{})
+	rc := io.NopCloser(&blockingReader{finishRead})
+
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellation{}
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return()
+
+	// Initialize custom random reader
+	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
+	wrapped := rr.(*randomReader)
+	wrapped.reader = &fake.FakeReader{ReadCloser: rc}
+	wrapped.start = 1
+	wrapped.limit = 4
+	wrapped.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
+
+	// Snoop on when cancel is called.
+	cancelCalled := make(chan struct{})
+	wrapped.cancel = func() { close(cancelCalled) }
+
+	// Start a read in the background using a context with a very short timeout.
+	readReturned := make(chan struct{})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+
+	go func() {
+		buf := make([]byte, 2)
+		_, _ = wrapped.ReadAt(ctx, buf, 1)
+		close(readReturned)
+	}()
+
+	// Wait for background timeout cancellation processing to complete
+	<-cancelCalled
+
+	// Clean up blocking read
+	close(finishRead)
+	<-readReturned
+
+	// Assert: verify that metrics were tracked exactly as expected!
+	mh.AssertExpectations(t.T())
+}
+
+func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecordsMetric() {
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellation{}
+	// Expect ReasonSeekAttr to be called because readType is sequential on seek realignment!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return()
+
+	// Initialize random reader
+	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
+	wrapped := rr.(*randomReader)
+
+	// Simulate an existing, partially read sequential reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	wrapped.reader = rc
+	wrapped.start = 2
+	wrapped.limit = 6
+	wrapped.cancel = func() {}
+	wrapped.readType.Store(metrics.ReadTypeSequential)
+
+	// Act: trigger invalidation by passing a different/misaligned starting offset (e.g., offset 4)
+	wrapped.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeSequential)
+
+	// Assert: connection closed and cancellation metric verified!
+	assert.Nil(t.T(), wrapped.reader)
+	mh.AssertExpectations(t.T())
+}
+
+func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRecordsMetric() {
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellation{}
+	// Expect ReasonSequentialToRandomAttr to be called because readType is Random!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return()
+
+	// Initialize random reader
+	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
+	wrapped := rr.(*randomReader)
+
+	// Simulate an existing, partially read sequential reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	wrapped.reader = rc
+	wrapped.start = 2
+	wrapped.limit = 6
+	wrapped.cancel = func() {}
+	wrapped.readType.Store(metrics.ReadTypeRandom)
+
+	// Act: trigger invalidation by passing a different/misaligned starting offset (e.g., offset 4) and target Random readType
+	wrapped.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeRandom)
+
+	// Assert: connection closed and cancellation metric verified!
+	assert.Nil(t.T(), wrapped.reader)
+	mh.AssertExpectations(t.T())
+}
+
+func (t *RandomReaderStretchrTest) Test_Destroy_PartiallyReadSequentialReaderRecordsMetric() {
+	// Setup mock metrics handle
+	mh := &mockMetricHandleForCancellation{}
+	// Expect ReasonExplicitCloseAttr to be called because GCS reader is destroyed before fully consumed!
+	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return()
+
+	// Initialize random reader
+	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
+	wrapped := rr.(*randomReader)
+
+	// Simulate an existing, partially read sequential reader.
+	rc := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader("xxxxxx"))}
+	wrapped.reader = rc
+	wrapped.start = 2
+	wrapped.limit = 6
+	wrapped.cancel = func() {}
+
+	// Act: destroy the reader
+	wrapped.Destroy()
+
+	// Assert: connection closed and explicit close cancellation metric verified!
+	assert.Nil(t.T(), wrapped.reader)
+	mh.AssertExpectations(t.T())
+}

--- a/internal/gcsx/random_reader_stretchr_test.go
+++ b/internal/gcsx/random_reader_stretchr_test.go
@@ -1260,8 +1260,8 @@ func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationCount
 	m.Called(inc, reason)
 }
 
-func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationBytesCount(inc int64, reason metrics.Reason) {
-	m.Called(inc, reason)
+func (m *mockMetricHandleForCancellation) GcsExperimentalReaderCancellationUnreadBytes(ctx context.Context, value int64, reason metrics.Reason) {
+	m.Called(ctx, value, reason)
 }
 
 func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
@@ -1272,7 +1272,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonCanceledAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(1024), metrics.ReasonCanceledAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(3), metrics.ReasonCanceledAttr).Return().Once()
 
 	// Initialize custom random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1310,8 +1310,6 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_CancellationRecordsMetric() {
 	close(finishRead)
 	<-readReturned
 
-	// Set successful connection read bytes prior to preemption close
-	wrapped.connectionReadBytes = 1024
 	wrapped.Destroy()
 
 	// Assert: verify that metrics were tracked exactly as expected!
@@ -1326,7 +1324,7 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric()
 	// Setup mock metrics handle
 	mh := &mockMetricHandleForCancellation{}
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonDeadlineExceededAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(2048), metrics.ReasonDeadlineExceededAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(3), metrics.ReasonDeadlineExceededAttr).Return().Once()
 
 	// Initialize custom random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1359,8 +1357,6 @@ func (t *RandomReaderStretchrTest) Test_ReadFull_DeadlineExceededRecordsMetric()
 	close(finishRead)
 	<-readReturned
 
-	// Set successful connection read bytes prior to preemption close
-	wrapped.connectionReadBytes = 2048
 	wrapped.Destroy()
 
 	// Assert: verify that metrics were tracked exactly as expected!
@@ -1372,7 +1368,7 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecords
 	mh := &mockMetricHandleForCancellation{}
 	// Expect ReasonSeekAttr and ReasonSeekAttr bytes to be called!
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSeekAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(256), metrics.ReasonSeekAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonSeekAttr).Return().Once()
 
 	// Initialize random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1384,12 +1380,11 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeekMisalignmentRecords
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
-	wrapped.connectionReadBytes = 256
 	wrapped.cancel = func() {}
 	wrapped.readType.Store(metrics.ReadTypeSequential)
 
 	// Act: trigger invalidation by passing a different/misaligned starting offset (e.g., offset 4)
-	wrapped.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeSequential)
+	wrapped.invalidateReaderIfMisalignedOrTooSmall(context.Background(), 4, 6, metrics.ReadTypeSequential)
 
 	// Assert: connection closed and cancellation metric verified!
 	assert.Nil(t.T(), wrapped.reader)
@@ -1401,7 +1396,7 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRe
 	mh := &mockMetricHandleForCancellation{}
 	// Expect ReasonSequentialToRandomAttr and ReasonSequentialToRandomAttr bytes to be called!
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonSequentialToRandomAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(512), metrics.ReasonSequentialToRandomAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonSequentialToRandomAttr).Return().Once()
 
 	// Initialize random reader
 	t.mockBucket.On("BucketType", mock.Anything).Return(gcs.BucketType{Zonal: false})
@@ -1413,12 +1408,11 @@ func (t *RandomReaderStretchrTest) Test_invalidateReader_SeqToRandomTransitionRe
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
-	wrapped.connectionReadBytes = 512
 	wrapped.cancel = func() {}
 	wrapped.readType.Store(metrics.ReadTypeRandom)
 
 	// Act: trigger invalidation by passing a different/misaligned starting offset (e.g., offset 4) and target Random readType
-	wrapped.invalidateReaderIfMisalignedOrTooSmall(4, 6, metrics.ReadTypeRandom)
+	wrapped.invalidateReaderIfMisalignedOrTooSmall(context.Background(), 4, 6, metrics.ReadTypeRandom)
 
 	// Assert: verify that metrics were tracked exactly as expected!
 	assert.Nil(t.T(), wrapped.reader)
@@ -1430,7 +1424,7 @@ func (t *RandomReaderStretchrTest) Test_Destroy_PartiallyReadSequentialReaderRec
 	mh := &mockMetricHandleForCancellation{}
 	// Expect ReasonExplicitCloseAttr and ReasonExplicitCloseAttr bytes to be called!
 	mh.On("GcsExperimentalReaderCancellationCount", int64(1), metrics.ReasonExplicitCloseAttr).Return().Once()
-	mh.On("GcsExperimentalReaderCancellationBytesCount", int64(128), metrics.ReasonExplicitCloseAttr).Return().Once()
+	mh.On("GcsExperimentalReaderCancellationUnreadBytes", mock.Anything, int64(4), metrics.ReasonExplicitCloseAttr).Return().Once()
 
 	// Initialize random reader
 	rr := NewRandomReader(t.object, t.mockBucket, sequentialReadSizeInMb, nil, false, mh, tracing.NewNoopTracer(), nil, nil, 0)
@@ -1441,7 +1435,6 @@ func (t *RandomReaderStretchrTest) Test_Destroy_PartiallyReadSequentialReaderRec
 	wrapped.reader = rc
 	wrapped.start = 2
 	wrapped.limit = 6
-	wrapped.connectionReadBytes = 128
 	wrapped.cancel = func() {}
 
 	// Act: destroy the reader

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -104,7 +104,7 @@ func NewReadManager(object *gcs.MinObject, bucket gcs.Bucket, config *ReadManage
 		readers = append(readers, fileCacheReader)
 	}
 
-	readClassifier := gcsx.NewReadTypeClassifier(int64(config.SequentialReadSizeMB), config.InitialOffset)
+	readClassifier := gcsx.NewReadTypeClassifier(int64(config.SequentialReadSizeMB), config.InitialOffset, config.MetricHandle)
 
 	// If buffered read is enabled, initialize the buffered reader and add it to the readers.
 	if config.Config.Read.EnableBufferedRead {

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -341,7 +341,7 @@ func (t *readManagerTest) Test_ReadAt_R1FailsR2Succeeds() {
 	rm := &ReadManager{
 		object:             t.object,
 		readers:            []gcsx.Reader{mockReader1, mockReader2},
-		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0),
+		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
 		traceHandle:        tracing.NewNoopTracer(),
 	}
 	mockReader1.On("ReadAt", t.ctx, mock.AnythingOfType("*gcsx.ReadRequest")).Return(gcsx.ReadResponse{}, gcsx.FallbackToAnotherReader).Once()
@@ -369,7 +369,7 @@ func (t *readManagerTest) Test_ReadAt_BufferedReaderFallsBack() {
 	rm := &ReadManager{
 		object:             t.object,
 		readers:            []gcsx.Reader{mockBufferedReader, mockGCSReader},
-		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0),
+		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
 		traceHandle:        tracing.NewNoopTracer(),
 	}
 	mockBufferedReader.On("ReadAt", t.ctx, mock.AnythingOfType("*gcsx.ReadRequest")).Return(gcsx.ReadResponse{}, gcsx.FallbackToAnotherReader).Once()

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -341,7 +341,7 @@ func (t *readManagerTest) Test_ReadAt_R1FailsR2Succeeds() {
 	rm := &ReadManager{
 		object:             t.object,
 		readers:            []gcsx.Reader{mockReader1, mockReader2},
-		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
+		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics()),
 		traceHandle:        tracing.NewNoopTracer(),
 	}
 	mockReader1.On("ReadAt", t.ctx, mock.AnythingOfType("*gcsx.ReadRequest")).Return(gcsx.ReadResponse{}, gcsx.FallbackToAnotherReader).Once()
@@ -369,7 +369,7 @@ func (t *readManagerTest) Test_ReadAt_BufferedReaderFallsBack() {
 	rm := &ReadManager{
 		object:             t.object,
 		readers:            []gcsx.Reader{mockBufferedReader, mockGCSReader},
-		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil),
+		readTypeClassifier: gcsx.NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics()),
 		traceHandle:        tracing.NewNoopTracer(),
 	}
 	mockBufferedReader.On("ReadAt", t.ctx, mock.AnythingOfType("*gcsx.ReadRequest")).Return(gcsx.ReadResponse{}, gcsx.FallbackToAnotherReader).Once()

--- a/internal/gcsx/read_type_classifier.go
+++ b/internal/gcsx/read_type_classifier.go
@@ -65,6 +65,9 @@ type ReadTypeClassifier struct {
 }
 
 func NewReadTypeClassifier(sequentialReadSizeMb int64, initialOffset int64, mh metrics.MetricHandle) *ReadTypeClassifier {
+	if mh == nil {
+		mh = metrics.NewNoopMetrics()
+	}
 	state := &ReadTypeClassifier{
 		metricHandle:         mh,
 		readType:             atomic.Int64{},
@@ -160,18 +163,16 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 
 	if readType != previousReadType {
 		if rtc.readType.CompareAndSwap(previousReadType, readType) {
-			if rtc.metricHandle != nil {
-				if previousReadType == metrics.ReadTypeSequential && readType == metrics.ReadTypeRandom {
-					if reason == "" && rtc.initialOffset != 0 {
-						reason = metrics.ReasonInitialOffsetNonZeroAttr
-					}
-					if reason != "" {
-						rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
-					}
-				} else if previousReadType == metrics.ReadTypeRandom && readType == metrics.ReadTypeSequential {
-					reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
-					rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+			if previousReadType == metrics.ReadTypeSequential && readType == metrics.ReadTypeRandom {
+				if reason == "" && rtc.initialOffset != 0 {
+					reason = metrics.ReasonInitialOffsetNonZeroAttr
 				}
+				if reason != "" {
+					rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+				}
+			} else if previousReadType == metrics.ReadTypeRandom && readType == metrics.ReadTypeSequential {
+				reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
+				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
 			}
 		}
 	}
@@ -205,7 +206,7 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 			randomReadSize = min(max(randomReadSize, minReadSize), maxReadSize)
 			if currentReadType != metrics.ReadTypeRandom {
 				if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeRandom) {
-					if currentReadType == metrics.ReadTypeSequential && rtc.metricHandle != nil {
+					if currentReadType == metrics.ReadTypeSequential {
 						var reason metrics.Reason
 						if seeks > 0 {
 							// Seek transition already logged in GetReadInfo
@@ -223,7 +224,7 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 	}
 	if currentReadType != metrics.ReadTypeSequential {
 		if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
-			if currentReadType == metrics.ReadTypeRandom && rtc.metricHandle != nil {
+			if currentReadType == metrics.ReadTypeRandom {
 				reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
 				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
 			}

--- a/internal/gcsx/read_type_classifier.go
+++ b/internal/gcsx/read_type_classifier.go
@@ -132,16 +132,11 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 
 	var reason metrics.Reason
 
-	if !seekRecorded && rtc.isSeekNeeded(offset) {
-		numSeeks = rtc.seeks.Add(1)
-		seekRecorded = true
-
-		if offset < expOffset {
-			reason = metrics.ReasonBackwardSeekAttr
-		} else if offset > expOffset+maxReadSize {
-			reason = metrics.ReasonForwardSeekAttr
+	if rtc.isSeekNeeded(offset) {
+		if !seekRecorded {
+			numSeeks = rtc.seeks.Add(1)
+			seekRecorded = true
 		}
-	} else if rtc.isSeekNeeded(offset) && seekRecorded {
 		if offset < expOffset {
 			reason = metrics.ReasonBackwardSeekAttr
 		} else if offset > expOffset+maxReadSize {
@@ -161,27 +156,38 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 		readType = metrics.ReadTypeSequential
 	}
 
-	if readType != previousReadType {
-		if rtc.readType.CompareAndSwap(previousReadType, readType) {
-			if previousReadType == metrics.ReadTypeSequential && readType == metrics.ReadTypeRandom {
-				if reason == "" && rtc.initialOffset != 0 {
-					reason = metrics.ReasonInitialOffsetNonZeroAttr
-				}
-				if reason != "" {
-					rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
-				}
-			} else if previousReadType == metrics.ReadTypeRandom && readType == metrics.ReadTypeSequential {
-				reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
-				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
-			}
-		}
-	}
+	_ = rtc.transitionTo(previousReadType, readType, reason)
 
 	return ReadInfo{
 		ReadType:       readType,
 		ExpectedOffset: expOffset,
 		SeekRecorded:   seekRecorded,
 	}
+}
+
+func (rtc *ReadTypeClassifier) transitionTo(previousType int64, targetType int64, reason metrics.Reason) bool {
+	if previousType == targetType {
+		return false
+	}
+	if !rtc.readType.CompareAndSwap(previousType, targetType) {
+		return false
+	}
+
+	if previousType == metrics.ReadTypeSequential && targetType == metrics.ReadTypeRandom {
+		if reason == "" && rtc.initialOffset != 0 {
+			reason = metrics.ReasonInitialOffsetNonZeroAttr
+		}
+		if reason != "" {
+			rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+		}
+	} else if previousType == metrics.ReadTypeRandom && targetType == metrics.ReadTypeSequential {
+		if reason == "" {
+			reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
+		}
+		rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+	}
+
+	return true
 }
 
 // ComputeSeqPrefetchWindowAndAdjustType computes the sequential IO size heuristically based on
@@ -213,34 +219,15 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 }
 
 func (rtc *ReadTypeClassifier) adjustToRandom(currentReadType int64, seeks uint64) {
-	if currentReadType == metrics.ReadTypeRandom {
-		return
+	var reason metrics.Reason
+	if seeks == 0 && rtc.initialOffset > 0 {
+		reason = metrics.ReasonInitialOffsetNonZeroAttr
 	}
-	if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeRandom) {
-		if currentReadType == metrics.ReadTypeSequential {
-			var reason metrics.Reason
-			if seeks > 0 {
-				// Seek transition already logged in GetReadInfo
-			} else if rtc.initialOffset > 0 {
-				reason = metrics.ReasonInitialOffsetNonZeroAttr
-			}
-			if reason != "" {
-				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
-			}
-		}
-	}
+	_ = rtc.transitionTo(currentReadType, metrics.ReadTypeRandom, reason)
 }
 
 func (rtc *ReadTypeClassifier) adjustToSequential(currentReadType int64) {
-	if currentReadType == metrics.ReadTypeSequential {
-		return
-	}
-	if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
-		if currentReadType == metrics.ReadTypeRandom {
-			reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
-			rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
-		}
-	}
+	_ = rtc.transitionTo(currentReadType, metrics.ReadTypeSequential, metrics.ReasonAverageReadSizeLargeEnoughAttr)
 }
 
 // IsReadSequential returns true if the current read pattern is sequential

--- a/internal/gcsx/read_type_classifier.go
+++ b/internal/gcsx/read_type_classifier.go
@@ -42,6 +42,8 @@ type ReadInfo struct {
 // It uses heuristics based on the number of seeks and average read size to classify the read pattern.
 // It is safe for concurrent use by multiple goroutines.
 type ReadTypeClassifier struct {
+	metricHandle metrics.MetricHandle
+
 	// ReadType of the reader. Will be sequential by default.
 	readType atomic.Int64
 
@@ -62,8 +64,9 @@ type ReadTypeClassifier struct {
 	initialOffset int64
 }
 
-func NewReadTypeClassifier(sequentialReadSizeMb int64, initialOffset int64) *ReadTypeClassifier {
+func NewReadTypeClassifier(sequentialReadSizeMb int64, initialOffset int64, mh metrics.MetricHandle) *ReadTypeClassifier {
 	state := &ReadTypeClassifier{
+		metricHandle:         mh,
 		readType:             atomic.Int64{},
 		expectedOffset:       atomic.Int64{},
 		seeks:                atomic.Uint64{},
@@ -124,9 +127,25 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 	numSeeks := rtc.seeks.Load()
 	currentTotalReadBytes := rtc.totalReadBytes.Load()
 
+	var reason metrics.Reason
+
 	if !seekRecorded && rtc.isSeekNeeded(offset) {
 		numSeeks = rtc.seeks.Add(1)
 		seekRecorded = true
+
+		if offset < expOffset {
+			reason = metrics.ReasonBackwardSeekAttr
+		} else if offset > expOffset+maxReadSize {
+			reason = metrics.ReasonForwardSeekAttr
+		}
+	} else if rtc.isSeekNeeded(offset) && seekRecorded {
+		if offset < expOffset {
+			reason = metrics.ReasonBackwardSeekAttr
+		} else if offset > expOffset+maxReadSize {
+			reason = metrics.ReasonForwardSeekAttr
+		}
+	} else if numSeeks == 0 && rtc.initialOffset != 0 && previousReadType == metrics.ReadTypeSequential {
+		reason = metrics.ReasonInitialOffsetNonZeroAttr
 	}
 
 	readType := metrics.ReadTypeRandom
@@ -140,7 +159,21 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 	}
 
 	if readType != previousReadType {
-		rtc.readType.Store(readType)
+		if rtc.readType.CompareAndSwap(previousReadType, readType) {
+			if rtc.metricHandle != nil {
+				if previousReadType == metrics.ReadTypeSequential && readType == metrics.ReadTypeRandom {
+					if reason == "" && rtc.initialOffset != 0 {
+						reason = metrics.ReasonInitialOffsetNonZeroAttr
+					}
+					if reason != "" {
+						rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+					}
+				} else if previousReadType == metrics.ReadTypeRandom && readType == metrics.ReadTypeSequential {
+					reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
+					rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+				}
+			}
+		}
 	}
 
 	return ReadInfo{
@@ -171,13 +204,30 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 			// Clamp to [minReadSize, maxReadSize]
 			randomReadSize = min(max(randomReadSize, minReadSize), maxReadSize)
 			if currentReadType != metrics.ReadTypeRandom {
-				rtc.readType.Store(metrics.ReadTypeRandom)
+				if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeRandom) {
+					if currentReadType == metrics.ReadTypeSequential && rtc.metricHandle != nil {
+						var reason metrics.Reason
+						if seeks > 0 {
+							// Seek transition already logged in GetReadInfo
+						} else if rtc.initialOffset > 0 {
+							reason = metrics.ReasonInitialOffsetNonZeroAttr
+						}
+						if reason != "" {
+							rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+						}
+					}
+				}
 			}
 			return int64(randomReadSize)
 		}
 	}
 	if currentReadType != metrics.ReadTypeSequential {
-		rtc.readType.Store(metrics.ReadTypeSequential)
+		if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
+			if currentReadType == metrics.ReadTypeRandom && rtc.metricHandle != nil {
+				reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
+				rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+			}
+		}
 	}
 	return rtc.sequentialReadSizeMb * MB
 }

--- a/internal/gcsx/read_type_classifier.go
+++ b/internal/gcsx/read_type_classifier.go
@@ -166,11 +166,11 @@ func (rtc *ReadTypeClassifier) GetReadInfo(offset int64, seekRecorded bool) Read
 						reason = metrics.ReasonInitialOffsetNonZeroAttr
 					}
 					if reason != "" {
-						rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+						rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
 					}
 				} else if previousReadType == metrics.ReadTypeRandom && readType == metrics.ReadTypeSequential {
 					reason = metrics.ReasonAverageReadSizeLargeEnoughAttr
-					rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+					rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
 				}
 			}
 		}
@@ -213,7 +213,7 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 							reason = metrics.ReasonInitialOffsetNonZeroAttr
 						}
 						if reason != "" {
-							rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
+							rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
 						}
 					}
 				}
@@ -225,7 +225,7 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 		if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
 			if currentReadType == metrics.ReadTypeRandom && rtc.metricHandle != nil {
 				reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
-				rtc.metricHandle.GcsExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
 			}
 		}
 	}

--- a/internal/gcsx/read_type_classifier.go
+++ b/internal/gcsx/read_type_classifier.go
@@ -204,33 +204,43 @@ func (rtc *ReadTypeClassifier) ComputeSeqPrefetchWindowAndAdjustType() int64 {
 			randomReadSize := ((averageReadBytes + MB - 1) / MB) * MB
 			// Clamp to [minReadSize, maxReadSize]
 			randomReadSize = min(max(randomReadSize, minReadSize), maxReadSize)
-			if currentReadType != metrics.ReadTypeRandom {
-				if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeRandom) {
-					if currentReadType == metrics.ReadTypeSequential {
-						var reason metrics.Reason
-						if seeks > 0 {
-							// Seek transition already logged in GetReadInfo
-						} else if rtc.initialOffset > 0 {
-							reason = metrics.ReasonInitialOffsetNonZeroAttr
-						}
-						if reason != "" {
-							rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
-						}
-					}
-				}
-			}
+			rtc.adjustToRandom(currentReadType, seeks)
 			return int64(randomReadSize)
 		}
 	}
-	if currentReadType != metrics.ReadTypeSequential {
-		if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
-			if currentReadType == metrics.ReadTypeRandom {
-				reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
-				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+	rtc.adjustToSequential(currentReadType)
+	return rtc.sequentialReadSizeMb * MB
+}
+
+func (rtc *ReadTypeClassifier) adjustToRandom(currentReadType int64, seeks uint64) {
+	if currentReadType == metrics.ReadTypeRandom {
+		return
+	}
+	if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeRandom) {
+		if currentReadType == metrics.ReadTypeSequential {
+			var reason metrics.Reason
+			if seeks > 0 {
+				// Seek transition already logged in GetReadInfo
+			} else if rtc.initialOffset > 0 {
+				reason = metrics.ReasonInitialOffsetNonZeroAttr
+			}
+			if reason != "" {
+				rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeSequentialToRandomAttr)
 			}
 		}
 	}
-	return rtc.sequentialReadSizeMb * MB
+}
+
+func (rtc *ReadTypeClassifier) adjustToSequential(currentReadType int64) {
+	if currentReadType == metrics.ReadTypeSequential {
+		return
+	}
+	if rtc.readType.CompareAndSwap(currentReadType, metrics.ReadTypeSequential) {
+		if currentReadType == metrics.ReadTypeRandom {
+			reason := metrics.ReasonAverageReadSizeLargeEnoughAttr
+			rtc.metricHandle.ReadExperimentalReadTypeTransitionsCount(1, reason, metrics.TransitionTypeRandomToSequentialAttr)
+		}
+	}
 }
 
 // IsReadSequential returns true if the current read pattern is sequential

--- a/internal/gcsx/read_type_classifier_test.go
+++ b/internal/gcsx/read_type_classifier_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestReadTypeClassifier_InitialState(t *testing.T) {
-	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 
 	assert.Equal(t, metrics.ReadTypeSequential, readTypeClassifier.readType.Load())
 	assert.Equal(t, int64(0), readTypeClassifier.expectedOffset.Load())
@@ -107,7 +107,7 @@ func TestReadTypeClassifier_IsSeekNeeded(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 			classifier.readType.Store(tc.readType)
 			classifier.expectedOffset.Store(tc.expectedOffset)
 
@@ -304,7 +304,7 @@ func TestReadTypeClassifier_GetReadInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+			readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 			readTypeClassifier.readType.Store(tc.initialReadType)
 			readTypeClassifier.expectedOffset.Store(tc.initialExpOffset)
 			readTypeClassifier.seeks.Store(tc.initialNumSeeks)
@@ -360,7 +360,7 @@ func TestReadTypeClassifier_RecordRead(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 			classifier.expectedOffset.Store(tc.initialExpectedOffset)
 			classifier.totalReadBytes.Store(tc.initialTotalReadBytes)
 
@@ -473,7 +473,7 @@ func TestReadTypeClassifier_ComputeSeqPrefetchWindowAndAdjustType(t *testing.T) 
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(tc.sequentialReadSizeMb, 0, nil)
+			classifier := NewReadTypeClassifier(tc.sequentialReadSizeMb, 0, metrics.NewNoopMetrics())
 			classifier.seeks.Store(tc.initialNumSeeks)
 			classifier.totalReadBytes.Store(tc.initialTotalReadBytes)
 			classifier.initialOffset = tc.initialOffset
@@ -510,7 +510,7 @@ func TestReadTypeClassifier_IsSequentialRead(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 			classifier.readType.Store(tc.readType)
 
 			assert.Equal(t, tc.SequentialRead, classifier.IsReadSequential())
@@ -560,7 +560,7 @@ func Test_avgReadBytes(t *testing.T) {
 }
 
 func TestReadTypeClassifier_SequentialReads(t *testing.T) {
-	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 
 	// Simulate 4 reads of 10MB IO.
 	readSizes := []int64{10 * MB, 10 * MB, 10 * MB, 10 * MB}
@@ -579,7 +579,7 @@ func TestReadTypeClassifier_SequentialReads(t *testing.T) {
 }
 
 func TestReadTypeClassifier_RandomReads(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 
 	// Simulate random reads of 5MB each at different offsets.
 	readSizes := []int64{5 * MB, 5 * MB, 5 * MB, 5 * MB}
@@ -595,7 +595,7 @@ func TestReadTypeClassifier_RandomReads(t *testing.T) {
 }
 
 func TestReadTypeClassifier_RandomToSequentialRead(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 	// Start with random reads.
 	randomReadSizes := []int64{2 * MB, 2 * MB, 2 * MB, 2 * MB, 2 * MB}
 	randomOffsets := []int64{50 * MB, 20 * MB, 10 * MB, 30 * MB, 40 * MB}
@@ -621,7 +621,7 @@ func TestReadTypeClassifier_RandomToSequentialRead(t *testing.T) {
 }
 
 func TestReadTypeClassifier_ConcurrentUpdates(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, metrics.NewNoopMetrics())
 	var wg sync.WaitGroup
 	numGoroutines := 10
 	readsPerGoroutine := 100

--- a/internal/gcsx/read_type_classifier_test.go
+++ b/internal/gcsx/read_type_classifier_test.go
@@ -657,7 +657,7 @@ type mockMetricHandle struct {
 	lastTransition   metrics.TransitionType
 }
 
-func (m *mockMetricHandle) GcsExperimentalReadTypeTransitionsCount(inc int64, reason metrics.Reason, transitionType metrics.TransitionType) {
+func (m *mockMetricHandle) ReadExperimentalReadTypeTransitionsCount(inc int64, reason metrics.Reason, transitionType metrics.TransitionType) {
 	m.transitionsCount += inc
 	m.lastReason = reason
 	m.lastTransition = transitionType

--- a/internal/gcsx/read_type_classifier_test.go
+++ b/internal/gcsx/read_type_classifier_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestReadTypeClassifier_InitialState(t *testing.T) {
-	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 
 	assert.Equal(t, metrics.ReadTypeSequential, readTypeClassifier.readType.Load())
 	assert.Equal(t, int64(0), readTypeClassifier.expectedOffset.Load())
@@ -107,7 +107,7 @@ func TestReadTypeClassifier_IsSeekNeeded(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 			classifier.readType.Store(tc.readType)
 			classifier.expectedOffset.Store(tc.expectedOffset)
 
@@ -304,7 +304,7 @@ func TestReadTypeClassifier_GetReadInfo(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+			readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 			readTypeClassifier.readType.Store(tc.initialReadType)
 			readTypeClassifier.expectedOffset.Store(tc.initialExpOffset)
 			readTypeClassifier.seeks.Store(tc.initialNumSeeks)
@@ -360,7 +360,7 @@ func TestReadTypeClassifier_RecordRead(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 			classifier.expectedOffset.Store(tc.initialExpectedOffset)
 			classifier.totalReadBytes.Store(tc.initialTotalReadBytes)
 
@@ -473,7 +473,7 @@ func TestReadTypeClassifier_ComputeSeqPrefetchWindowAndAdjustType(t *testing.T) 
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(tc.sequentialReadSizeMb, 0)
+			classifier := NewReadTypeClassifier(tc.sequentialReadSizeMb, 0, nil)
 			classifier.seeks.Store(tc.initialNumSeeks)
 			classifier.totalReadBytes.Store(tc.initialTotalReadBytes)
 			classifier.initialOffset = tc.initialOffset
@@ -510,7 +510,7 @@ func TestReadTypeClassifier_IsSequentialRead(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+			classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 			classifier.readType.Store(tc.readType)
 
 			assert.Equal(t, tc.SequentialRead, classifier.IsReadSequential())
@@ -560,7 +560,7 @@ func Test_avgReadBytes(t *testing.T) {
 }
 
 func TestReadTypeClassifier_SequentialReads(t *testing.T) {
-	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+	readTypeClassifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 
 	// Simulate 4 reads of 10MB IO.
 	readSizes := []int64{10 * MB, 10 * MB, 10 * MB, 10 * MB}
@@ -579,7 +579,7 @@ func TestReadTypeClassifier_SequentialReads(t *testing.T) {
 }
 
 func TestReadTypeClassifier_RandomReads(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 
 	// Simulate random reads of 5MB each at different offsets.
 	readSizes := []int64{5 * MB, 5 * MB, 5 * MB, 5 * MB}
@@ -595,7 +595,7 @@ func TestReadTypeClassifier_RandomReads(t *testing.T) {
 }
 
 func TestReadTypeClassifier_RandomToSequentialRead(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 	// Start with random reads.
 	randomReadSizes := []int64{2 * MB, 2 * MB, 2 * MB, 2 * MB, 2 * MB}
 	randomOffsets := []int64{50 * MB, 20 * MB, 10 * MB, 30 * MB, 40 * MB}
@@ -621,7 +621,7 @@ func TestReadTypeClassifier_RandomToSequentialRead(t *testing.T) {
 }
 
 func TestReadTypeClassifier_ConcurrentUpdates(t *testing.T) {
-	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0)
+	classifier := NewReadTypeClassifier(sequentialReadSizeInMb, 0, nil)
 	var wg sync.WaitGroup
 	numGoroutines := 10
 	readsPerGoroutine := 100
@@ -648,4 +648,61 @@ func TestReadTypeClassifier_ConcurrentUpdates(t *testing.T) {
 	// Read type could be either sequential or random depending on timing, so just check it's valid.
 	readType := classifier.readType.Load()
 	assert.True(t, readType == metrics.ReadTypeSequential || readType == metrics.ReadTypeRandom)
+}
+
+type mockMetricHandle struct {
+	metrics.MetricHandle
+	transitionsCount int64
+	lastReason       metrics.Reason
+	lastTransition   metrics.TransitionType
+}
+
+func (m *mockMetricHandle) GcsExperimentalReadTypeTransitionsCount(inc int64, reason metrics.Reason, transitionType metrics.TransitionType) {
+	m.transitionsCount += inc
+	m.lastReason = reason
+	m.lastTransition = transitionType
+}
+
+func TestReadTypeClassifier_TransitionMetrics(t *testing.T) {
+	// Test case 1: Initial non-zero offset transitions to Random with ReasonInitialOffsetNonZeroAttr
+	mh1 := &mockMetricHandle{}
+	classifier1 := NewReadTypeClassifier(sequentialReadSizeInMb, 100, mh1)
+	_ = classifier1.GetReadInfo(100, false)
+	assert.Equal(t, int64(1), mh1.transitionsCount)
+	assert.Equal(t, metrics.TransitionTypeSequentialToRandomAttr, mh1.lastTransition)
+	assert.Equal(t, metrics.ReasonInitialOffsetNonZeroAttr, mh1.lastReason)
+
+	// Test case 2: Backward seek transitions to Random with ReasonBackwardSeekAttr
+	mh2 := &mockMetricHandle{}
+	classifier2 := NewReadTypeClassifier(sequentialReadSizeInMb, 0, mh2)
+	_ = classifier2.GetReadInfo(0, false)  // 1st read at 0 -> sequential
+	classifier2.RecordRead(0, 100)         // expectedOffset = 100
+	_ = classifier2.GetReadInfo(50, false) // backward jump to 50
+	assert.Equal(t, int64(1), mh2.transitionsCount)
+	assert.Equal(t, metrics.TransitionTypeSequentialToRandomAttr, mh2.lastTransition)
+	assert.Equal(t, metrics.ReasonBackwardSeekAttr, mh2.lastReason)
+
+	// Test case 3: Forward seek transitions to Random with ReasonForwardSeekAttr
+	mh3 := &mockMetricHandle{}
+	classifier3 := NewReadTypeClassifier(sequentialReadSizeInMb, 0, mh3)
+	_ = classifier3.GetReadInfo(0, false)                   // 1st read at 0 -> sequential
+	classifier3.RecordRead(0, 100)                          // expectedOffset = 100
+	_ = classifier3.GetReadInfo(100+maxReadSize+100, false) // forward seek beyond limit
+	assert.Equal(t, int64(1), mh3.transitionsCount)
+	assert.Equal(t, metrics.TransitionTypeSequentialToRandomAttr, mh3.lastTransition)
+	assert.Equal(t, metrics.ReasonForwardSeekAttr, mh3.lastReason)
+
+	// Test case 4: Transition back to Sequential due to average read size being large enough
+	mh4 := &mockMetricHandle{}
+	classifier4 := NewReadTypeClassifier(sequentialReadSizeInMb, 100, mh4)
+	_ = classifier4.GetReadInfo(100, false) // transitions from Seq to Random due to initial non-zero offset
+	assert.Equal(t, int64(1), mh4.transitionsCount)
+	assert.Equal(t, metrics.TransitionTypeSequentialToRandomAttr, mh4.lastTransition)
+	assert.Equal(t, metrics.ReasonInitialOffsetNonZeroAttr, mh4.lastReason)
+
+	classifier4.RecordRead(100, 9*MB)            // read 9MB of data contiguous (greater than maxReadSize = 8MB)
+	_ = classifier4.GetReadInfo(100+9*MB, false) // evaluate next read. transitions back from Random to Seq!
+	assert.Equal(t, int64(2), mh4.transitionsCount)
+	assert.Equal(t, metrics.TransitionTypeRandomToSequentialAttr, mh4.lastTransition)
+	assert.Equal(t, metrics.ReasonAverageReadSizeLargeEnoughAttr, mh4.lastReason)
 }

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -240,8 +240,9 @@ type monitoringReadCloser struct {
 
 func (mrc *monitoringReadCloser) Read(p []byte) (n int, err error) {
 	n, err = mrc.wrapped.Read(p)
+	mrc.metricHandle.GcsReadBytesCount(int64(n))
 	readType := metrics.GetReadTypeFromContext(mrc.ctx)
-	mrc.metricHandle.GcsReadBytesCount(int64(n), readType)
+	mrc.metricHandle.GcsExperimentalReadBytesCount(int64(n), readType)
 	return
 }
 

--- a/internal/monitor/bucket.go
+++ b/internal/monitor/bucket.go
@@ -240,7 +240,8 @@ type monitoringReadCloser struct {
 
 func (mrc *monitoringReadCloser) Read(p []byte) (n int, err error) {
 	n, err = mrc.wrapped.Read(p)
-	mrc.metricHandle.GcsReadBytesCount(int64(n))
+	readType := metrics.GetReadTypeFromContext(mrc.ctx)
+	mrc.metricHandle.GcsReadBytesCount(int64(n), readType)
 	return
 }
 

--- a/internal/storage/storageutil/read_object.go
+++ b/internal/storage/storageutil/read_object.go
@@ -19,6 +19,7 @@ import (
 	"io"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/net/context"
 )
 
@@ -33,6 +34,7 @@ func ReadObject(
 		Name: name,
 	}
 
+	ctx = metrics.ContextWithReadType(ctx, metrics.ReadTypeSequentialAttr)
 	rc, err := bucket.NewReaderWithReadHandle(ctx, req)
 	if err != nil {
 		return

--- a/metrics/helper.go
+++ b/metrics/helper.go
@@ -14,6 +14,25 @@
 
 package metrics
 
+import "context"
+
+type contextKeyType int
+
+const readTypeKey contextKeyType = iota
+
+// GetReadTypeFromContext returns the ReadType stored in the context, or ReadTypeUnknownAttr if not present.
+func GetReadTypeFromContext(ctx context.Context) ReadType {
+	if val, ok := ctx.Value(readTypeKey).(ReadType); ok {
+		return val
+	}
+	return ReadTypeUnknownAttr
+}
+
+// ContextWithReadType returns a new context with the provided ReadType stored.
+func ContextWithReadType(ctx context.Context, readType ReadType) context.Context {
+	return context.WithValue(ctx, readTypeKey, readType)
+}
+
 // CaptureGCSReadMetrics is a helper function to encapsulate the logic for recording
 // GCS read-related metrics.
 func CaptureGCSReadMetrics(mh MetricHandle, readType ReadType, downloadBytes int64) {

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -151,10 +151,18 @@ type Reason string
 const (
 	ReasonAverageReadSizeLargeEnoughAttr Reason = "average_read_size_large_enough"
 	ReasonBackwardSeekAttr               Reason = "backward_seek"
+	ReasonCanceledAttr                   Reason = "canceled"
+	ReasonDeadlineExceededAttr           Reason = "deadline_exceeded"
+	ReasonExplicitCloseAttr              Reason = "explicit_close"
+	ReasonForcedRecreateAttr             Reason = "forced_recreate"
 	ReasonForwardSeekAttr                Reason = "forward_seek"
+	ReasonInactiveTimeoutAttr            Reason = "inactive_timeout"
 	ReasonInitialOffsetNonZeroAttr       Reason = "initial_offset_non_zero"
 	ReasonInsufficientMemoryAttr         Reason = "insufficient_memory"
 	ReasonRandomReadDetectedAttr         Reason = "random_read_detected"
+	ReasonSeekAttr                       Reason = "seek"
+	ReasonSequentialToRandomAttr         Reason = "sequential_to_random"
+	ReasonUnknownAttr                    Reason = "unknown"
 )
 
 // RequestType is a custom type for the request_type attribute.
@@ -227,6 +235,9 @@ type MetricHandle interface {
 
 	// GcsExperimentalReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
 	GcsExperimentalReadBytesCount(inc int64, readType ReadType)
+
+	// GcsExperimentalReaderCancellationCount - The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason.
+	GcsExperimentalReaderCancellationCount(inc int64, reason Reason)
 
 	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
 	GcsReadBytesCount(inc int64)

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -149,8 +149,12 @@ const (
 type Reason string
 
 const (
-	ReasonInsufficientMemoryAttr Reason = "insufficient_memory"
-	ReasonRandomReadDetectedAttr Reason = "random_read_detected"
+	ReasonAverageReadSizeLargeEnoughAttr Reason = "average_read_size_large_enough"
+	ReasonBackwardSeekAttr               Reason = "backward_seek"
+	ReasonForwardSeekAttr                Reason = "forward_seek"
+	ReasonInitialOffsetNonZeroAttr       Reason = "initial_offset_non_zero"
+	ReasonInsufficientMemoryAttr         Reason = "insufficient_memory"
+	ReasonRandomReadDetectedAttr         Reason = "random_read_detected"
 )
 
 // RequestType is a custom type for the request_type attribute.
@@ -167,6 +171,14 @@ type RetryErrorCategory string
 const (
 	RetryErrorCategoryOTHERERRORSAttr        RetryErrorCategory = "OTHER_ERRORS"
 	RetryErrorCategorySTALLEDREADREQUESTAttr RetryErrorCategory = "STALLED_READ_REQUEST"
+)
+
+// TransitionType is a custom type for the transition_type attribute.
+type TransitionType string
+
+const (
+	TransitionTypeRandomToSequentialAttr TransitionType = "random_to_sequential"
+	TransitionTypeSequentialToRandomAttr TransitionType = "sequential_to_random"
 )
 
 // WriteFallbackReason is a custom type for the write_fallback_reason attribute.
@@ -213,8 +225,14 @@ type MetricHandle interface {
 	// GcsDownloadBytesCount - The cumulative number of bytes downloaded from GCS along with type - Sequential/Random
 	GcsDownloadBytesCount(inc int64, readType ReadType)
 
-	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
-	GcsReadBytesCount(inc int64, readType ReadType)
+	// GcsExperimentalReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
+	GcsExperimentalReadBytesCount(inc int64, readType ReadType)
+
+	// GcsExperimentalReadTypeTransitionsCount - The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough.
+	GcsExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType)
+
+	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
+	GcsReadBytesCount(inc int64)
 
 	// GcsReadCount - Specifies the number of gcs reads made along with type - Sequential/Random
 	GcsReadCount(inc int64, readType ReadType)

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -236,11 +236,11 @@ type MetricHandle interface {
 	// GcsExperimentalReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
 	GcsExperimentalReadBytesCount(inc int64, readType ReadType)
 
-	// GcsExperimentalReaderCancellationBytesCount - The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason.
-	GcsExperimentalReaderCancellationBytesCount(inc int64, reason Reason)
-
 	// GcsExperimentalReaderCancellationCount - The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason.
 	GcsExperimentalReaderCancellationCount(inc int64, reason Reason)
+
+	// GcsExperimentalReaderCancellationUnreadBytes - The distribution of requested bytes that went unread when an in-flight GCS object reader was canceled or aborted, tracked across preemption triggers.
+	GcsExperimentalReaderCancellationUnreadBytes(ctx context.Context, value int64, reason Reason)
 
 	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
 	GcsReadBytesCount(inc int64)

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -236,6 +236,9 @@ type MetricHandle interface {
 	// GcsExperimentalReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
 	GcsExperimentalReadBytesCount(inc int64, readType ReadType)
 
+	// GcsExperimentalReaderCancellationBytesCount - The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason.
+	GcsExperimentalReaderCancellationBytesCount(inc int64, reason Reason)
+
 	// GcsExperimentalReaderCancellationCount - The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason.
 	GcsExperimentalReaderCancellationCount(inc int64, reason Reason)
 

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -213,8 +213,8 @@ type MetricHandle interface {
 	// GcsDownloadBytesCount - The cumulative number of bytes downloaded from GCS along with type - Sequential/Random
 	GcsDownloadBytesCount(inc int64, readType ReadType)
 
-	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
-	GcsReadBytesCount(inc int64)
+	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
+	GcsReadBytesCount(inc int64, readType ReadType)
 
 	// GcsReadCount - Specifies the number of gcs reads made along with type - Sequential/Random
 	GcsReadCount(inc int64, readType ReadType)

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -228,9 +228,6 @@ type MetricHandle interface {
 	// GcsExperimentalReadBytesCount - The cumulative number of bytes read from GCS objects along with type - Sequential/Random
 	GcsExperimentalReadBytesCount(inc int64, readType ReadType)
 
-	// GcsExperimentalReadTypeTransitionsCount - The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough.
-	GcsExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType)
-
 	// GcsReadBytesCount - The cumulative number of bytes read from GCS objects.
 	GcsReadBytesCount(inc int64)
 
@@ -254,6 +251,9 @@ type MetricHandle interface {
 
 	// ReadBlockSizes - The cumulative distribution of read block sizes across different bucket boundaries
 	ReadBlockSizes(ctx context.Context, value int64)
+
+	// ReadExperimentalReadTypeTransitionsCount - The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough.
+	ReadExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType)
 
 	// TestUpdownCounter - Test metric for updown counters.
 	TestUpdownCounter(inc int64)

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -183,6 +183,22 @@
     values: *read_types_list
 
 
+- metric-name: "gcs/experimental_reader_cancellation_count"
+  description: "The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."
+  type: "int_counter"
+  attributes:
+  - attribute-name: reason
+    attribute-type: string
+    values:
+    - "canceled"
+    - "deadline_exceeded"
+    - "explicit_close"
+    - "forced_recreate"
+    - "inactive_timeout"
+    - "seek"
+    - "sequential_to_random"
+    - "unknown"
+
 - metric-name: "gcs/read_bytes_count"
   description: "The cumulative number of bytes read from GCS objects."
   unit: "By"

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -182,22 +182,6 @@
     attribute-type: string
     values: *read_types_list
 
-- metric-name: "gcs/experimental_read_type_transitions_count"
-  description: "The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."
-  type: "int_counter"
-  attributes:
-  - attribute-name: reason
-    attribute-type: string
-    values:
-    - "average_read_size_large_enough"
-    - "backward_seek"
-    - "forward_seek"
-    - "initial_offset_non_zero"
-  - attribute-name: transition_type
-    attribute-type: string
-    values:
-    - "random_to_sequential"
-    - "sequential_to_random"
 
 - metric-name: "gcs/read_bytes_count"
   description: "The cumulative number of bytes read from GCS objects."
@@ -321,6 +305,23 @@
   - 33554432
   - 67108864
   - 134217728
+
+- metric-name: "read/experimental_read_type_transitions_count"
+  description: "The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."
+  type: "int_counter"
+  attributes:
+  - attribute-name: reason
+    attribute-type: string
+    values:
+    - "average_read_size_large_enough"
+    - "backward_seek"
+    - "forward_seek"
+    - "initial_offset_non_zero"
+  - attribute-name: transition_type
+    attribute-type: string
+    values:
+    - "random_to_sequential"
+    - "sequential_to_random"
 
 - metric-name: "test/updown_counter"
   description: "Test metric for updown counters."

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -174,9 +174,13 @@
     - "Sequential"
 
 - metric-name: "gcs/read_bytes_count"
-  description: "The cumulative number of bytes read from GCS objects."
+  description: "The cumulative number of bytes read from GCS objects along with type - Sequential/Random"
   unit: "By"
   type: "int_counter"
+  attributes:
+  - attribute-name: read_type
+    attribute-type: string
+    values: *read_types_list
 
 - metric-name: "gcs/read_count"
   description: "Specifies the number of gcs reads made along with type - Sequential/Random"

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -173,7 +173,7 @@
     - "Random"
     - "Sequential"
 
-- metric-name: "gcs/read_bytes_count"
+- metric-name: "gcs/experimental_read_bytes_count"
   description: "The cumulative number of bytes read from GCS objects along with type - Sequential/Random"
   unit: "By"
   type: "int_counter"
@@ -181,6 +181,28 @@
   - attribute-name: read_type
     attribute-type: string
     values: *read_types_list
+
+- metric-name: "gcs/experimental_read_type_transitions_count"
+  description: "The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."
+  type: "int_counter"
+  attributes:
+  - attribute-name: reason
+    attribute-type: string
+    values:
+    - "average_read_size_large_enough"
+    - "backward_seek"
+    - "forward_seek"
+    - "initial_offset_non_zero"
+  - attribute-name: transition_type
+    attribute-type: string
+    values:
+    - "random_to_sequential"
+    - "sequential_to_random"
+
+- metric-name: "gcs/read_bytes_count"
+  description: "The cumulative number of bytes read from GCS objects."
+  unit: "By"
+  type: "int_counter"
 
 - metric-name: "gcs/read_count"
   description: "Specifies the number of gcs reads made along with type - Sequential/Random"

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -183,13 +183,14 @@
     values: *read_types_list
 
 
-- metric-name: "gcs/experimental_reader_cancellation_count"
-  description: "The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."
+- metric-name: "gcs/experimental_reader_cancellation_bytes_count"
+  description: "The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason."
+  unit: "By"
   type: "int_counter"
   attributes:
   - attribute-name: reason
     attribute-type: string
-    values:
+    values: &cancellation_reasons_list
     - "canceled"
     - "deadline_exceeded"
     - "explicit_close"
@@ -198,6 +199,14 @@
     - "seek"
     - "sequential_to_random"
     - "unknown"
+
+- metric-name: "gcs/experimental_reader_cancellation_count"
+  description: "The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."
+  type: "int_counter"
+  attributes:
+  - attribute-name: reason
+    attribute-type: string
+    values: *cancellation_reasons_list
 
 - metric-name: "gcs/read_bytes_count"
   description: "The cumulative number of bytes read from GCS objects."

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -183,9 +183,8 @@
     values: *read_types_list
 
 
-- metric-name: "gcs/experimental_reader_cancellation_bytes_count"
-  description: "The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason."
-  unit: "By"
+- metric-name: "gcs/experimental_reader_cancellation_count"
+  description: "The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."
   type: "int_counter"
   attributes:
   - attribute-name: reason
@@ -200,9 +199,27 @@
     - "sequential_to_random"
     - "unknown"
 
-- metric-name: "gcs/experimental_reader_cancellation_count"
-  description: "The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."
-  type: "int_counter"
+- metric-name: "gcs/experimental_reader_cancellation_unread_bytes"
+  description: "The distribution of requested bytes that went unread when an in-flight GCS object reader was canceled or aborted, tracked across preemption triggers."
+  unit: "By"
+  type: "int_histogram"
+  boundaries: &bytes_boundaries
+  - 0 # To detect EOF scenarios
+  - 8192
+  - 16384
+  - 32768
+  - 65536
+  - 131072
+  - 262144
+  - 524288
+  - 1048576
+  - 2097152
+  - 4194304
+  - 8388608
+  - 16777216
+  - 33554432
+  - 67108864
+  - 134217728
   attributes:
   - attribute-name: reason
     attribute-type: string
@@ -313,23 +330,7 @@
   description: "The cumulative distribution of read block sizes across different bucket boundaries"
   type: "int_histogram"
   unit: "By"
-  boundaries: &bytes_boundaries # in bytes
-  - 0 # To detect EOF scenarios
-  - 8192
-  - 16384
-  - 32768
-  - 65536
-  - 131072
-  - 262144
-  - 524288
-  - 1048576
-  - 2097152
-  - 4194304
-  - 8388608
-  - 16777216
-  - 33554432
-  - 67108864
-  - 134217728
+  boundaries: *bytes_boundaries
 
 - metric-name: "read/experimental_read_type_transitions_count"
   description: "The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."

--- a/metrics/metrics_test_utils.go
+++ b/metrics/metrics_test_utils.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -96,12 +97,18 @@ func VerifyCounterMetric(t *testing.T, ctx context.Context, reader *metric.Manua
 						return
 					}
 				}
+
+				// If metric exists but attrs don't match, print recorded data points
+				var recordedPoints []string
+				for _, dp := range data.DataPoints {
+					recordedPoints = append(recordedPoints, fmt.Sprintf("attrs: %v, value: %d", dp.Attributes.ToSlice(), dp.Value))
+				}
+				require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric. Recorded data points: %v", attrs.ToSlice(), metricName, recordedPoints))
 			}
 		}
 	}
 
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
 }
 
 // VerifyHistogramMetric finds a histogram metric across all scopes and verifies its count.
@@ -140,13 +147,13 @@ func VerifyHistogramMetric(t *testing.T, ctx context.Context, reader *metric.Man
 						}
 					}
 				default:
-					require.Fail(t, "metric %s is not an expected histogram type, but %T", metricName, m.Data)
+					require.Fail(t, fmt.Sprintf("metric %s is not an expected histogram type, but %T", metricName, m.Data))
 				}
 			}
 		}
 	}
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
+	require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric", attrs, metricName))
 }
 
 // VerifyHistogramFull finds a histogram metric and fully verifies its state including total count, sum, and bucket distribution.
@@ -200,5 +207,5 @@ func VerifyHistogramFull[T int64 | float64](t *testing.T, ctx context.Context, r
 		}
 	}
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
+	require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric", attrs, metricName))
 }

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -46,9 +46,10 @@ func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsExperimentalReadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsExperimentalReaderCancellationBytesCount(inc int64, reason Reason) {}
-
 func (*noopMetrics) GcsExperimentalReaderCancellationCount(inc int64, reason Reason) {}
+
+func (*noopMetrics) GcsExperimentalReaderCancellationUnreadBytes(ctx context.Context, value int64, reason Reason) {
+}
 
 func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -46,6 +46,8 @@ func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsExperimentalReadBytesCount(inc int64, readType ReadType) {}
 
+func (*noopMetrics) GcsExperimentalReaderCancellationCount(inc int64, reason Reason) {}
+
 func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -44,7 +44,12 @@ func (*noopMetrics) FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, 
 
 func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsReadBytesCount(inc int64, readType ReadType) {}
+func (*noopMetrics) GcsExperimentalReadBytesCount(inc int64, readType ReadType) {}
+
+func (*noopMetrics) GcsExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType) {
+}
+
+func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}
 

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -46,6 +46,8 @@ func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsExperimentalReadBytesCount(inc int64, readType ReadType) {}
 
+func (*noopMetrics) GcsExperimentalReaderCancellationBytesCount(inc int64, reason Reason) {}
+
 func (*noopMetrics) GcsExperimentalReaderCancellationCount(inc int64, reason Reason) {}
 
 func (*noopMetrics) GcsReadBytesCount(inc int64) {}

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -44,7 +44,7 @@ func (*noopMetrics) FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, 
 
 func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsReadBytesCount(inc int64) {}
+func (*noopMetrics) GcsReadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}
 

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -46,9 +46,6 @@ func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
 func (*noopMetrics) GcsExperimentalReadBytesCount(inc int64, readType ReadType) {}
 
-func (*noopMetrics) GcsExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType) {
-}
-
 func (*noopMetrics) GcsReadBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsReadCount(inc int64, readType ReadType) {}
@@ -66,6 +63,9 @@ func (*noopMetrics) MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus
 }
 
 func (*noopMetrics) ReadBlockSizes(ctx context.Context, value int64) {}
+
+func (*noopMetrics) ReadExperimentalReadTypeTransitionsCount(inc int64, reason Reason, transitionType TransitionType) {
+}
 
 func (*noopMetrics) TestUpdownCounter(inc int64) {}
 

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -527,14 +527,6 @@ var (
 	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
 	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsExperimentalReaderCancellationBytesCountReasonCanceledAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
-	gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
-	gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
-	gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forced_recreate")))
-	gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "inactive_timeout")))
-	gcsExperimentalReaderCancellationBytesCountReasonSeekAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "seek")))
-	gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "sequential_to_random")))
-	gcsExperimentalReaderCancellationBytesCountReasonUnknownAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "unknown")))
 	gcsExperimentalReaderCancellationCountReasonCanceledAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
 	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
 	gcsExperimentalReaderCancellationCountReasonExplicitCloseAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
@@ -543,6 +535,14 @@ var (
 	gcsExperimentalReaderCancellationCountReasonSeekAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "seek")))
 	gcsExperimentalReaderCancellationCountReasonSequentialToRandomAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "sequential_to_random")))
 	gcsExperimentalReaderCancellationCountReasonUnknownAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "unknown")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonCanceledAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonDeadlineExceededAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonExplicitCloseAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonForcedRecreateAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forced_recreate")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonInactiveTimeoutAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "inactive_timeout")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonSeekAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "seek")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonSequentialToRandomAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "sequential_to_random")))
+	gcsExperimentalReaderCancellationUnreadBytesReasonUnknownAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "unknown")))
 	gcsReadCountReadTypeParallelAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
 	gcsReadCountReadTypeRandomAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsReadCountReadTypeSequentialAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
@@ -1090,14 +1090,6 @@ type otelMetrics struct {
 	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                              *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                          *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                             *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic                                                *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic                                        *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic                                           *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic                                          *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic                                         *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic                                                    *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic                                      *atomic.Int64
-	gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic                                                 *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonCanceledAtomic                                                     *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic                                             *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic                                                *atomic.Int64
@@ -1160,6 +1152,7 @@ type otelMetrics struct {
 	bufferedReadReadLatency                                                                                        metric.Int64Histogram
 	fileCacheReadLatencies                                                                                         metric.Int64Histogram
 	fsOpsLatency                                                                                                   metric.Int64Histogram
+	gcsExperimentalReaderCancellationUnreadBytes                                                                   metric.Int64Histogram
 	gcsRequestLatencies                                                                                            metric.Int64Histogram
 	readBlockSizes                                                                                                 metric.Int64Histogram
 }
@@ -2428,35 +2421,6 @@ func (o *otelMetrics) GcsExperimentalReadBytesCount(
 	}
 }
 
-func (o *otelMetrics) GcsExperimentalReaderCancellationBytesCount(
-	inc int64, reason Reason) {
-	if inc < 0 {
-		logger.Errorf("Counter metric gcs/experimental_reader_cancellation_bytes_count received a negative increment: %d", inc)
-		return
-	}
-	switch reason {
-	case ReasonCanceledAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic.Add(inc)
-	case ReasonDeadlineExceededAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic.Add(inc)
-	case ReasonExplicitCloseAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic.Add(inc)
-	case ReasonForcedRecreateAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic.Add(inc)
-	case ReasonInactiveTimeoutAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic.Add(inc)
-	case ReasonSeekAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic.Add(inc)
-	case ReasonSequentialToRandomAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic.Add(inc)
-	case ReasonUnknownAttr:
-		o.gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic.Add(inc)
-	default:
-		updateUnrecognizedAttribute(string(reason))
-		return
-	}
-}
-
 func (o *otelMetrics) GcsExperimentalReaderCancellationCount(
 	inc int64, reason Reason) {
 	if inc < 0 {
@@ -2483,6 +2447,37 @@ func (o *otelMetrics) GcsExperimentalReaderCancellationCount(
 	default:
 		updateUnrecognizedAttribute(string(reason))
 		return
+	}
+}
+
+func (o *otelMetrics) GcsExperimentalReaderCancellationUnreadBytes(
+	ctx context.Context, value int64, reason Reason) {
+	var record histogramRecord
+	switch reason {
+	case ReasonCanceledAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonCanceledAttrSet}
+	case ReasonDeadlineExceededAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonDeadlineExceededAttrSet}
+	case ReasonExplicitCloseAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonExplicitCloseAttrSet}
+	case ReasonForcedRecreateAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonForcedRecreateAttrSet}
+	case ReasonInactiveTimeoutAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonInactiveTimeoutAttrSet}
+	case ReasonSeekAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonSeekAttrSet}
+	case ReasonSequentialToRandomAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonSequentialToRandomAttrSet}
+	case ReasonUnknownAttr:
+		record = histogramRecord{ctx: ctx, instrument: o.gcsExperimentalReaderCancellationUnreadBytes, value: value, attributes: gcsExperimentalReaderCancellationUnreadBytesReasonUnknownAttrSet}
+	default:
+		updateUnrecognizedAttribute(string(reason))
+		return
+	}
+
+	select {
+	case o.ch <- record: // Do nothing
+	default: // Unblock writes to channel if it's full.
 	}
 }
 
@@ -3298,15 +3293,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic atomic.Int64
 
-	var gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic atomic.Int64
-
 	var gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
 		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
 		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,
@@ -3914,22 +3900,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_bytes_count",
-		metric.WithDescription("The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason."),
-		metric.WithUnit("By"),
-		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic, gcsExperimentalReaderCancellationBytesCountReasonCanceledAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic, gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic, gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic, gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic, gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic, gcsExperimentalReaderCancellationBytesCountReasonSeekAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic, gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic, gcsExperimentalReaderCancellationBytesCountReasonUnknownAttrSet)
-			return nil
-		}))
-
-	_, err12 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_count",
 		metric.WithDescription("The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3943,6 +3914,11 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonUnknownAtomic, gcsExperimentalReaderCancellationCountReasonUnknownAttrSet)
 			return nil
 		}))
+
+	gcsExperimentalReaderCancellationUnreadBytes, err12 := meter.Int64Histogram("gcs/experimental_reader_cancellation_unread_bytes",
+		metric.WithDescription("The distribution of requested bytes that went unread when an in-flight GCS object reader was canceled or aborted, tracked across preemption triggers."),
+		metric.WithUnit("By"),
+		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
 	_, err13 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
@@ -4546,14 +4522,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                     &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                 &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                    &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic:                                       &gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic:                               &gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic:                                  &gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic:                                 &gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic:                                &gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic:                                           &gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic:                             &gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic,
-		gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic:                                        &gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic,
 		gcsExperimentalReaderCancellationCountReasonCanceledAtomic:                                            &gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
 		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic:                                    &gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
 		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic:                                       &gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,
@@ -4562,6 +4530,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReaderCancellationCountReasonSeekAtomic:                                                &gcsExperimentalReaderCancellationCountReasonSeekAtomic,
 		gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic:                                  &gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic,
 		gcsExperimentalReaderCancellationCountReasonUnknownAtomic:                                             &gcsExperimentalReaderCancellationCountReasonUnknownAtomic,
+		gcsExperimentalReaderCancellationUnreadBytes:                                                          gcsExperimentalReaderCancellationUnreadBytes,
 		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
 		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -523,6 +523,10 @@ var (
 	gcsDownloadBytesCountReadTypeParallelAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
 	gcsDownloadBytesCountReadTypeRandomAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsDownloadBytesCountReadTypeSequentialAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsReadBytesCountReadTypeParallelAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsReadBytesCountReadTypeRandomAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsReadBytesCountReadTypeSequentialAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsReadBytesCountReadTypeUnknownAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
 	gcsReadCountReadTypeParallelAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
 	gcsReadCountReadTypeRandomAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsReadCountReadTypeSequentialAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
@@ -1058,7 +1062,10 @@ type otelMetrics struct {
 	gcsDownloadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
 	gcsDownloadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
 	gcsDownloadBytesCountReadTypeSequentialAtomic                                                         *atomic.Int64
-	gcsReadBytesCountAtomic                                                                               *atomic.Int64
+	gcsReadBytesCountReadTypeParallelAtomic                                                               *atomic.Int64
+	gcsReadBytesCountReadTypeRandomAtomic                                                                 *atomic.Int64
+	gcsReadBytesCountReadTypeSequentialAtomic                                                             *atomic.Int64
+	gcsReadBytesCountReadTypeUnknownAtomic                                                                *atomic.Int64
 	gcsReadCountReadTypeParallelAtomic                                                                    *atomic.Int64
 	gcsReadCountReadTypeRandomAtomic                                                                      *atomic.Int64
 	gcsReadCountReadTypeSequentialAtomic                                                                  *atomic.Int64
@@ -2352,12 +2359,24 @@ func (o *otelMetrics) GcsDownloadBytesCount(
 }
 
 func (o *otelMetrics) GcsReadBytesCount(
-	inc int64) {
+	inc int64, readType ReadType) {
 	if inc < 0 {
 		logger.Errorf("Counter metric gcs/read_bytes_count received a negative increment: %d", inc)
 		return
 	}
-	o.gcsReadBytesCountAtomic.Add(inc)
+	switch readType {
+	case ReadTypeParallelAttr:
+		o.gcsReadBytesCountReadTypeParallelAtomic.Add(inc)
+	case ReadTypeRandomAttr:
+		o.gcsReadBytesCountReadTypeRandomAtomic.Add(inc)
+	case ReadTypeSequentialAttr:
+		o.gcsReadBytesCountReadTypeSequentialAtomic.Add(inc)
+	case ReadTypeUnknownAttr:
+		o.gcsReadBytesCountReadTypeUnknownAtomic.Add(inc)
+	default:
+		updateUnrecognizedAttribute(string(readType))
+		return
+	}
 }
 
 func (o *otelMetrics) GcsReadCount(
@@ -3105,7 +3124,10 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsDownloadBytesCountReadTypeRandomAtomic,
 		gcsDownloadBytesCountReadTypeSequentialAtomic atomic.Int64
 
-	var gcsReadBytesCountAtomic atomic.Int64
+	var gcsReadBytesCountReadTypeParallelAtomic,
+		gcsReadBytesCountReadTypeRandomAtomic,
+		gcsReadBytesCountReadTypeSequentialAtomic,
+		gcsReadBytesCountReadTypeUnknownAtomic atomic.Int64
 
 	var gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic,
@@ -3684,10 +3706,13 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		}))
 
 	_, err10 := meter.Int64ObservableCounter("gcs/read_bytes_count",
-		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
+		metric.WithDescription("The cumulative number of bytes read from GCS objects along with type - Sequential/Random"),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &gcsReadBytesCountAtomic)
+			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeParallelAtomic, gcsReadBytesCountReadTypeParallelAttrSet)
+			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeRandomAtomic, gcsReadBytesCountReadTypeRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeSequentialAtomic, gcsReadBytesCountReadTypeSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeUnknownAtomic, gcsReadBytesCountReadTypeUnknownAttrSet)
 			return nil
 		}))
 
@@ -4266,33 +4291,36 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
 		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
 		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
-		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
-		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
-		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,
-		gcsReadCountReadTypeSequentialAtomic:                                               &gcsReadCountReadTypeSequentialAtomic,
-		gcsReadCountReadTypeUnknownAtomic:                                                  &gcsReadCountReadTypeUnknownAtomic,
-		gcsReaderCountIoMethodClosedAtomic:                                                 &gcsReaderCountIoMethodClosedAtomic,
-		gcsReaderCountIoMethodOpenedAtomic:                                                 &gcsReaderCountIoMethodOpenedAtomic,
-		gcsRequestCountGcsMethodComposeObjectsAtomic:                                       &gcsRequestCountGcsMethodComposeObjectsAtomic,
-		gcsRequestCountGcsMethodCopyObjectAtomic:                                           &gcsRequestCountGcsMethodCopyObjectAtomic,
-		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic:                         &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
-		gcsRequestCountGcsMethodCreateFolderAtomic:                                         &gcsRequestCountGcsMethodCreateFolderAtomic,
-		gcsRequestCountGcsMethodCreateObjectAtomic:                                         &gcsRequestCountGcsMethodCreateObjectAtomic,
-		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:                              &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
-		gcsRequestCountGcsMethodDeleteFolderAtomic:                                         &gcsRequestCountGcsMethodDeleteFolderAtomic,
-		gcsRequestCountGcsMethodDeleteObjectAtomic:                                         &gcsRequestCountGcsMethodDeleteObjectAtomic,
-		gcsRequestCountGcsMethodFinalizeUploadAtomic:                                       &gcsRequestCountGcsMethodFinalizeUploadAtomic,
-		gcsRequestCountGcsMethodFlushPendingWritesAtomic:                                   &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
-		gcsRequestCountGcsMethodGetFolderAtomic:                                            &gcsRequestCountGcsMethodGetFolderAtomic,
-		gcsRequestCountGcsMethodListObjectsAtomic:                                          &gcsRequestCountGcsMethodListObjectsAtomic,
-		gcsRequestCountGcsMethodMoveObjectAtomic:                                           &gcsRequestCountGcsMethodMoveObjectAtomic,
-		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:                              &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
-		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:                              &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
-		gcsRequestCountGcsMethodNewReaderAtomic:                                            &gcsRequestCountGcsMethodNewReaderAtomic,
-		gcsRequestCountGcsMethodRenameFolderAtomic:                                         &gcsRequestCountGcsMethodRenameFolderAtomic,
-		gcsRequestCountGcsMethodStatObjectAtomic:                                           &gcsRequestCountGcsMethodStatObjectAtomic,
-		gcsRequestCountGcsMethodUpdateObjectAtomic:                                         &gcsRequestCountGcsMethodUpdateObjectAtomic,
-		gcsRequestLatencies:                                                                gcsRequestLatencies,
+		gcsReadBytesCountReadTypeParallelAtomic:                                                               &gcsReadBytesCountReadTypeParallelAtomic,
+		gcsReadBytesCountReadTypeRandomAtomic:                                                                 &gcsReadBytesCountReadTypeRandomAtomic,
+		gcsReadBytesCountReadTypeSequentialAtomic:                                                             &gcsReadBytesCountReadTypeSequentialAtomic,
+		gcsReadBytesCountReadTypeUnknownAtomic:                                                                &gcsReadBytesCountReadTypeUnknownAtomic,
+		gcsReadCountReadTypeParallelAtomic:                                                                    &gcsReadCountReadTypeParallelAtomic,
+		gcsReadCountReadTypeRandomAtomic:                                                                      &gcsReadCountReadTypeRandomAtomic,
+		gcsReadCountReadTypeSequentialAtomic:                                                                  &gcsReadCountReadTypeSequentialAtomic,
+		gcsReadCountReadTypeUnknownAtomic:                                                                     &gcsReadCountReadTypeUnknownAtomic,
+		gcsReaderCountIoMethodClosedAtomic:                                                                    &gcsReaderCountIoMethodClosedAtomic,
+		gcsReaderCountIoMethodOpenedAtomic:                                                                    &gcsReaderCountIoMethodOpenedAtomic,
+		gcsRequestCountGcsMethodComposeObjectsAtomic:                                                          &gcsRequestCountGcsMethodComposeObjectsAtomic,
+		gcsRequestCountGcsMethodCopyObjectAtomic:                                                              &gcsRequestCountGcsMethodCopyObjectAtomic,
+		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic:                                            &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
+		gcsRequestCountGcsMethodCreateFolderAtomic:                                                            &gcsRequestCountGcsMethodCreateFolderAtomic,
+		gcsRequestCountGcsMethodCreateObjectAtomic:                                                            &gcsRequestCountGcsMethodCreateObjectAtomic,
+		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:                                                 &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
+		gcsRequestCountGcsMethodDeleteFolderAtomic:                                                            &gcsRequestCountGcsMethodDeleteFolderAtomic,
+		gcsRequestCountGcsMethodDeleteObjectAtomic:                                                            &gcsRequestCountGcsMethodDeleteObjectAtomic,
+		gcsRequestCountGcsMethodFinalizeUploadAtomic:                                                          &gcsRequestCountGcsMethodFinalizeUploadAtomic,
+		gcsRequestCountGcsMethodFlushPendingWritesAtomic:                                                      &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
+		gcsRequestCountGcsMethodGetFolderAtomic:                                                               &gcsRequestCountGcsMethodGetFolderAtomic,
+		gcsRequestCountGcsMethodListObjectsAtomic:                                                             &gcsRequestCountGcsMethodListObjectsAtomic,
+		gcsRequestCountGcsMethodMoveObjectAtomic:                                                              &gcsRequestCountGcsMethodMoveObjectAtomic,
+		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:                                                 &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
+		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:                                                 &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
+		gcsRequestCountGcsMethodNewReaderAtomic:                                                               &gcsRequestCountGcsMethodNewReaderAtomic,
+		gcsRequestCountGcsMethodRenameFolderAtomic:                                                            &gcsRequestCountGcsMethodRenameFolderAtomic,
+		gcsRequestCountGcsMethodStatObjectAtomic:                                                              &gcsRequestCountGcsMethodStatObjectAtomic,
+		gcsRequestCountGcsMethodUpdateObjectAtomic:                                                            &gcsRequestCountGcsMethodUpdateObjectAtomic,
+		gcsRequestLatencies: gcsRequestLatencies,
 		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:                                   &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
 		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:                            &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
 		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic:       &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -527,6 +527,14 @@ var (
 	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
 	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsExperimentalReaderCancellationBytesCountReasonCanceledAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
+	gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
+	gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
+	gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forced_recreate")))
+	gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "inactive_timeout")))
+	gcsExperimentalReaderCancellationBytesCountReasonSeekAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "seek")))
+	gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "sequential_to_random")))
+	gcsExperimentalReaderCancellationBytesCountReasonUnknownAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "unknown")))
 	gcsExperimentalReaderCancellationCountReasonCanceledAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
 	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
 	gcsExperimentalReaderCancellationCountReasonExplicitCloseAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
@@ -1082,6 +1090,14 @@ type otelMetrics struct {
 	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                              *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                          *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                             *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic                                                *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic                                        *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic                                           *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic                                          *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic                                         *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic                                                    *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic                                      *atomic.Int64
+	gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic                                                 *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonCanceledAtomic                                                     *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic                                             *atomic.Int64
 	gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic                                                *atomic.Int64
@@ -2412,6 +2428,35 @@ func (o *otelMetrics) GcsExperimentalReadBytesCount(
 	}
 }
 
+func (o *otelMetrics) GcsExperimentalReaderCancellationBytesCount(
+	inc int64, reason Reason) {
+	if inc < 0 {
+		logger.Errorf("Counter metric gcs/experimental_reader_cancellation_bytes_count received a negative increment: %d", inc)
+		return
+	}
+	switch reason {
+	case ReasonCanceledAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic.Add(inc)
+	case ReasonDeadlineExceededAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic.Add(inc)
+	case ReasonExplicitCloseAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic.Add(inc)
+	case ReasonForcedRecreateAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic.Add(inc)
+	case ReasonInactiveTimeoutAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic.Add(inc)
+	case ReasonSeekAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic.Add(inc)
+	case ReasonSequentialToRandomAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic.Add(inc)
+	case ReasonUnknownAttr:
+		o.gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic.Add(inc)
+	default:
+		updateUnrecognizedAttribute(string(reason))
+		return
+	}
+}
+
 func (o *otelMetrics) GcsExperimentalReaderCancellationCount(
 	inc int64, reason Reason) {
 	if inc < 0 {
@@ -3253,6 +3298,15 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic atomic.Int64
 
+	var gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic atomic.Int64
+
 	var gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
 		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
 		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,
@@ -3860,7 +3914,22 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_bytes_count",
+		metric.WithDescription("The cumulative number of bytes successfully read from in-flight GCS object readers that were subsequently canceled/aborted along with the cancellation reason."),
+		metric.WithUnit("By"),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic, gcsExperimentalReaderCancellationBytesCountReasonCanceledAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic, gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic, gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic, gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic, gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic, gcsExperimentalReaderCancellationBytesCountReasonSeekAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic, gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic, gcsExperimentalReaderCancellationBytesCountReasonUnknownAttrSet)
+			return nil
+		}))
+
+	_, err12 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_count",
 		metric.WithDescription("The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3875,7 +3944,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err13 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3883,7 +3952,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err14 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3894,7 +3963,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err15 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3903,7 +3972,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err16 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3929,12 +3998,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err17 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err18 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3943,7 +4012,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err19 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3962,12 +4031,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err19 := meter.Int64Histogram("read/block_sizes",
+	readBlockSizes, err20 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err20 := meter.Int64ObservableCounter("read/experimental_read_type_transitions_count",
+	_, err21 := meter.Int64ObservableCounter("read/experimental_read_type_transitions_count",
 		metric.WithDescription("The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3982,7 +4051,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err22 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3990,7 +4059,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err22 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err23 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3999,7 +4068,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21, err22}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21, err22, err23}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4477,6 +4546,14 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                     &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                 &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                    &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic:                                       &gcsExperimentalReaderCancellationBytesCountReasonCanceledAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic:                               &gcsExperimentalReaderCancellationBytesCountReasonDeadlineExceededAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic:                                  &gcsExperimentalReaderCancellationBytesCountReasonExplicitCloseAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic:                                 &gcsExperimentalReaderCancellationBytesCountReasonForcedRecreateAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic:                                &gcsExperimentalReaderCancellationBytesCountReasonInactiveTimeoutAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic:                                           &gcsExperimentalReaderCancellationBytesCountReasonSeekAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic:                             &gcsExperimentalReaderCancellationBytesCountReasonSequentialToRandomAtomic,
+		gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic:                                        &gcsExperimentalReaderCancellationBytesCountReasonUnknownAtomic,
 		gcsExperimentalReaderCancellationCountReasonCanceledAtomic:                                            &gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
 		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic:                                    &gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
 		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic:                                       &gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -527,6 +527,14 @@ var (
 	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
 	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsExperimentalReaderCancellationCountReasonCanceledAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "canceled")))
+	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "deadline_exceeded")))
+	gcsExperimentalReaderCancellationCountReasonExplicitCloseAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "explicit_close")))
+	gcsExperimentalReaderCancellationCountReasonForcedRecreateAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forced_recreate")))
+	gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "inactive_timeout")))
+	gcsExperimentalReaderCancellationCountReasonSeekAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "seek")))
+	gcsExperimentalReaderCancellationCountReasonSequentialToRandomAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "sequential_to_random")))
+	gcsExperimentalReaderCancellationCountReasonUnknownAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "unknown")))
 	gcsReadCountReadTypeParallelAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
 	gcsReadCountReadTypeRandomAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
 	gcsReadCountReadTypeSequentialAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
@@ -1074,6 +1082,14 @@ type otelMetrics struct {
 	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                              *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                          *atomic.Int64
 	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                             *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonCanceledAtomic                                                     *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic                                             *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic                                                *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic                                               *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic                                              *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonSeekAtomic                                                         *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic                                           *atomic.Int64
+	gcsExperimentalReaderCancellationCountReasonUnknownAtomic                                                      *atomic.Int64
 	gcsReadBytesCountAtomic                                                                                        *atomic.Int64
 	gcsReadCountReadTypeParallelAtomic                                                                             *atomic.Int64
 	gcsReadCountReadTypeRandomAtomic                                                                               *atomic.Int64
@@ -2396,6 +2412,35 @@ func (o *otelMetrics) GcsExperimentalReadBytesCount(
 	}
 }
 
+func (o *otelMetrics) GcsExperimentalReaderCancellationCount(
+	inc int64, reason Reason) {
+	if inc < 0 {
+		logger.Errorf("Counter metric gcs/experimental_reader_cancellation_count received a negative increment: %d", inc)
+		return
+	}
+	switch reason {
+	case ReasonCanceledAttr:
+		o.gcsExperimentalReaderCancellationCountReasonCanceledAtomic.Add(inc)
+	case ReasonDeadlineExceededAttr:
+		o.gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic.Add(inc)
+	case ReasonExplicitCloseAttr:
+		o.gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic.Add(inc)
+	case ReasonForcedRecreateAttr:
+		o.gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic.Add(inc)
+	case ReasonInactiveTimeoutAttr:
+		o.gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic.Add(inc)
+	case ReasonSeekAttr:
+		o.gcsExperimentalReaderCancellationCountReasonSeekAtomic.Add(inc)
+	case ReasonSequentialToRandomAttr:
+		o.gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic.Add(inc)
+	case ReasonUnknownAttr:
+		o.gcsExperimentalReaderCancellationCountReasonUnknownAtomic.Add(inc)
+	default:
+		updateUnrecognizedAttribute(string(reason))
+		return
+	}
+}
+
 func (o *otelMetrics) GcsReadBytesCount(
 	inc int64) {
 	if inc < 0 {
@@ -3208,6 +3253,15 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic atomic.Int64
 
+	var gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
+		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
+		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,
+		gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic,
+		gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic,
+		gcsExperimentalReaderCancellationCountReasonSeekAtomic,
+		gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic,
+		gcsExperimentalReaderCancellationCountReasonUnknownAtomic atomic.Int64
+
 	var gcsReadBytesCountAtomic atomic.Int64
 
 	var gcsReadCountReadTypeParallelAtomic,
@@ -3806,7 +3860,22 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/experimental_reader_cancellation_count",
+		metric.WithDescription("The cumulative number of times an in-flight GCS object reader was canceled along with the cancellation reason."),
+		metric.WithUnit(""),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonCanceledAtomic, gcsExperimentalReaderCancellationCountReasonCanceledAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic, gcsExperimentalReaderCancellationCountReasonDeadlineExceededAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic, gcsExperimentalReaderCancellationCountReasonExplicitCloseAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic, gcsExperimentalReaderCancellationCountReasonForcedRecreateAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic, gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonSeekAtomic, gcsExperimentalReaderCancellationCountReasonSeekAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic, gcsExperimentalReaderCancellationCountReasonSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReaderCancellationCountReasonUnknownAtomic, gcsExperimentalReaderCancellationCountReasonUnknownAttrSet)
+			return nil
+		}))
+
+	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3814,7 +3883,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err12 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3825,7 +3894,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3834,7 +3903,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err14 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3860,12 +3929,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err15 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err16 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3874,7 +3943,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err17 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3893,12 +3962,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err18 := meter.Int64Histogram("read/block_sizes",
+	readBlockSizes, err19 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err19 := meter.Int64ObservableCounter("read/experimental_read_type_transitions_count",
+	_, err20 := meter.Int64ObservableCounter("read/experimental_read_type_transitions_count",
 		metric.WithDescription("The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3913,7 +3982,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err20 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3921,7 +3990,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err22 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3930,7 +3999,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21, err22}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4408,6 +4477,14 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                     &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                 &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                    &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
+		gcsExperimentalReaderCancellationCountReasonCanceledAtomic:                                            &gcsExperimentalReaderCancellationCountReasonCanceledAtomic,
+		gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic:                                    &gcsExperimentalReaderCancellationCountReasonDeadlineExceededAtomic,
+		gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic:                                       &gcsExperimentalReaderCancellationCountReasonExplicitCloseAtomic,
+		gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic:                                      &gcsExperimentalReaderCancellationCountReasonForcedRecreateAtomic,
+		gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic:                                     &gcsExperimentalReaderCancellationCountReasonInactiveTimeoutAtomic,
+		gcsExperimentalReaderCancellationCountReasonSeekAtomic:                                                &gcsExperimentalReaderCancellationCountReasonSeekAtomic,
+		gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic:                                  &gcsExperimentalReaderCancellationCountReasonSequentialToRandomAtomic,
+		gcsExperimentalReaderCancellationCountReasonUnknownAtomic:                                             &gcsExperimentalReaderCancellationCountReasonUnknownAtomic,
 		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
 		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -32,569 +32,569 @@ import (
 const logInterval = 5 * time.Minute
 
 var (
-	unrecognizedAttr                                                                                               atomic.Value
-	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "insufficient_memory")))
-	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "random_read_detected")))
-	fileCacheReadBytesCountReadTypeParallelAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	fileCacheReadBytesCountReadTypeRandomAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	fileCacheReadBytesCountReadTypeSequentialAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	fileCacheReadBytesCountReadTypeUnknownAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	fileCacheReadCountCacheHitTrueReadTypeParallelAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")))
-	fileCacheReadCountCacheHitTrueReadTypeRandomAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")))
-	fileCacheReadCountCacheHitTrueReadTypeSequentialAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Sequential")))
-	fileCacheReadCountCacheHitTrueReadTypeUnknownAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Unknown")))
-	fileCacheReadCountCacheHitFalseReadTypeParallelAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Parallel")))
-	fileCacheReadCountCacheHitFalseReadTypeRandomAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Random")))
-	fileCacheReadCountCacheHitFalseReadTypeSequentialAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Sequential")))
-	fileCacheReadCountCacheHitFalseReadTypeUnknownAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Unknown")))
-	fileCacheReadLatenciesCacheHitTrueAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true)))
-	fileCacheReadLatenciesCacheHitFalseAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false)))
-	fsOpsCountFsOpBatchForgetAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
-	fsOpsCountFsOpCreateFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
-	fsOpsCountFsOpCreateLinkAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
-	fsOpsCountFsOpCreateSymlinkAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
-	fsOpsCountFsOpFlushFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
-	fsOpsCountFsOpForgetInodeAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
-	fsOpsCountFsOpGetInodeAttributesAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsCountFsOpLookUpInodeAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
-	fsOpsCountFsOpMkDirAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
-	fsOpsCountFsOpMkNodeAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
-	fsOpsCountFsOpOpenDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
-	fsOpsCountFsOpOpenFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
-	fsOpsCountFsOpOthersAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
-	fsOpsCountFsOpReadDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
-	fsOpsCountFsOpReadDirPlusAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsCountFsOpReadFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
-	fsOpsCountFsOpReadSymlinkAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
-	fsOpsCountFsOpReleaseDirHandleAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsCountFsOpReleaseFileHandleAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsCountFsOpRenameAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
-	fsOpsCountFsOpRmDirAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
-	fsOpsCountFsOpSetInodeAttributesAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsCountFsOpSyncFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
-	fsOpsCountFsOpUnlinkAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
-	fsOpsCountFsOpWriteFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "WriteFile")))
-	fsOpsLatencyFsOpBatchForgetAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
-	fsOpsLatencyFsOpCreateFileAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
-	fsOpsLatencyFsOpCreateLinkAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
-	fsOpsLatencyFsOpCreateSymlinkAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
-	fsOpsLatencyFsOpFlushFileAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
-	fsOpsLatencyFsOpForgetInodeAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
-	fsOpsLatencyFsOpGetInodeAttributesAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsLatencyFsOpLookUpInodeAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
-	fsOpsLatencyFsOpMkDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
-	fsOpsLatencyFsOpMkNodeAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
-	fsOpsLatencyFsOpOpenDirAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
-	fsOpsLatencyFsOpOpenFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
-	fsOpsLatencyFsOpOthersAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
-	fsOpsLatencyFsOpReadDirAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
-	fsOpsLatencyFsOpReadDirPlusAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsLatencyFsOpReadFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
-	fsOpsLatencyFsOpReadSymlinkAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
-	fsOpsLatencyFsOpReleaseDirHandleAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsLatencyFsOpReleaseFileHandleAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsLatencyFsOpRenameAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
-	fsOpsLatencyFsOpRmDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
-	fsOpsLatencyFsOpSetInodeAttributesAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsLatencyFsOpSyncFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
-	fsOpsLatencyFsOpUnlinkAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
-	fsOpsLatencyFsOpWriteFileAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAttrSet                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet         = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet         = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "out_of_order")))
-	gcsDownloadBytesCountReadTypeBufferedAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Buffered")))
-	gcsDownloadBytesCountReadTypeParallelAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsDownloadBytesCountReadTypeRandomAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsDownloadBytesCountReadTypeSequentialAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsExperimentalReadBytesCountReadTypeParallelAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")))
-	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")))
-	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")))
-	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")))
-	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")))
-	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")))
-	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")))
-	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")))
-	gcsReadCountReadTypeParallelAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsReadCountReadTypeRandomAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsReadCountReadTypeSequentialAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsReadCountReadTypeUnknownAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsReaderCountIoMethodClosedAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "closed")))
-	gcsReaderCountIoMethodOpenedAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "opened")))
-	gcsRequestCountGcsMethodComposeObjectsAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
-	gcsRequestCountGcsMethodCopyObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
-	gcsRequestCountGcsMethodCreateAppendableObjectWriterAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
-	gcsRequestCountGcsMethodCreateFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
-	gcsRequestCountGcsMethodCreateObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
-	gcsRequestCountGcsMethodCreateObjectChunkWriterAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
-	gcsRequestCountGcsMethodDeleteFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
-	gcsRequestCountGcsMethodDeleteObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
-	gcsRequestCountGcsMethodFinalizeUploadAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
-	gcsRequestCountGcsMethodFlushPendingWritesAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
-	gcsRequestCountGcsMethodGetFolderAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
-	gcsRequestCountGcsMethodListObjectsAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
-	gcsRequestCountGcsMethodMoveObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
-	gcsRequestCountGcsMethodMultiRangeDownloaderAddAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
-	gcsRequestCountGcsMethodNewMultiRangeDownloaderAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
-	gcsRequestCountGcsMethodNewReaderAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
-	gcsRequestCountGcsMethodRenameFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
-	gcsRequestCountGcsMethodStatObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
-	gcsRequestCountGcsMethodUpdateObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
-	gcsRequestLatenciesGcsMethodComposeObjectsAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
-	gcsRequestLatenciesGcsMethodCopyObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
-	gcsRequestLatenciesGcsMethodCreateAppendableObjectWriterAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
-	gcsRequestLatenciesGcsMethodCreateFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
-	gcsRequestLatenciesGcsMethodCreateObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
-	gcsRequestLatenciesGcsMethodCreateObjectChunkWriterAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
-	gcsRequestLatenciesGcsMethodDeleteFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
-	gcsRequestLatenciesGcsMethodDeleteObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
-	gcsRequestLatenciesGcsMethodFinalizeUploadAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
-	gcsRequestLatenciesGcsMethodFlushPendingWritesAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
-	gcsRequestLatenciesGcsMethodGetFolderAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
-	gcsRequestLatenciesGcsMethodListObjectsAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
-	gcsRequestLatenciesGcsMethodMoveObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
-	gcsRequestLatenciesGcsMethodMultiRangeDownloaderAddAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
-	gcsRequestLatenciesGcsMethodNewMultiRangeDownloaderAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
-	gcsRequestLatenciesGcsMethodNewReaderAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
-	gcsRequestLatenciesGcsMethodRenameFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
-	gcsRequestLatenciesGcsMethodStatObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
-	gcsRequestLatenciesGcsMethodUpdateObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
-	gcsRetryCountRetryErrorCategoryOTHERERRORSAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")))
-	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
-	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
-	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
+	unrecognizedAttr                                                                                                atomic.Value
+	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "insufficient_memory")))
+	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "random_read_detected")))
+	fileCacheReadBytesCountReadTypeParallelAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	fileCacheReadBytesCountReadTypeRandomAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	fileCacheReadBytesCountReadTypeSequentialAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	fileCacheReadBytesCountReadTypeUnknownAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	fileCacheReadCountCacheHitTrueReadTypeParallelAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")))
+	fileCacheReadCountCacheHitTrueReadTypeRandomAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")))
+	fileCacheReadCountCacheHitTrueReadTypeSequentialAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Sequential")))
+	fileCacheReadCountCacheHitTrueReadTypeUnknownAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Unknown")))
+	fileCacheReadCountCacheHitFalseReadTypeParallelAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Parallel")))
+	fileCacheReadCountCacheHitFalseReadTypeRandomAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Random")))
+	fileCacheReadCountCacheHitFalseReadTypeSequentialAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Sequential")))
+	fileCacheReadCountCacheHitFalseReadTypeUnknownAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Unknown")))
+	fileCacheReadLatenciesCacheHitTrueAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true)))
+	fileCacheReadLatenciesCacheHitFalseAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false)))
+	fsOpsCountFsOpBatchForgetAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
+	fsOpsCountFsOpCreateFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
+	fsOpsCountFsOpCreateLinkAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
+	fsOpsCountFsOpCreateSymlinkAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
+	fsOpsCountFsOpFlushFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
+	fsOpsCountFsOpForgetInodeAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
+	fsOpsCountFsOpGetInodeAttributesAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsCountFsOpLookUpInodeAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
+	fsOpsCountFsOpMkDirAttrSet                                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
+	fsOpsCountFsOpMkNodeAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
+	fsOpsCountFsOpOpenDirAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
+	fsOpsCountFsOpOpenFileAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
+	fsOpsCountFsOpOthersAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
+	fsOpsCountFsOpReadDirAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
+	fsOpsCountFsOpReadDirPlusAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsCountFsOpReadFileAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
+	fsOpsCountFsOpReadSymlinkAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
+	fsOpsCountFsOpReleaseDirHandleAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsCountFsOpReleaseFileHandleAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsCountFsOpRenameAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
+	fsOpsCountFsOpRmDirAttrSet                                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
+	fsOpsCountFsOpSetInodeAttributesAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsCountFsOpSyncFileAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
+	fsOpsCountFsOpUnlinkAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
+	fsOpsCountFsOpWriteFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "WriteFile")))
+	fsOpsLatencyFsOpBatchForgetAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
+	fsOpsLatencyFsOpCreateFileAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
+	fsOpsLatencyFsOpCreateLinkAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
+	fsOpsLatencyFsOpCreateSymlinkAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
+	fsOpsLatencyFsOpFlushFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
+	fsOpsLatencyFsOpForgetInodeAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
+	fsOpsLatencyFsOpGetInodeAttributesAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsLatencyFsOpLookUpInodeAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
+	fsOpsLatencyFsOpMkDirAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
+	fsOpsLatencyFsOpMkNodeAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
+	fsOpsLatencyFsOpOpenDirAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
+	fsOpsLatencyFsOpOpenFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
+	fsOpsLatencyFsOpOthersAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
+	fsOpsLatencyFsOpReadDirAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
+	fsOpsLatencyFsOpReadDirPlusAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsLatencyFsOpReadFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
+	fsOpsLatencyFsOpReadSymlinkAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
+	fsOpsLatencyFsOpReleaseDirHandleAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsLatencyFsOpReleaseFileHandleAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsLatencyFsOpRenameAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
+	fsOpsLatencyFsOpRmDirAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
+	fsOpsLatencyFsOpSetInodeAttributesAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsLatencyFsOpSyncFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
+	fsOpsLatencyFsOpUnlinkAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
+	fsOpsLatencyFsOpWriteFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet          = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAttrSet                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet          = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAttrSet                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "out_of_order")))
+	gcsDownloadBytesCountReadTypeBufferedAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Buffered")))
+	gcsDownloadBytesCountReadTypeParallelAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsDownloadBytesCountReadTypeRandomAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsDownloadBytesCountReadTypeSequentialAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsExperimentalReadBytesCountReadTypeParallelAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsReadCountReadTypeParallelAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsReadCountReadTypeRandomAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsReadCountReadTypeSequentialAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsReadCountReadTypeUnknownAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsReaderCountIoMethodClosedAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "closed")))
+	gcsReaderCountIoMethodOpenedAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "opened")))
+	gcsRequestCountGcsMethodComposeObjectsAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
+	gcsRequestCountGcsMethodCopyObjectAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
+	gcsRequestCountGcsMethodCreateAppendableObjectWriterAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
+	gcsRequestCountGcsMethodCreateFolderAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
+	gcsRequestCountGcsMethodCreateObjectAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
+	gcsRequestCountGcsMethodCreateObjectChunkWriterAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
+	gcsRequestCountGcsMethodDeleteFolderAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
+	gcsRequestCountGcsMethodDeleteObjectAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
+	gcsRequestCountGcsMethodFinalizeUploadAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
+	gcsRequestCountGcsMethodFlushPendingWritesAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
+	gcsRequestCountGcsMethodGetFolderAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
+	gcsRequestCountGcsMethodListObjectsAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
+	gcsRequestCountGcsMethodMoveObjectAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
+	gcsRequestCountGcsMethodMultiRangeDownloaderAddAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
+	gcsRequestCountGcsMethodNewMultiRangeDownloaderAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
+	gcsRequestCountGcsMethodNewReaderAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
+	gcsRequestCountGcsMethodRenameFolderAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
+	gcsRequestCountGcsMethodStatObjectAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
+	gcsRequestCountGcsMethodUpdateObjectAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
+	gcsRequestLatenciesGcsMethodComposeObjectsAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
+	gcsRequestLatenciesGcsMethodCopyObjectAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
+	gcsRequestLatenciesGcsMethodCreateAppendableObjectWriterAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
+	gcsRequestLatenciesGcsMethodCreateFolderAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
+	gcsRequestLatenciesGcsMethodCreateObjectAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
+	gcsRequestLatenciesGcsMethodCreateObjectChunkWriterAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
+	gcsRequestLatenciesGcsMethodDeleteFolderAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
+	gcsRequestLatenciesGcsMethodDeleteObjectAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
+	gcsRequestLatenciesGcsMethodFinalizeUploadAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
+	gcsRequestLatenciesGcsMethodFlushPendingWritesAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
+	gcsRequestLatenciesGcsMethodGetFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
+	gcsRequestLatenciesGcsMethodListObjectsAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
+	gcsRequestLatenciesGcsMethodMoveObjectAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
+	gcsRequestLatenciesGcsMethodMultiRangeDownloaderAddAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
+	gcsRequestLatenciesGcsMethodNewMultiRangeDownloaderAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
+	gcsRequestLatenciesGcsMethodNewReaderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
+	gcsRequestLatenciesGcsMethodRenameFolderAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
+	gcsRequestLatenciesGcsMethodStatObjectAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
+	gcsRequestLatenciesGcsMethodUpdateObjectAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
+	gcsRetryCountRetryErrorCategoryOTHERERRORSAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")))
+	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")))
+	readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")))
+	readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")))
+	readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")))
+	readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")))
+	readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")))
+	readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")))
+	readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")))
+	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
+	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
 )
 
 type histogramRecord struct {
@@ -605,531 +605,531 @@ type histogramRecord struct {
 }
 
 type otelMetrics struct {
-	ch                                                                                                            chan histogramRecord
-	wg                                                                                                            *sync.WaitGroup
-	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAtomic                                                *atomic.Int64
-	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAtomic                                                *atomic.Int64
-	fileCacheReadBytesCountReadTypeParallelAtomic                                                                 *atomic.Int64
-	fileCacheReadBytesCountReadTypeRandomAtomic                                                                   *atomic.Int64
-	fileCacheReadBytesCountReadTypeSequentialAtomic                                                               *atomic.Int64
-	fileCacheReadBytesCountReadTypeUnknownAtomic                                                                  *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeParallelAtomic                                                          *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeRandomAtomic                                                            *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeSequentialAtomic                                                        *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeUnknownAtomic                                                           *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeParallelAtomic                                                         *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeRandomAtomic                                                           *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeSequentialAtomic                                                       *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeUnknownAtomic                                                          *atomic.Int64
-	fsOpsCountFsOpBatchForgetAtomic                                                                               *atomic.Int64
-	fsOpsCountFsOpCreateFileAtomic                                                                                *atomic.Int64
-	fsOpsCountFsOpCreateLinkAtomic                                                                                *atomic.Int64
-	fsOpsCountFsOpCreateSymlinkAtomic                                                                             *atomic.Int64
-	fsOpsCountFsOpFlushFileAtomic                                                                                 *atomic.Int64
-	fsOpsCountFsOpForgetInodeAtomic                                                                               *atomic.Int64
-	fsOpsCountFsOpGetInodeAttributesAtomic                                                                        *atomic.Int64
-	fsOpsCountFsOpLookUpInodeAtomic                                                                               *atomic.Int64
-	fsOpsCountFsOpMkDirAtomic                                                                                     *atomic.Int64
-	fsOpsCountFsOpMkNodeAtomic                                                                                    *atomic.Int64
-	fsOpsCountFsOpOpenDirAtomic                                                                                   *atomic.Int64
-	fsOpsCountFsOpOpenFileAtomic                                                                                  *atomic.Int64
-	fsOpsCountFsOpOthersAtomic                                                                                    *atomic.Int64
-	fsOpsCountFsOpReadDirAtomic                                                                                   *atomic.Int64
-	fsOpsCountFsOpReadDirPlusAtomic                                                                               *atomic.Int64
-	fsOpsCountFsOpReadFileAtomic                                                                                  *atomic.Int64
-	fsOpsCountFsOpReadSymlinkAtomic                                                                               *atomic.Int64
-	fsOpsCountFsOpReleaseDirHandleAtomic                                                                          *atomic.Int64
-	fsOpsCountFsOpReleaseFileHandleAtomic                                                                         *atomic.Int64
-	fsOpsCountFsOpRenameAtomic                                                                                    *atomic.Int64
-	fsOpsCountFsOpRmDirAtomic                                                                                     *atomic.Int64
-	fsOpsCountFsOpSetInodeAttributesAtomic                                                                        *atomic.Int64
-	fsOpsCountFsOpSyncFileAtomic                                                                                  *atomic.Int64
-	fsOpsCountFsOpUnlinkAtomic                                                                                    *atomic.Int64
-	fsOpsCountFsOpWriteFileAtomic                                                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAtomic                                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAtomic                                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAtomic                                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAtomic                                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAtomic                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAtomic                                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAtomic                                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAtomic                                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAtomic                                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAtomic                                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAtomic                                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                             *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic                   *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                               *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                                      *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic                                 *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic               *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic                           *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic                                  *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic                             *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic         *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic                     *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic                            *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic                       *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic               *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic                           *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic                                  *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic                             *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic         *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic                     *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                            *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic                       *atomic.Int64
-	gcsDownloadBytesCountReadTypeBufferedAtomic                                                                   *atomic.Int64
-	gcsDownloadBytesCountReadTypeParallelAtomic                                                                   *atomic.Int64
-	gcsDownloadBytesCountReadTypeRandomAtomic                                                                     *atomic.Int64
-	gcsDownloadBytesCountReadTypeSequentialAtomic                                                                 *atomic.Int64
-	gcsExperimentalReadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
-	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
-	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                         *atomic.Int64
-	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                            *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic               *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic               *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic                *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic                *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic       *atomic.Int64
-	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic       *atomic.Int64
-	gcsReadBytesCountAtomic                                                                                       *atomic.Int64
-	gcsReadCountReadTypeParallelAtomic                                                                            *atomic.Int64
-	gcsReadCountReadTypeRandomAtomic                                                                              *atomic.Int64
-	gcsReadCountReadTypeSequentialAtomic                                                                          *atomic.Int64
-	gcsReadCountReadTypeUnknownAtomic                                                                             *atomic.Int64
-	gcsReaderCountIoMethodClosedAtomic                                                                            *atomic.Int64
-	gcsReaderCountIoMethodOpenedAtomic                                                                            *atomic.Int64
-	gcsRequestCountGcsMethodComposeObjectsAtomic                                                                  *atomic.Int64
-	gcsRequestCountGcsMethodCopyObjectAtomic                                                                      *atomic.Int64
-	gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic                                                    *atomic.Int64
-	gcsRequestCountGcsMethodCreateFolderAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodCreateObjectAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic                                                         *atomic.Int64
-	gcsRequestCountGcsMethodDeleteFolderAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodDeleteObjectAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodFinalizeUploadAtomic                                                                  *atomic.Int64
-	gcsRequestCountGcsMethodFlushPendingWritesAtomic                                                              *atomic.Int64
-	gcsRequestCountGcsMethodGetFolderAtomic                                                                       *atomic.Int64
-	gcsRequestCountGcsMethodListObjectsAtomic                                                                     *atomic.Int64
-	gcsRequestCountGcsMethodMoveObjectAtomic                                                                      *atomic.Int64
-	gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic                                                         *atomic.Int64
-	gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic                                                         *atomic.Int64
-	gcsRequestCountGcsMethodNewReaderAtomic                                                                       *atomic.Int64
-	gcsRequestCountGcsMethodRenameFolderAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodStatObjectAtomic                                                                      *atomic.Int64
-	gcsRequestCountGcsMethodUpdateObjectAtomic                                                                    *atomic.Int64
-	gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic                                                              *atomic.Int64
-	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic                                                       *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic                                  *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic                               *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic                             *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic                                  *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic                               *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic                             *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic                                 *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic                              *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic                            *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                                 *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                              *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                            *atomic.Int64
-	testUpdownCounterAtomic                                                                                       *atomic.Int64
-	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                              *atomic.Int64
-	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                              *atomic.Int64
-	bufferedReadReadLatency                                                                                       metric.Int64Histogram
-	fileCacheReadLatencies                                                                                        metric.Int64Histogram
-	fsOpsLatency                                                                                                  metric.Int64Histogram
-	gcsRequestLatencies                                                                                           metric.Int64Histogram
-	readBlockSizes                                                                                                metric.Int64Histogram
+	ch                                                                                                             chan histogramRecord
+	wg                                                                                                             *sync.WaitGroup
+	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAtomic                                                 *atomic.Int64
+	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAtomic                                                 *atomic.Int64
+	fileCacheReadBytesCountReadTypeParallelAtomic                                                                  *atomic.Int64
+	fileCacheReadBytesCountReadTypeRandomAtomic                                                                    *atomic.Int64
+	fileCacheReadBytesCountReadTypeSequentialAtomic                                                                *atomic.Int64
+	fileCacheReadBytesCountReadTypeUnknownAtomic                                                                   *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeParallelAtomic                                                           *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeRandomAtomic                                                             *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeSequentialAtomic                                                         *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeUnknownAtomic                                                            *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeParallelAtomic                                                          *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeRandomAtomic                                                            *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeSequentialAtomic                                                        *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeUnknownAtomic                                                           *atomic.Int64
+	fsOpsCountFsOpBatchForgetAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpCreateFileAtomic                                                                                 *atomic.Int64
+	fsOpsCountFsOpCreateLinkAtomic                                                                                 *atomic.Int64
+	fsOpsCountFsOpCreateSymlinkAtomic                                                                              *atomic.Int64
+	fsOpsCountFsOpFlushFileAtomic                                                                                  *atomic.Int64
+	fsOpsCountFsOpForgetInodeAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpGetInodeAttributesAtomic                                                                         *atomic.Int64
+	fsOpsCountFsOpLookUpInodeAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpMkDirAtomic                                                                                      *atomic.Int64
+	fsOpsCountFsOpMkNodeAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpOpenDirAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpOpenFileAtomic                                                                                   *atomic.Int64
+	fsOpsCountFsOpOthersAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpReadDirAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpReadDirPlusAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpReadFileAtomic                                                                                   *atomic.Int64
+	fsOpsCountFsOpReadSymlinkAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpReleaseDirHandleAtomic                                                                           *atomic.Int64
+	fsOpsCountFsOpReleaseFileHandleAtomic                                                                          *atomic.Int64
+	fsOpsCountFsOpRenameAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpRmDirAtomic                                                                                      *atomic.Int64
+	fsOpsCountFsOpSetInodeAttributesAtomic                                                                         *atomic.Int64
+	fsOpsCountFsOpSyncFileAtomic                                                                                   *atomic.Int64
+	fsOpsCountFsOpUnlinkAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpWriteFileAtomic                                                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAtomic                                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAtomic                                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAtomic                                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAtomic                                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAtomic                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAtomic                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAtomic                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAtomic                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAtomic                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                              *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic                    *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                                *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                                       *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic                                  *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic                *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic                            *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic                                   *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic                              *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic          *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic                      *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic                             *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic                        *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic                *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic                            *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic                                   *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic                              *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic          *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic                      *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                             *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic                        *atomic.Int64
+	gcsDownloadBytesCountReadTypeBufferedAtomic                                                                    *atomic.Int64
+	gcsDownloadBytesCountReadTypeParallelAtomic                                                                    *atomic.Int64
+	gcsDownloadBytesCountReadTypeRandomAtomic                                                                      *atomic.Int64
+	gcsDownloadBytesCountReadTypeSequentialAtomic                                                                  *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeParallelAtomic                                                            *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                              *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                          *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                             *atomic.Int64
+	gcsReadBytesCountAtomic                                                                                        *atomic.Int64
+	gcsReadCountReadTypeParallelAtomic                                                                             *atomic.Int64
+	gcsReadCountReadTypeRandomAtomic                                                                               *atomic.Int64
+	gcsReadCountReadTypeSequentialAtomic                                                                           *atomic.Int64
+	gcsReadCountReadTypeUnknownAtomic                                                                              *atomic.Int64
+	gcsReaderCountIoMethodClosedAtomic                                                                             *atomic.Int64
+	gcsReaderCountIoMethodOpenedAtomic                                                                             *atomic.Int64
+	gcsRequestCountGcsMethodComposeObjectsAtomic                                                                   *atomic.Int64
+	gcsRequestCountGcsMethodCopyObjectAtomic                                                                       *atomic.Int64
+	gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic                                                     *atomic.Int64
+	gcsRequestCountGcsMethodCreateFolderAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodCreateObjectAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic                                                          *atomic.Int64
+	gcsRequestCountGcsMethodDeleteFolderAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodDeleteObjectAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodFinalizeUploadAtomic                                                                   *atomic.Int64
+	gcsRequestCountGcsMethodFlushPendingWritesAtomic                                                               *atomic.Int64
+	gcsRequestCountGcsMethodGetFolderAtomic                                                                        *atomic.Int64
+	gcsRequestCountGcsMethodListObjectsAtomic                                                                      *atomic.Int64
+	gcsRequestCountGcsMethodMoveObjectAtomic                                                                       *atomic.Int64
+	gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic                                                          *atomic.Int64
+	gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic                                                          *atomic.Int64
+	gcsRequestCountGcsMethodNewReaderAtomic                                                                        *atomic.Int64
+	gcsRequestCountGcsMethodRenameFolderAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodStatObjectAtomic                                                                       *atomic.Int64
+	gcsRequestCountGcsMethodUpdateObjectAtomic                                                                     *atomic.Int64
+	gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic                                                               *atomic.Int64
+	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic                                                        *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic                                   *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic                                *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic                              *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic                                   *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic                                *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic                              *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic                                  *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic                               *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic                             *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                                  *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                               *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                             *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic               *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic               *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic                *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic                *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic       *atomic.Int64
+	readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic       *atomic.Int64
+	testUpdownCounterAtomic                                                                                        *atomic.Int64
+	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                               *atomic.Int64
+	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                               *atomic.Int64
+	bufferedReadReadLatency                                                                                        metric.Int64Histogram
+	fileCacheReadLatencies                                                                                         metric.Int64Histogram
+	fsOpsLatency                                                                                                   metric.Int64Histogram
+	gcsRequestLatencies                                                                                            metric.Int64Histogram
+	readBlockSizes                                                                                                 metric.Int64Histogram
 }
 
 func (o *otelMetrics) BufferedReadFallbackTriggerCount(
@@ -2396,59 +2396,6 @@ func (o *otelMetrics) GcsExperimentalReadBytesCount(
 	}
 }
 
-func (o *otelMetrics) GcsExperimentalReadTypeTransitionsCount(
-	inc int64, reason Reason, transitionType TransitionType) {
-	if inc < 0 {
-		logger.Errorf("Counter metric gcs/experimental_read_type_transitions_count received a negative increment: %d", inc)
-		return
-	}
-	switch reason {
-	case ReasonAverageReadSizeLargeEnoughAttr:
-		switch transitionType {
-		case TransitionTypeRandomToSequentialAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic.Add(inc)
-		case TransitionTypeSequentialToRandomAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic.Add(inc)
-		default:
-			updateUnrecognizedAttribute(string(transitionType))
-			return
-		}
-	case ReasonBackwardSeekAttr:
-		switch transitionType {
-		case TransitionTypeRandomToSequentialAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
-		case TransitionTypeSequentialToRandomAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
-		default:
-			updateUnrecognizedAttribute(string(transitionType))
-			return
-		}
-	case ReasonForwardSeekAttr:
-		switch transitionType {
-		case TransitionTypeRandomToSequentialAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
-		case TransitionTypeSequentialToRandomAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
-		default:
-			updateUnrecognizedAttribute(string(transitionType))
-			return
-		}
-	case ReasonInitialOffsetNonZeroAttr:
-		switch transitionType {
-		case TransitionTypeRandomToSequentialAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic.Add(inc)
-		case TransitionTypeSequentialToRandomAttr:
-			o.gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic.Add(inc)
-		default:
-			updateUnrecognizedAttribute(string(transitionType))
-			return
-		}
-	default:
-		updateUnrecognizedAttribute(string(reason))
-		return
-	}
-}
-
 func (o *otelMetrics) GcsReadBytesCount(
 	inc int64) {
 	if inc < 0 {
@@ -2694,6 +2641,59 @@ func (o *otelMetrics) ReadBlockSizes(
 	select {
 	case o.ch <- record: // Do nothing
 	default: // Unblock writes to channel if it's full.
+	}
+}
+
+func (o *otelMetrics) ReadExperimentalReadTypeTransitionsCount(
+	inc int64, reason Reason, transitionType TransitionType) {
+	if inc < 0 {
+		logger.Errorf("Counter metric read/experimental_read_type_transitions_count received a negative increment: %d", inc)
+		return
+	}
+	switch reason {
+	case ReasonAverageReadSizeLargeEnoughAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonBackwardSeekAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonForwardSeekAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonInitialOffsetNonZeroAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	default:
+		updateUnrecognizedAttribute(string(reason))
+		return
 	}
 }
 
@@ -3208,15 +3208,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
 		gcsExperimentalReadBytesCountReadTypeUnknownAtomic atomic.Int64
 
-	var gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic atomic.Int64
-
 	var gcsReadBytesCountAtomic atomic.Int64
 
 	var gcsReadCountReadTypeParallelAtomic,
@@ -3262,6 +3253,15 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic atomic.Int64
+
+	var readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic atomic.Int64
 
 	var testUpdownCounterAtomic atomic.Int64
 
@@ -3806,22 +3806,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/experimental_read_type_transitions_count",
-		metric.WithDescription("The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."),
-		metric.WithUnit(""),
-		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet)
-			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet)
-			return nil
-		}))
-
-	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3829,7 +3814,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err12 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3840,7 +3825,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err13 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3849,7 +3834,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err14 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3875,12 +3860,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err15 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err16 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3889,7 +3874,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err17 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3908,10 +3893,25 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err19 := meter.Int64Histogram("read/block_sizes",
+	readBlockSizes, err18 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
+
+	_, err19 := meter.Int64ObservableCounter("read/experimental_read_type_transitions_count",
+		metric.WithDescription("The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."),
+		metric.WithUnit(""),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic, readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic, readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic, readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic, readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic, readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic, readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic, readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic, readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet)
+			return nil
+		}))
 
 	_, err20 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
@@ -4380,42 +4380,34 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic:                     &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic:                  &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic,
 		fsOpsLatency: fsOpsLatency,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:                   &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                               &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                                      &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic:                                 &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic:               &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic:                           &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic:                                  &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic:                             &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic:         &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic:                     &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic:                            &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic:                       &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic:                           &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic:                                  &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic:                             &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic:         &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:                     &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                            &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:                       &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
-		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                                   &gcsDownloadBytesCountReadTypeBufferedAtomic,
-		gcsDownloadBytesCountReadTypeParallelAtomic:                                                                   &gcsDownloadBytesCountReadTypeParallelAtomic,
-		gcsDownloadBytesCountReadTypeRandomAtomic:                                                                     &gcsDownloadBytesCountReadTypeRandomAtomic,
-		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                                 &gcsDownloadBytesCountReadTypeSequentialAtomic,
-		gcsExperimentalReadBytesCountReadTypeParallelAtomic:                                                           &gcsExperimentalReadBytesCountReadTypeParallelAtomic,
-		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                             &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
-		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                         &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
-		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                            &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic: &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic: &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic:               &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic:               &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic:                &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic:                &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic:       &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
-		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic:       &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:           &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                       &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                              &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic:                         &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic:       &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic:                   &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic:                          &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic:                     &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic: &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic:       &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic:                   &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic:                          &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic:                     &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic: &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
+		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                           &gcsDownloadBytesCountReadTypeBufferedAtomic,
+		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
+		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
+		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
+		gcsExperimentalReadBytesCountReadTypeParallelAtomic:                                                   &gcsExperimentalReadBytesCountReadTypeParallelAtomic,
+		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                     &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
+		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                 &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
+		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                    &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
 		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
 		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,
@@ -4457,8 +4449,16 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic:      &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic:   &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic: &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic,
-		readBlockSizes:          readBlockSizes,
-		testUpdownCounterAtomic: &testUpdownCounterAtomic,
+		readBlockSizes: readBlockSizes,
+		readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic: &readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic: &readExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic:               &readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic:               &readExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic:                &readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic:                &readExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
+		readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic:       &readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
+		readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic:       &readExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic,
+		testUpdownCounterAtomic:                          &testUpdownCounterAtomic,
 		testUpdownCounterWithAttrsRequestTypeAttr1Atomic: &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,
 		testUpdownCounterWithAttrsRequestTypeAttr2Atomic: &testUpdownCounterWithAttrsRequestTypeAttr2Atomic,
 	}, nil

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -32,561 +32,569 @@ import (
 const logInterval = 5 * time.Minute
 
 var (
-	unrecognizedAttr                                                                                       atomic.Value
-	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "insufficient_memory")))
-	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "random_read_detected")))
-	fileCacheReadBytesCountReadTypeParallelAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	fileCacheReadBytesCountReadTypeRandomAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	fileCacheReadBytesCountReadTypeSequentialAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	fileCacheReadBytesCountReadTypeUnknownAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	fileCacheReadCountCacheHitTrueReadTypeParallelAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")))
-	fileCacheReadCountCacheHitTrueReadTypeRandomAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")))
-	fileCacheReadCountCacheHitTrueReadTypeSequentialAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Sequential")))
-	fileCacheReadCountCacheHitTrueReadTypeUnknownAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Unknown")))
-	fileCacheReadCountCacheHitFalseReadTypeParallelAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Parallel")))
-	fileCacheReadCountCacheHitFalseReadTypeRandomAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Random")))
-	fileCacheReadCountCacheHitFalseReadTypeSequentialAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Sequential")))
-	fileCacheReadCountCacheHitFalseReadTypeUnknownAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Unknown")))
-	fileCacheReadLatenciesCacheHitTrueAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true)))
-	fileCacheReadLatenciesCacheHitFalseAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false)))
-	fsOpsCountFsOpBatchForgetAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
-	fsOpsCountFsOpCreateFileAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
-	fsOpsCountFsOpCreateLinkAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
-	fsOpsCountFsOpCreateSymlinkAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
-	fsOpsCountFsOpFlushFileAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
-	fsOpsCountFsOpForgetInodeAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
-	fsOpsCountFsOpGetInodeAttributesAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsCountFsOpLookUpInodeAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
-	fsOpsCountFsOpMkDirAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
-	fsOpsCountFsOpMkNodeAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
-	fsOpsCountFsOpOpenDirAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
-	fsOpsCountFsOpOpenFileAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
-	fsOpsCountFsOpOthersAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
-	fsOpsCountFsOpReadDirAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
-	fsOpsCountFsOpReadDirPlusAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsCountFsOpReadFileAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
-	fsOpsCountFsOpReadSymlinkAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
-	fsOpsCountFsOpReleaseDirHandleAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsCountFsOpReleaseFileHandleAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsCountFsOpRenameAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
-	fsOpsCountFsOpRmDirAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
-	fsOpsCountFsOpSetInodeAttributesAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsCountFsOpSyncFileAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
-	fsOpsCountFsOpUnlinkAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
-	fsOpsCountFsOpWriteFileAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAttrSet                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "WriteFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "BatchForget")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateLink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateSymlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "FlushFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ForgetInode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "LookUpInode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkNode")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Others")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadSymlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Rename")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RmDir")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFile")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Unlink")))
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "WriteFile")))
-	fsOpsLatencyFsOpBatchForgetAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
-	fsOpsLatencyFsOpCreateFileAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
-	fsOpsLatencyFsOpCreateLinkAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
-	fsOpsLatencyFsOpCreateSymlinkAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
-	fsOpsLatencyFsOpFlushFileAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
-	fsOpsLatencyFsOpForgetInodeAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
-	fsOpsLatencyFsOpGetInodeAttributesAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
-	fsOpsLatencyFsOpLookUpInodeAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
-	fsOpsLatencyFsOpMkDirAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
-	fsOpsLatencyFsOpMkNodeAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
-	fsOpsLatencyFsOpOpenDirAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
-	fsOpsLatencyFsOpOpenFileAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
-	fsOpsLatencyFsOpOthersAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
-	fsOpsLatencyFsOpReadDirAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
-	fsOpsLatencyFsOpReadDirPlusAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
-	fsOpsLatencyFsOpReadFileAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
-	fsOpsLatencyFsOpReadSymlinkAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
-	fsOpsLatencyFsOpReleaseDirHandleAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
-	fsOpsLatencyFsOpReleaseFileHandleAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
-	fsOpsLatencyFsOpRenameAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
-	fsOpsLatencyFsOpRmDirAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
-	fsOpsLatencyFsOpSetInodeAttributesAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
-	fsOpsLatencyFsOpSyncFileAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
-	fsOpsLatencyFsOpUnlinkAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
-	fsOpsLatencyFsOpWriteFileAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAttrSet           = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAttrSet                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAttrSet             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAttrSet                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "out_of_order")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAttrSet             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "existing_file")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "other")))
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "out_of_order")))
-	gcsDownloadBytesCountReadTypeBufferedAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Buffered")))
-	gcsDownloadBytesCountReadTypeParallelAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsDownloadBytesCountReadTypeRandomAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsDownloadBytesCountReadTypeSequentialAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsReadBytesCountReadTypeParallelAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsReadBytesCountReadTypeRandomAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsReadBytesCountReadTypeSequentialAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsReadBytesCountReadTypeUnknownAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsReadCountReadTypeParallelAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
-	gcsReadCountReadTypeRandomAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
-	gcsReadCountReadTypeSequentialAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
-	gcsReadCountReadTypeUnknownAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
-	gcsReaderCountIoMethodClosedAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "closed")))
-	gcsReaderCountIoMethodOpenedAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "opened")))
-	gcsRequestCountGcsMethodComposeObjectsAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
-	gcsRequestCountGcsMethodCopyObjectAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
-	gcsRequestCountGcsMethodCreateAppendableObjectWriterAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
-	gcsRequestCountGcsMethodCreateFolderAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
-	gcsRequestCountGcsMethodCreateObjectAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
-	gcsRequestCountGcsMethodCreateObjectChunkWriterAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
-	gcsRequestCountGcsMethodDeleteFolderAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
-	gcsRequestCountGcsMethodDeleteObjectAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
-	gcsRequestCountGcsMethodFinalizeUploadAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
-	gcsRequestCountGcsMethodFlushPendingWritesAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
-	gcsRequestCountGcsMethodGetFolderAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
-	gcsRequestCountGcsMethodListObjectsAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
-	gcsRequestCountGcsMethodMoveObjectAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
-	gcsRequestCountGcsMethodMultiRangeDownloaderAddAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
-	gcsRequestCountGcsMethodNewMultiRangeDownloaderAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
-	gcsRequestCountGcsMethodNewReaderAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
-	gcsRequestCountGcsMethodRenameFolderAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
-	gcsRequestCountGcsMethodStatObjectAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
-	gcsRequestCountGcsMethodUpdateObjectAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
-	gcsRequestLatenciesGcsMethodComposeObjectsAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
-	gcsRequestLatenciesGcsMethodCopyObjectAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
-	gcsRequestLatenciesGcsMethodCreateAppendableObjectWriterAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
-	gcsRequestLatenciesGcsMethodCreateFolderAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
-	gcsRequestLatenciesGcsMethodCreateObjectAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
-	gcsRequestLatenciesGcsMethodCreateObjectChunkWriterAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
-	gcsRequestLatenciesGcsMethodDeleteFolderAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
-	gcsRequestLatenciesGcsMethodDeleteObjectAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
-	gcsRequestLatenciesGcsMethodFinalizeUploadAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
-	gcsRequestLatenciesGcsMethodFlushPendingWritesAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
-	gcsRequestLatenciesGcsMethodGetFolderAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
-	gcsRequestLatenciesGcsMethodListObjectsAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
-	gcsRequestLatenciesGcsMethodMoveObjectAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
-	gcsRequestLatenciesGcsMethodMultiRangeDownloaderAddAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
-	gcsRequestLatenciesGcsMethodNewMultiRangeDownloaderAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
-	gcsRequestLatenciesGcsMethodNewReaderAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
-	gcsRequestLatenciesGcsMethodRenameFolderAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
-	gcsRequestLatenciesGcsMethodStatObjectAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
-	gcsRequestLatenciesGcsMethodUpdateObjectAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
-	gcsRetryCountRetryErrorCategoryOTHERERRORSAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")))
-	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
-	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
-	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
+	unrecognizedAttr                                                                                               atomic.Value
+	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "insufficient_memory")))
+	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "random_read_detected")))
+	fileCacheReadBytesCountReadTypeParallelAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	fileCacheReadBytesCountReadTypeRandomAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	fileCacheReadBytesCountReadTypeSequentialAttrSet                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	fileCacheReadBytesCountReadTypeUnknownAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	fileCacheReadCountCacheHitTrueReadTypeParallelAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Parallel")))
+	fileCacheReadCountCacheHitTrueReadTypeRandomAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Random")))
+	fileCacheReadCountCacheHitTrueReadTypeSequentialAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Sequential")))
+	fileCacheReadCountCacheHitTrueReadTypeUnknownAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("read_type", "Unknown")))
+	fileCacheReadCountCacheHitFalseReadTypeParallelAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Parallel")))
+	fileCacheReadCountCacheHitFalseReadTypeRandomAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Random")))
+	fileCacheReadCountCacheHitFalseReadTypeSequentialAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Sequential")))
+	fileCacheReadCountCacheHitFalseReadTypeUnknownAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("read_type", "Unknown")))
+	fileCacheReadLatenciesCacheHitTrueAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true)))
+	fileCacheReadLatenciesCacheHitFalseAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false)))
+	fsOpsCountFsOpBatchForgetAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
+	fsOpsCountFsOpCreateFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
+	fsOpsCountFsOpCreateLinkAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
+	fsOpsCountFsOpCreateSymlinkAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
+	fsOpsCountFsOpFlushFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
+	fsOpsCountFsOpForgetInodeAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
+	fsOpsCountFsOpGetInodeAttributesAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsCountFsOpLookUpInodeAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
+	fsOpsCountFsOpMkDirAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
+	fsOpsCountFsOpMkNodeAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
+	fsOpsCountFsOpOpenDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
+	fsOpsCountFsOpOpenFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
+	fsOpsCountFsOpOthersAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
+	fsOpsCountFsOpReadDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
+	fsOpsCountFsOpReadDirPlusAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsCountFsOpReadFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
+	fsOpsCountFsOpReadSymlinkAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
+	fsOpsCountFsOpReleaseDirHandleAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsCountFsOpReleaseFileHandleAttrSet                                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsCountFsOpRenameAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
+	fsOpsCountFsOpRmDirAttrSet                                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
+	fsOpsCountFsOpSetInodeAttributesAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsCountFsOpSyncFileAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
+	fsOpsCountFsOpUnlinkAttrSet                                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
+	fsOpsCountFsOpWriteFileAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DEVICE_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "DIR_NOT_EMPTY"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_DIR_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "FILE_EXISTS"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INTERRUPT_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_ARGUMENT"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "INVALID_OPERATION"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "IO_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "MISC_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NETWORK_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_A_DIR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NOT_IMPLEMENTED"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAttrSet                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "NO_FILE_OR_DIR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAttrSet                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAttrSet                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAttrSet                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PERM_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAttrSet                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAttrSet                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAttrSet                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "PROCESS_RESOURCE_MGMT_ERROR"), attribute.String("fs_op", "WriteFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "BatchForget")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAttrSet                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateLink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAttrSet                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "CreateSymlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "FlushFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ForgetInode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "LookUpInode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "MkNode")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "OpenFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Others")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAttrSet                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAttrSet                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReadSymlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAttrSet                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Rename")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAttrSet                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "RmDir")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAttrSet                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAttrSet                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "SyncFile")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "Unlink")))
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAttrSet                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_error_category", "TOO_MANY_OPEN_FILES"), attribute.String("fs_op", "WriteFile")))
+	fsOpsLatencyFsOpBatchForgetAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "BatchForget")))
+	fsOpsLatencyFsOpCreateFileAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateFile")))
+	fsOpsLatencyFsOpCreateLinkAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateLink")))
+	fsOpsLatencyFsOpCreateSymlinkAttrSet                                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "CreateSymlink")))
+	fsOpsLatencyFsOpFlushFileAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "FlushFile")))
+	fsOpsLatencyFsOpForgetInodeAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ForgetInode")))
+	fsOpsLatencyFsOpGetInodeAttributesAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "GetInodeAttributes")))
+	fsOpsLatencyFsOpLookUpInodeAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "LookUpInode")))
+	fsOpsLatencyFsOpMkDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkDir")))
+	fsOpsLatencyFsOpMkNodeAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "MkNode")))
+	fsOpsLatencyFsOpOpenDirAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenDir")))
+	fsOpsLatencyFsOpOpenFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "OpenFile")))
+	fsOpsLatencyFsOpOthersAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Others")))
+	fsOpsLatencyFsOpReadDirAttrSet                                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDir")))
+	fsOpsLatencyFsOpReadDirPlusAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadDirPlus")))
+	fsOpsLatencyFsOpReadFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadFile")))
+	fsOpsLatencyFsOpReadSymlinkAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReadSymlink")))
+	fsOpsLatencyFsOpReleaseDirHandleAttrSet                                                                        = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseDirHandle")))
+	fsOpsLatencyFsOpReleaseFileHandleAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "ReleaseFileHandle")))
+	fsOpsLatencyFsOpRenameAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Rename")))
+	fsOpsLatencyFsOpRmDirAttrSet                                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "RmDir")))
+	fsOpsLatencyFsOpSetInodeAttributesAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SetInodeAttributes")))
+	fsOpsLatencyFsOpSyncFileAttrSet                                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "SyncFile")))
+	fsOpsLatencyFsOpUnlinkAttrSet                                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "Unlink")))
+	fsOpsLatencyFsOpWriteFileAttrSet                                                                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("fs_op", "WriteFile")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAttrSet                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAttrSet                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "other"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet         = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "read_write_append"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAttrSet                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only"), attribute.String("write_fallback_reason", "out_of_order")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAttrSet         = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "concurrency_limit_breached")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAttrSet                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "existing_file")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "other")))
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAttrSet                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("open_mode", "write_only_append"), attribute.String("write_fallback_reason", "out_of_order")))
+	gcsDownloadBytesCountReadTypeBufferedAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Buffered")))
+	gcsDownloadBytesCountReadTypeParallelAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsDownloadBytesCountReadTypeRandomAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsDownloadBytesCountReadTypeSequentialAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsExperimentalReadBytesCountReadTypeParallelAttrSet                                                           = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsExperimentalReadBytesCountReadTypeRandomAttrSet                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsExperimentalReadBytesCountReadTypeSequentialAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsExperimentalReadBytesCountReadTypeUnknownAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")))
+	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")))
+	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")))
+	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet               = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")))
+	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")))
+	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet                = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")))
+	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")))
+	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet       = metric.WithAttributeSet(attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")))
+	gcsReadCountReadTypeParallelAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Parallel")))
+	gcsReadCountReadTypeRandomAttrSet                                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Random")))
+	gcsReadCountReadTypeSequentialAttrSet                                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Sequential")))
+	gcsReadCountReadTypeUnknownAttrSet                                                                             = metric.WithAttributeSet(attribute.NewSet(attribute.String("read_type", "Unknown")))
+	gcsReaderCountIoMethodClosedAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "closed")))
+	gcsReaderCountIoMethodOpenedAttrSet                                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("io_method", "opened")))
+	gcsRequestCountGcsMethodComposeObjectsAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
+	gcsRequestCountGcsMethodCopyObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
+	gcsRequestCountGcsMethodCreateAppendableObjectWriterAttrSet                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
+	gcsRequestCountGcsMethodCreateFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
+	gcsRequestCountGcsMethodCreateObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
+	gcsRequestCountGcsMethodCreateObjectChunkWriterAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
+	gcsRequestCountGcsMethodDeleteFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
+	gcsRequestCountGcsMethodDeleteObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
+	gcsRequestCountGcsMethodFinalizeUploadAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
+	gcsRequestCountGcsMethodFlushPendingWritesAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
+	gcsRequestCountGcsMethodGetFolderAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
+	gcsRequestCountGcsMethodListObjectsAttrSet                                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
+	gcsRequestCountGcsMethodMoveObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
+	gcsRequestCountGcsMethodMultiRangeDownloaderAddAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
+	gcsRequestCountGcsMethodNewMultiRangeDownloaderAttrSet                                                         = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
+	gcsRequestCountGcsMethodNewReaderAttrSet                                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
+	gcsRequestCountGcsMethodRenameFolderAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
+	gcsRequestCountGcsMethodStatObjectAttrSet                                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
+	gcsRequestCountGcsMethodUpdateObjectAttrSet                                                                    = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
+	gcsRequestLatenciesGcsMethodComposeObjectsAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ComposeObjects")))
+	gcsRequestLatenciesGcsMethodCopyObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CopyObject")))
+	gcsRequestLatenciesGcsMethodCreateAppendableObjectWriterAttrSet                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateAppendableObjectWriter")))
+	gcsRequestLatenciesGcsMethodCreateFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateFolder")))
+	gcsRequestLatenciesGcsMethodCreateObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObject")))
+	gcsRequestLatenciesGcsMethodCreateObjectChunkWriterAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "CreateObjectChunkWriter")))
+	gcsRequestLatenciesGcsMethodDeleteFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteFolder")))
+	gcsRequestLatenciesGcsMethodDeleteObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "DeleteObject")))
+	gcsRequestLatenciesGcsMethodFinalizeUploadAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FinalizeUpload")))
+	gcsRequestLatenciesGcsMethodFlushPendingWritesAttrSet                                                          = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "FlushPendingWrites")))
+	gcsRequestLatenciesGcsMethodGetFolderAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "GetFolder")))
+	gcsRequestLatenciesGcsMethodListObjectsAttrSet                                                                 = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "ListObjects")))
+	gcsRequestLatenciesGcsMethodMoveObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MoveObject")))
+	gcsRequestLatenciesGcsMethodMultiRangeDownloaderAddAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")))
+	gcsRequestLatenciesGcsMethodNewMultiRangeDownloaderAttrSet                                                     = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewMultiRangeDownloader")))
+	gcsRequestLatenciesGcsMethodNewReaderAttrSet                                                                   = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "NewReader")))
+	gcsRequestLatenciesGcsMethodRenameFolderAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "RenameFolder")))
+	gcsRequestLatenciesGcsMethodStatObjectAttrSet                                                                  = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "StatObject")))
+	gcsRequestLatenciesGcsMethodUpdateObjectAttrSet                                                                = metric.WithAttributeSet(attribute.NewSet(attribute.String("gcs_method", "UpdateObject")))
+	gcsRetryCountRetryErrorCategoryOTHERERRORSAttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "OTHER_ERRORS")))
+	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAttrSet                                                       = metric.WithAttributeSet(attribute.NewSet(attribute.String("retry_error_category", "STALLED_READ_REQUEST")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAttrSet                                  = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAttrSet                               = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAttrSet                             = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", true), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "negative"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                                 = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                              = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                            = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
+	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                              = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
 )
 
 type histogramRecord struct {
@@ -597,522 +605,531 @@ type histogramRecord struct {
 }
 
 type otelMetrics struct {
-	ch                                                                                                    chan histogramRecord
-	wg                                                                                                    *sync.WaitGroup
-	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAtomic                                        *atomic.Int64
-	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAtomic                                        *atomic.Int64
-	fileCacheReadBytesCountReadTypeParallelAtomic                                                         *atomic.Int64
-	fileCacheReadBytesCountReadTypeRandomAtomic                                                           *atomic.Int64
-	fileCacheReadBytesCountReadTypeSequentialAtomic                                                       *atomic.Int64
-	fileCacheReadBytesCountReadTypeUnknownAtomic                                                          *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeParallelAtomic                                                  *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeRandomAtomic                                                    *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeSequentialAtomic                                                *atomic.Int64
-	fileCacheReadCountCacheHitTrueReadTypeUnknownAtomic                                                   *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeParallelAtomic                                                 *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeRandomAtomic                                                   *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeSequentialAtomic                                               *atomic.Int64
-	fileCacheReadCountCacheHitFalseReadTypeUnknownAtomic                                                  *atomic.Int64
-	fsOpsCountFsOpBatchForgetAtomic                                                                       *atomic.Int64
-	fsOpsCountFsOpCreateFileAtomic                                                                        *atomic.Int64
-	fsOpsCountFsOpCreateLinkAtomic                                                                        *atomic.Int64
-	fsOpsCountFsOpCreateSymlinkAtomic                                                                     *atomic.Int64
-	fsOpsCountFsOpFlushFileAtomic                                                                         *atomic.Int64
-	fsOpsCountFsOpForgetInodeAtomic                                                                       *atomic.Int64
-	fsOpsCountFsOpGetInodeAttributesAtomic                                                                *atomic.Int64
-	fsOpsCountFsOpLookUpInodeAtomic                                                                       *atomic.Int64
-	fsOpsCountFsOpMkDirAtomic                                                                             *atomic.Int64
-	fsOpsCountFsOpMkNodeAtomic                                                                            *atomic.Int64
-	fsOpsCountFsOpOpenDirAtomic                                                                           *atomic.Int64
-	fsOpsCountFsOpOpenFileAtomic                                                                          *atomic.Int64
-	fsOpsCountFsOpOthersAtomic                                                                            *atomic.Int64
-	fsOpsCountFsOpReadDirAtomic                                                                           *atomic.Int64
-	fsOpsCountFsOpReadDirPlusAtomic                                                                       *atomic.Int64
-	fsOpsCountFsOpReadFileAtomic                                                                          *atomic.Int64
-	fsOpsCountFsOpReadSymlinkAtomic                                                                       *atomic.Int64
-	fsOpsCountFsOpReleaseDirHandleAtomic                                                                  *atomic.Int64
-	fsOpsCountFsOpReleaseFileHandleAtomic                                                                 *atomic.Int64
-	fsOpsCountFsOpRenameAtomic                                                                            *atomic.Int64
-	fsOpsCountFsOpRmDirAtomic                                                                             *atomic.Int64
-	fsOpsCountFsOpSetInodeAttributesAtomic                                                                *atomic.Int64
-	fsOpsCountFsOpSyncFileAtomic                                                                          *atomic.Int64
-	fsOpsCountFsOpUnlinkAtomic                                                                            *atomic.Int64
-	fsOpsCountFsOpWriteFileAtomic                                                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAtomic                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAtomic                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAtomic                                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAtomic                                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAtomic                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAtomic                                  *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAtomic                                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAtomic                                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAtomic                                          *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAtomic                                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAtomic                                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAtomic                                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAtomic                                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAtomic                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAtomic                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAtomic                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAtomic                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAtomic                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAtomic                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAtomic                               *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAtomic                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAtomic                           *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAtomic                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAtomic                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAtomic                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAtomic                                *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAtomic                                    *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAtomic                                 *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAtomic                                     *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAtomic                                       *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAtomic                                   *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAtomic                              *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAtomic                             *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAtomic                                         *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAtomic                            *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                      *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                        *atomic.Int64
-	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                     *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic           *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                       *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                              *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic                         *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic       *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic                   *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic                          *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic                     *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic             *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic                    *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic               *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic       *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic                   *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic                          *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic                     *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic             *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                    *atomic.Int64
-	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic               *atomic.Int64
-	gcsDownloadBytesCountReadTypeBufferedAtomic                                                           *atomic.Int64
-	gcsDownloadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
-	gcsDownloadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
-	gcsDownloadBytesCountReadTypeSequentialAtomic                                                         *atomic.Int64
-	gcsReadBytesCountReadTypeParallelAtomic                                                               *atomic.Int64
-	gcsReadBytesCountReadTypeRandomAtomic                                                                 *atomic.Int64
-	gcsReadBytesCountReadTypeSequentialAtomic                                                             *atomic.Int64
-	gcsReadBytesCountReadTypeUnknownAtomic                                                                *atomic.Int64
-	gcsReadCountReadTypeParallelAtomic                                                                    *atomic.Int64
-	gcsReadCountReadTypeRandomAtomic                                                                      *atomic.Int64
-	gcsReadCountReadTypeSequentialAtomic                                                                  *atomic.Int64
-	gcsReadCountReadTypeUnknownAtomic                                                                     *atomic.Int64
-	gcsReaderCountIoMethodClosedAtomic                                                                    *atomic.Int64
-	gcsReaderCountIoMethodOpenedAtomic                                                                    *atomic.Int64
-	gcsRequestCountGcsMethodComposeObjectsAtomic                                                          *atomic.Int64
-	gcsRequestCountGcsMethodCopyObjectAtomic                                                              *atomic.Int64
-	gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic                                            *atomic.Int64
-	gcsRequestCountGcsMethodCreateFolderAtomic                                                            *atomic.Int64
-	gcsRequestCountGcsMethodCreateObjectAtomic                                                            *atomic.Int64
-	gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic                                                 *atomic.Int64
-	gcsRequestCountGcsMethodDeleteFolderAtomic                                                            *atomic.Int64
-	gcsRequestCountGcsMethodDeleteObjectAtomic                                                            *atomic.Int64
-	gcsRequestCountGcsMethodFinalizeUploadAtomic                                                          *atomic.Int64
-	gcsRequestCountGcsMethodFlushPendingWritesAtomic                                                      *atomic.Int64
-	gcsRequestCountGcsMethodGetFolderAtomic                                                               *atomic.Int64
-	gcsRequestCountGcsMethodListObjectsAtomic                                                             *atomic.Int64
-	gcsRequestCountGcsMethodMoveObjectAtomic                                                              *atomic.Int64
-	gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic                                                 *atomic.Int64
-	gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic                                                 *atomic.Int64
-	gcsRequestCountGcsMethodNewReaderAtomic                                                               *atomic.Int64
-	gcsRequestCountGcsMethodRenameFolderAtomic                                                            *atomic.Int64
-	gcsRequestCountGcsMethodStatObjectAtomic                                                              *atomic.Int64
-	gcsRequestCountGcsMethodUpdateObjectAtomic                                                            *atomic.Int64
-	gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic                                                      *atomic.Int64
-	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic                                               *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic                          *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic                       *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic                     *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic                          *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic                       *atomic.Int64
-	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic                     *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic                         *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic                      *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic                    *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                         *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                      *atomic.Int64
-	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                    *atomic.Int64
-	testUpdownCounterAtomic                                                                               *atomic.Int64
-	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                      *atomic.Int64
-	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                      *atomic.Int64
-	bufferedReadReadLatency                                                                               metric.Int64Histogram
-	fileCacheReadLatencies                                                                                metric.Int64Histogram
-	fsOpsLatency                                                                                          metric.Int64Histogram
-	gcsRequestLatencies                                                                                   metric.Int64Histogram
-	readBlockSizes                                                                                        metric.Int64Histogram
+	ch                                                                                                            chan histogramRecord
+	wg                                                                                                            *sync.WaitGroup
+	bufferedReadFallbackTriggerCountReasonInsufficientMemoryAtomic                                                *atomic.Int64
+	bufferedReadFallbackTriggerCountReasonRandomReadDetectedAtomic                                                *atomic.Int64
+	fileCacheReadBytesCountReadTypeParallelAtomic                                                                 *atomic.Int64
+	fileCacheReadBytesCountReadTypeRandomAtomic                                                                   *atomic.Int64
+	fileCacheReadBytesCountReadTypeSequentialAtomic                                                               *atomic.Int64
+	fileCacheReadBytesCountReadTypeUnknownAtomic                                                                  *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeParallelAtomic                                                          *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeRandomAtomic                                                            *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeSequentialAtomic                                                        *atomic.Int64
+	fileCacheReadCountCacheHitTrueReadTypeUnknownAtomic                                                           *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeParallelAtomic                                                         *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeRandomAtomic                                                           *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeSequentialAtomic                                                       *atomic.Int64
+	fileCacheReadCountCacheHitFalseReadTypeUnknownAtomic                                                          *atomic.Int64
+	fsOpsCountFsOpBatchForgetAtomic                                                                               *atomic.Int64
+	fsOpsCountFsOpCreateFileAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpCreateLinkAtomic                                                                                *atomic.Int64
+	fsOpsCountFsOpCreateSymlinkAtomic                                                                             *atomic.Int64
+	fsOpsCountFsOpFlushFileAtomic                                                                                 *atomic.Int64
+	fsOpsCountFsOpForgetInodeAtomic                                                                               *atomic.Int64
+	fsOpsCountFsOpGetInodeAttributesAtomic                                                                        *atomic.Int64
+	fsOpsCountFsOpLookUpInodeAtomic                                                                               *atomic.Int64
+	fsOpsCountFsOpMkDirAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpMkNodeAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpOpenDirAtomic                                                                                   *atomic.Int64
+	fsOpsCountFsOpOpenFileAtomic                                                                                  *atomic.Int64
+	fsOpsCountFsOpOthersAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpReadDirAtomic                                                                                   *atomic.Int64
+	fsOpsCountFsOpReadDirPlusAtomic                                                                               *atomic.Int64
+	fsOpsCountFsOpReadFileAtomic                                                                                  *atomic.Int64
+	fsOpsCountFsOpReadSymlinkAtomic                                                                               *atomic.Int64
+	fsOpsCountFsOpReleaseDirHandleAtomic                                                                          *atomic.Int64
+	fsOpsCountFsOpReleaseFileHandleAtomic                                                                         *atomic.Int64
+	fsOpsCountFsOpRenameAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpRmDirAtomic                                                                                     *atomic.Int64
+	fsOpsCountFsOpSetInodeAttributesAtomic                                                                        *atomic.Int64
+	fsOpsCountFsOpSyncFileAtomic                                                                                  *atomic.Int64
+	fsOpsCountFsOpUnlinkAtomic                                                                                    *atomic.Int64
+	fsOpsCountFsOpWriteFileAtomic                                                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpBatchForgetAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateLinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpCreateSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpFlushFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpForgetInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpGetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpLookUpInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpMkNodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOpenFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpOthersAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadDirPlusAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReadSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseDirHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpReleaseFileHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRenameAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpRmDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpSyncFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpUnlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDEVICEERRORFsOpWriteFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpBatchForgetAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateLinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpCreateSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpFlushFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpForgetInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpGetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpLookUpInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpMkNodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOpenFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpOthersAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadDirPlusAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReadSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseDirHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpReleaseFileHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRenameAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpRmDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpSyncFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpUnlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryDIRNOTEMPTYFsOpWriteFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpBatchForgetAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateLinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpCreateSymlinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpFlushFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpForgetInodeAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpGetInodeAttributesAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpLookUpInodeAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpMkNodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOpenFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpOthersAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadDirPlusAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReadSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseDirHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpReleaseFileHandleAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRenameAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpRmDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSetInodeAttributesAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpSyncFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpUnlinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEDIRERRORFsOpWriteFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpBatchForgetAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateLinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpCreateSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpFlushFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpForgetInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpGetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpLookUpInodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpMkNodeAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOpenFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpOthersAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadDirPlusAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReadSymlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseDirHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpReleaseFileHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRenameAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpRmDirAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSetInodeAttributesAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpSyncFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpUnlinkAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryFILEEXISTSFsOpWriteFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpBatchForgetAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateLinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpCreateSymlinkAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpFlushFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpForgetInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpGetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpLookUpInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpMkNodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOpenFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpOthersAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadDirPlusAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReadSymlinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseDirHandleAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpReleaseFileHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRenameAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpRmDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpSyncFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpUnlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINTERRUPTERRORFsOpWriteFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpBatchForgetAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateLinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpCreateSymlinkAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpFlushFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpForgetInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpGetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpLookUpInodeAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpMkNodeAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOpenFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpOthersAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadDirPlusAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReadSymlinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseDirHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpReleaseFileHandleAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRenameAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpRmDirAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSetInodeAttributesAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpSyncFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpUnlinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDARGUMENTFsOpWriteFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpBatchForgetAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateFileAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateLinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpCreateSymlinkAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpFlushFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpForgetInodeAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpGetInodeAttributesAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpLookUpInodeAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpMkNodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenDirAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOpenFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpOthersAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadDirPlusAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReadSymlinkAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseDirHandleAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpReleaseFileHandleAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRenameAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpRmDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSetInodeAttributesAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpSyncFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpUnlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryINVALIDOPERATIONFsOpWriteFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpBatchForgetAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateLinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpCreateSymlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpFlushFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpForgetInodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpGetInodeAttributesAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpLookUpInodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkDirAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpMkNodeAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOpenFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpOthersAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadDirPlusAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReadSymlinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseDirHandleAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpReleaseFileHandleAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRenameAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpRmDirAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSetInodeAttributesAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpSyncFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpUnlinkAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryIOERRORFsOpWriteFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpBatchForgetAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateLinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpCreateSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpFlushFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpForgetInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpGetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpLookUpInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpMkNodeAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOpenFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpOthersAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadDirPlusAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReadSymlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseDirHandleAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpReleaseFileHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRenameAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpRmDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpSyncFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpUnlinkAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryMISCERRORFsOpWriteFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpBatchForgetAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateLinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpCreateSymlinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpFlushFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpForgetInodeAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpGetInodeAttributesAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpLookUpInodeAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpMkNodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOpenFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpOthersAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadDirPlusAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReadSymlinkAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseDirHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpReleaseFileHandleAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRenameAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpRmDirAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSetInodeAttributesAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpSyncFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpUnlinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNETWORKERRORFsOpWriteFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpBatchForgetAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateLinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpCreateSymlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpFlushFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpForgetInodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpGetInodeAttributesAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpLookUpInodeAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkDirAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpMkNodeAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOpenFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpOthersAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadDirPlusAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReadSymlinkAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseDirHandleAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpReleaseFileHandleAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRenameAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpRmDirAtomic                                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSetInodeAttributesAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpSyncFileAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpUnlinkAtomic                                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTADIRFsOpWriteFileAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpBatchForgetAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateLinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpCreateSymlinkAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpFlushFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpForgetInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpGetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpLookUpInodeAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpMkNodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOpenFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpOthersAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadDirPlusAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReadSymlinkAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseDirHandleAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpReleaseFileHandleAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRenameAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpRmDirAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSetInodeAttributesAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpSyncFileAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpUnlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOTIMPLEMENTEDFsOpWriteFileAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpBatchForgetAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateFileAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateLinkAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpCreateSymlinkAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpFlushFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpForgetInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpGetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpLookUpInodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpMkNodeAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOpenFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpOthersAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadDirPlusAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReadSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseDirHandleAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpReleaseFileHandleAtomic                                          *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRenameAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpRmDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSetInodeAttributesAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpSyncFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpUnlinkAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryNOFILEORDIRFsOpWriteFileAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpBatchForgetAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateFileAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateLinkAtomic                                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpCreateSymlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpFlushFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpForgetInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpGetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpLookUpInodeAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpMkNodeAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOpenFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpOthersAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirAtomic                                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadDirPlusAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReadSymlinkAtomic                                                  *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseDirHandleAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpReleaseFileHandleAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRenameAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpRmDirAtomic                                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSetInodeAttributesAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpSyncFileAtomic                                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpUnlinkAtomic                                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPERMERRORFsOpWriteFileAtomic                                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpBatchForgetAtomic                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateFileAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateLinkAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpCreateSymlinkAtomic                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpFlushFileAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpForgetInodeAtomic                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpGetInodeAttributesAtomic                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpLookUpInodeAtomic                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkDirAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpMkNodeAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenDirAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOpenFileAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpOthersAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirAtomic                                       *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadDirPlusAtomic                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadFileAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReadSymlinkAtomic                                   *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseDirHandleAtomic                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpReleaseFileHandleAtomic                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRenameAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpRmDirAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSetInodeAttributesAtomic                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpSyncFileAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpUnlinkAtomic                                        *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryPROCESSRESOURCEMGMTERRORFsOpWriteFileAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpBatchForgetAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateFileAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateLinkAtomic                                            *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpCreateSymlinkAtomic                                         *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpFlushFileAtomic                                             *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpForgetInodeAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpGetInodeAttributesAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpLookUpInodeAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpMkNodeAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenDirAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOpenFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpOthersAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirAtomic                                               *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadDirPlusAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReadSymlinkAtomic                                           *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseDirHandleAtomic                                      *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpReleaseFileHandleAtomic                                     *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRenameAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpRmDirAtomic                                                 *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSetInodeAttributesAtomic                                    *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                              *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                                *atomic.Int64
+	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                             *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic                   *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                               *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                                      *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic                                 *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic               *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic                           *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic                                  *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic                             *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic         *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic                     *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic                            *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic                       *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic               *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic                           *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic                                  *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic                             *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic         *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic                     *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                            *atomic.Int64
+	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic                       *atomic.Int64
+	gcsDownloadBytesCountReadTypeBufferedAtomic                                                                   *atomic.Int64
+	gcsDownloadBytesCountReadTypeParallelAtomic                                                                   *atomic.Int64
+	gcsDownloadBytesCountReadTypeRandomAtomic                                                                     *atomic.Int64
+	gcsDownloadBytesCountReadTypeSequentialAtomic                                                                 *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeSequentialAtomic                                                         *atomic.Int64
+	gcsExperimentalReadBytesCountReadTypeUnknownAtomic                                                            *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic               *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic               *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic                *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic                *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic       *atomic.Int64
+	gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic       *atomic.Int64
+	gcsReadBytesCountAtomic                                                                                       *atomic.Int64
+	gcsReadCountReadTypeParallelAtomic                                                                            *atomic.Int64
+	gcsReadCountReadTypeRandomAtomic                                                                              *atomic.Int64
+	gcsReadCountReadTypeSequentialAtomic                                                                          *atomic.Int64
+	gcsReadCountReadTypeUnknownAtomic                                                                             *atomic.Int64
+	gcsReaderCountIoMethodClosedAtomic                                                                            *atomic.Int64
+	gcsReaderCountIoMethodOpenedAtomic                                                                            *atomic.Int64
+	gcsRequestCountGcsMethodComposeObjectsAtomic                                                                  *atomic.Int64
+	gcsRequestCountGcsMethodCopyObjectAtomic                                                                      *atomic.Int64
+	gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic                                                    *atomic.Int64
+	gcsRequestCountGcsMethodCreateFolderAtomic                                                                    *atomic.Int64
+	gcsRequestCountGcsMethodCreateObjectAtomic                                                                    *atomic.Int64
+	gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic                                                         *atomic.Int64
+	gcsRequestCountGcsMethodDeleteFolderAtomic                                                                    *atomic.Int64
+	gcsRequestCountGcsMethodDeleteObjectAtomic                                                                    *atomic.Int64
+	gcsRequestCountGcsMethodFinalizeUploadAtomic                                                                  *atomic.Int64
+	gcsRequestCountGcsMethodFlushPendingWritesAtomic                                                              *atomic.Int64
+	gcsRequestCountGcsMethodGetFolderAtomic                                                                       *atomic.Int64
+	gcsRequestCountGcsMethodListObjectsAtomic                                                                     *atomic.Int64
+	gcsRequestCountGcsMethodMoveObjectAtomic                                                                      *atomic.Int64
+	gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic                                                         *atomic.Int64
+	gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic                                                         *atomic.Int64
+	gcsRequestCountGcsMethodNewReaderAtomic                                                                       *atomic.Int64
+	gcsRequestCountGcsMethodRenameFolderAtomic                                                                    *atomic.Int64
+	gcsRequestCountGcsMethodStatObjectAtomic                                                                      *atomic.Int64
+	gcsRequestCountGcsMethodUpdateObjectAtomic                                                                    *atomic.Int64
+	gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic                                                              *atomic.Int64
+	gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic                                                       *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic                                  *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailNotFoundAtomic                               *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailTtlExpiredAtomic                             *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailFoundAtomic                                  *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailNotFoundAtomic                               *atomic.Int64
+	metadataCacheReadCountCacheHitTrueEntryStatusPositiveLookupDetailTtlExpiredAtomic                             *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailFoundAtomic                                 *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailNotFoundAtomic                              *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusNegativeLookupDetailTtlExpiredAtomic                            *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                                 *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                              *atomic.Int64
+	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                            *atomic.Int64
+	testUpdownCounterAtomic                                                                                       *atomic.Int64
+	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                              *atomic.Int64
+	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                              *atomic.Int64
+	bufferedReadReadLatency                                                                                       metric.Int64Histogram
+	fileCacheReadLatencies                                                                                        metric.Int64Histogram
+	fsOpsLatency                                                                                                  metric.Int64Histogram
+	gcsRequestLatencies                                                                                           metric.Int64Histogram
+	readBlockSizes                                                                                                metric.Int64Histogram
 }
 
 func (o *otelMetrics) BufferedReadFallbackTriggerCount(
@@ -2358,25 +2375,87 @@ func (o *otelMetrics) GcsDownloadBytesCount(
 	}
 }
 
-func (o *otelMetrics) GcsReadBytesCount(
+func (o *otelMetrics) GcsExperimentalReadBytesCount(
 	inc int64, readType ReadType) {
 	if inc < 0 {
-		logger.Errorf("Counter metric gcs/read_bytes_count received a negative increment: %d", inc)
+		logger.Errorf("Counter metric gcs/experimental_read_bytes_count received a negative increment: %d", inc)
 		return
 	}
 	switch readType {
 	case ReadTypeParallelAttr:
-		o.gcsReadBytesCountReadTypeParallelAtomic.Add(inc)
+		o.gcsExperimentalReadBytesCountReadTypeParallelAtomic.Add(inc)
 	case ReadTypeRandomAttr:
-		o.gcsReadBytesCountReadTypeRandomAtomic.Add(inc)
+		o.gcsExperimentalReadBytesCountReadTypeRandomAtomic.Add(inc)
 	case ReadTypeSequentialAttr:
-		o.gcsReadBytesCountReadTypeSequentialAtomic.Add(inc)
+		o.gcsExperimentalReadBytesCountReadTypeSequentialAtomic.Add(inc)
 	case ReadTypeUnknownAttr:
-		o.gcsReadBytesCountReadTypeUnknownAtomic.Add(inc)
+		o.gcsExperimentalReadBytesCountReadTypeUnknownAtomic.Add(inc)
 	default:
 		updateUnrecognizedAttribute(string(readType))
 		return
 	}
+}
+
+func (o *otelMetrics) GcsExperimentalReadTypeTransitionsCount(
+	inc int64, reason Reason, transitionType TransitionType) {
+	if inc < 0 {
+		logger.Errorf("Counter metric gcs/experimental_read_type_transitions_count received a negative increment: %d", inc)
+		return
+	}
+	switch reason {
+	case ReasonAverageReadSizeLargeEnoughAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonBackwardSeekAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonForwardSeekAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	case ReasonInitialOffsetNonZeroAttr:
+		switch transitionType {
+		case TransitionTypeRandomToSequentialAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic.Add(inc)
+		case TransitionTypeSequentialToRandomAttr:
+			o.gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic.Add(inc)
+		default:
+			updateUnrecognizedAttribute(string(transitionType))
+			return
+		}
+	default:
+		updateUnrecognizedAttribute(string(reason))
+		return
+	}
+}
+
+func (o *otelMetrics) GcsReadBytesCount(
+	inc int64) {
+	if inc < 0 {
+		logger.Errorf("Counter metric gcs/read_bytes_count received a negative increment: %d", inc)
+		return
+	}
+	o.gcsReadBytesCountAtomic.Add(inc)
 }
 
 func (o *otelMetrics) GcsReadCount(
@@ -3124,10 +3203,21 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		gcsDownloadBytesCountReadTypeRandomAtomic,
 		gcsDownloadBytesCountReadTypeSequentialAtomic atomic.Int64
 
-	var gcsReadBytesCountReadTypeParallelAtomic,
-		gcsReadBytesCountReadTypeRandomAtomic,
-		gcsReadBytesCountReadTypeSequentialAtomic,
-		gcsReadBytesCountReadTypeUnknownAtomic atomic.Int64
+	var gcsExperimentalReadBytesCountReadTypeParallelAtomic,
+		gcsExperimentalReadBytesCountReadTypeRandomAtomic,
+		gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
+		gcsExperimentalReadBytesCountReadTypeUnknownAtomic atomic.Int64
+
+	var gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic atomic.Int64
+
+	var gcsReadBytesCountAtomic atomic.Int64
 
 	var gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic,
@@ -3705,18 +3795,41 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err10 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err10 := meter.Int64ObservableCounter("gcs/experimental_read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects along with type - Sequential/Random"),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeParallelAtomic, gcsReadBytesCountReadTypeParallelAttrSet)
-			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeRandomAtomic, gcsReadBytesCountReadTypeRandomAttrSet)
-			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeSequentialAtomic, gcsReadBytesCountReadTypeSequentialAttrSet)
-			conditionallyObserve(obsrv, &gcsReadBytesCountReadTypeUnknownAtomic, gcsReadBytesCountReadTypeUnknownAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadBytesCountReadTypeParallelAtomic, gcsExperimentalReadBytesCountReadTypeParallelAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadBytesCountReadTypeRandomAtomic, gcsExperimentalReadBytesCountReadTypeRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadBytesCountReadTypeSequentialAtomic, gcsExperimentalReadBytesCountReadTypeSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadBytesCountReadTypeUnknownAtomic, gcsExperimentalReadBytesCountReadTypeUnknownAttrSet)
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/experimental_read_type_transitions_count",
+		metric.WithDescription("The cumulative number of read pattern transitions, along with the transition direction (sequential_to_random or random_to_sequential) and the reason: backward_seek, forward_seek, initial_offset_non_zero, or average_read_size_large_enough."),
+		metric.WithUnit(""),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic, gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAttrSet)
+			conditionallyObserve(obsrv, &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic, gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAttrSet)
+			return nil
+		}))
+
+	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
+		metric.WithUnit("By"),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &gcsReadBytesCountAtomic)
+			return nil
+		}))
+
+	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3727,7 +3840,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err12 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3736,7 +3849,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3762,12 +3875,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err14 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err15 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3776,7 +3889,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err16 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3795,12 +3908,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err17 := meter.Int64Histogram("read/block_sizes",
+	readBlockSizes, err19 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err18 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err20 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3808,7 +3921,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err19 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3817,7 +3930,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4267,60 +4380,69 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic:                     &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic:                  &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic,
 		fsOpsLatency: fsOpsLatency,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:           &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                       &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                              &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic:                         &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic:       &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic:                   &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic:                          &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic:                     &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic: &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic:       &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic:                   &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic:                          &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic:                     &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic: &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
-		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
-		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                           &gcsDownloadBytesCountReadTypeBufferedAtomic,
-		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
-		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
-		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
-		gcsReadBytesCountReadTypeParallelAtomic:                                                               &gcsReadBytesCountReadTypeParallelAtomic,
-		gcsReadBytesCountReadTypeRandomAtomic:                                                                 &gcsReadBytesCountReadTypeRandomAtomic,
-		gcsReadBytesCountReadTypeSequentialAtomic:                                                             &gcsReadBytesCountReadTypeSequentialAtomic,
-		gcsReadBytesCountReadTypeUnknownAtomic:                                                                &gcsReadBytesCountReadTypeUnknownAtomic,
-		gcsReadCountReadTypeParallelAtomic:                                                                    &gcsReadCountReadTypeParallelAtomic,
-		gcsReadCountReadTypeRandomAtomic:                                                                      &gcsReadCountReadTypeRandomAtomic,
-		gcsReadCountReadTypeSequentialAtomic:                                                                  &gcsReadCountReadTypeSequentialAtomic,
-		gcsReadCountReadTypeUnknownAtomic:                                                                     &gcsReadCountReadTypeUnknownAtomic,
-		gcsReaderCountIoMethodClosedAtomic:                                                                    &gcsReaderCountIoMethodClosedAtomic,
-		gcsReaderCountIoMethodOpenedAtomic:                                                                    &gcsReaderCountIoMethodOpenedAtomic,
-		gcsRequestCountGcsMethodComposeObjectsAtomic:                                                          &gcsRequestCountGcsMethodComposeObjectsAtomic,
-		gcsRequestCountGcsMethodCopyObjectAtomic:                                                              &gcsRequestCountGcsMethodCopyObjectAtomic,
-		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic:                                            &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
-		gcsRequestCountGcsMethodCreateFolderAtomic:                                                            &gcsRequestCountGcsMethodCreateFolderAtomic,
-		gcsRequestCountGcsMethodCreateObjectAtomic:                                                            &gcsRequestCountGcsMethodCreateObjectAtomic,
-		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:                                                 &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
-		gcsRequestCountGcsMethodDeleteFolderAtomic:                                                            &gcsRequestCountGcsMethodDeleteFolderAtomic,
-		gcsRequestCountGcsMethodDeleteObjectAtomic:                                                            &gcsRequestCountGcsMethodDeleteObjectAtomic,
-		gcsRequestCountGcsMethodFinalizeUploadAtomic:                                                          &gcsRequestCountGcsMethodFinalizeUploadAtomic,
-		gcsRequestCountGcsMethodFlushPendingWritesAtomic:                                                      &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
-		gcsRequestCountGcsMethodGetFolderAtomic:                                                               &gcsRequestCountGcsMethodGetFolderAtomic,
-		gcsRequestCountGcsMethodListObjectsAtomic:                                                             &gcsRequestCountGcsMethodListObjectsAtomic,
-		gcsRequestCountGcsMethodMoveObjectAtomic:                                                              &gcsRequestCountGcsMethodMoveObjectAtomic,
-		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:                                                 &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
-		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:                                                 &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
-		gcsRequestCountGcsMethodNewReaderAtomic:                                                               &gcsRequestCountGcsMethodNewReaderAtomic,
-		gcsRequestCountGcsMethodRenameFolderAtomic:                                                            &gcsRequestCountGcsMethodRenameFolderAtomic,
-		gcsRequestCountGcsMethodStatObjectAtomic:                                                              &gcsRequestCountGcsMethodStatObjectAtomic,
-		gcsRequestCountGcsMethodUpdateObjectAtomic:                                                            &gcsRequestCountGcsMethodUpdateObjectAtomic,
-		gcsRequestLatencies: gcsRequestLatencies,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:                   &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                               &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                                      &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic:                                 &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic:               &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic:                           &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic:                                  &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic:                             &fsStreamingWriteFallbackCountOpenModeReadWriteWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic:         &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic:                     &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic:                            &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic:                       &fsStreamingWriteFallbackCountOpenModeReadWriteAppendWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic:                           &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic:                                  &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic:                             &fsStreamingWriteFallbackCountOpenModeWriteOnlyWriteFallbackReasonOutOfOrderAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic:         &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonConcurrencyLimitBreachedAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:                     &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                            &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
+		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:                       &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
+		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                                   &gcsDownloadBytesCountReadTypeBufferedAtomic,
+		gcsDownloadBytesCountReadTypeParallelAtomic:                                                                   &gcsDownloadBytesCountReadTypeParallelAtomic,
+		gcsDownloadBytesCountReadTypeRandomAtomic:                                                                     &gcsDownloadBytesCountReadTypeRandomAtomic,
+		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                                 &gcsDownloadBytesCountReadTypeSequentialAtomic,
+		gcsExperimentalReadBytesCountReadTypeParallelAtomic:                                                           &gcsExperimentalReadBytesCountReadTypeParallelAtomic,
+		gcsExperimentalReadBytesCountReadTypeRandomAtomic:                                                             &gcsExperimentalReadBytesCountReadTypeRandomAtomic,
+		gcsExperimentalReadBytesCountReadTypeSequentialAtomic:                                                         &gcsExperimentalReadBytesCountReadTypeSequentialAtomic,
+		gcsExperimentalReadBytesCountReadTypeUnknownAtomic:                                                            &gcsExperimentalReadBytesCountReadTypeUnknownAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic: &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic: &gcsExperimentalReadTypeTransitionsCountReasonAverageReadSizeLargeEnoughTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic:               &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic:               &gcsExperimentalReadTypeTransitionsCountReasonBackwardSeekTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic:                &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic:                &gcsExperimentalReadTypeTransitionsCountReasonForwardSeekTransitionTypeSequentialToRandomAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic:       &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeRandomToSequentialAtomic,
+		gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic:       &gcsExperimentalReadTypeTransitionsCountReasonInitialOffsetNonZeroTransitionTypeSequentialToRandomAtomic,
+		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
+		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
+		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,
+		gcsReadCountReadTypeSequentialAtomic:                                               &gcsReadCountReadTypeSequentialAtomic,
+		gcsReadCountReadTypeUnknownAtomic:                                                  &gcsReadCountReadTypeUnknownAtomic,
+		gcsReaderCountIoMethodClosedAtomic:                                                 &gcsReaderCountIoMethodClosedAtomic,
+		gcsReaderCountIoMethodOpenedAtomic:                                                 &gcsReaderCountIoMethodOpenedAtomic,
+		gcsRequestCountGcsMethodComposeObjectsAtomic:                                       &gcsRequestCountGcsMethodComposeObjectsAtomic,
+		gcsRequestCountGcsMethodCopyObjectAtomic:                                           &gcsRequestCountGcsMethodCopyObjectAtomic,
+		gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic:                         &gcsRequestCountGcsMethodCreateAppendableObjectWriterAtomic,
+		gcsRequestCountGcsMethodCreateFolderAtomic:                                         &gcsRequestCountGcsMethodCreateFolderAtomic,
+		gcsRequestCountGcsMethodCreateObjectAtomic:                                         &gcsRequestCountGcsMethodCreateObjectAtomic,
+		gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic:                              &gcsRequestCountGcsMethodCreateObjectChunkWriterAtomic,
+		gcsRequestCountGcsMethodDeleteFolderAtomic:                                         &gcsRequestCountGcsMethodDeleteFolderAtomic,
+		gcsRequestCountGcsMethodDeleteObjectAtomic:                                         &gcsRequestCountGcsMethodDeleteObjectAtomic,
+		gcsRequestCountGcsMethodFinalizeUploadAtomic:                                       &gcsRequestCountGcsMethodFinalizeUploadAtomic,
+		gcsRequestCountGcsMethodFlushPendingWritesAtomic:                                   &gcsRequestCountGcsMethodFlushPendingWritesAtomic,
+		gcsRequestCountGcsMethodGetFolderAtomic:                                            &gcsRequestCountGcsMethodGetFolderAtomic,
+		gcsRequestCountGcsMethodListObjectsAtomic:                                          &gcsRequestCountGcsMethodListObjectsAtomic,
+		gcsRequestCountGcsMethodMoveObjectAtomic:                                           &gcsRequestCountGcsMethodMoveObjectAtomic,
+		gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic:                              &gcsRequestCountGcsMethodMultiRangeDownloaderAddAtomic,
+		gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic:                              &gcsRequestCountGcsMethodNewMultiRangeDownloaderAtomic,
+		gcsRequestCountGcsMethodNewReaderAtomic:                                            &gcsRequestCountGcsMethodNewReaderAtomic,
+		gcsRequestCountGcsMethodRenameFolderAtomic:                                         &gcsRequestCountGcsMethodRenameFolderAtomic,
+		gcsRequestCountGcsMethodStatObjectAtomic:                                           &gcsRequestCountGcsMethodStatObjectAtomic,
+		gcsRequestCountGcsMethodUpdateObjectAtomic:                                         &gcsRequestCountGcsMethodUpdateObjectAtomic,
+		gcsRequestLatencies:                                                                gcsRequestLatencies,
 		gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic:                                   &gcsRetryCountRetryErrorCategoryOTHERERRORSAtomic,
 		gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic:                            &gcsRetryCountRetryErrorCategorySTALLEDREADREQUESTAtomic,
 		metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic:       &metadataCacheReadCountCacheHitTrueEntryStatusNegativeLookupDetailFoundAtomic,

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4975,6 +4975,129 @@ func TestGcsExperimentalReadBytesCount(t *testing.T) {
 	}
 }
 
+func TestGcsExperimentalReaderCancellationCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "reason_canceled",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "canceled")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "canceled")): 5,
+			},
+		},
+		{
+			name: "reason_deadline_exceeded",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "deadline_exceeded")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 5,
+			},
+		},
+		{
+			name: "reason_explicit_close",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "explicit_close")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "explicit_close")): 5,
+			},
+		},
+		{
+			name: "reason_forced_recreate",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "forced_recreate")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forced_recreate")): 5,
+			},
+		},
+		{
+			name: "reason_inactive_timeout",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "inactive_timeout")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "inactive_timeout")): 5,
+			},
+		},
+		{
+			name: "reason_seek",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "seek")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "seek")): 5,
+			},
+		},
+		{
+			name: "reason_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_unknown",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "unknown")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "unknown")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(5, "canceled")
+				m.GcsExperimentalReaderCancellationCount(2, "deadline_exceeded")
+				m.GcsExperimentalReaderCancellationCount(3, "canceled")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 8,
+				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationCount(-5, "canceled")
+				m.GcsExperimentalReaderCancellationCount(2, "canceled")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["gcs/experimental_reader_cancellation_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "gcs/experimental_reader_cancellation_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "gcs/experimental_reader_cancellation_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
 func TestGcsReadBytesCount(t *testing.T) {
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4975,6 +4975,129 @@ func TestGcsExperimentalReadBytesCount(t *testing.T) {
 	}
 }
 
+func TestGcsExperimentalReaderCancellationBytesCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "reason_canceled",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "canceled")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "canceled")): 5,
+			},
+		},
+		{
+			name: "reason_deadline_exceeded",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "deadline_exceeded")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 5,
+			},
+		},
+		{
+			name: "reason_explicit_close",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "explicit_close")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "explicit_close")): 5,
+			},
+		},
+		{
+			name: "reason_forced_recreate",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "forced_recreate")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forced_recreate")): 5,
+			},
+		},
+		{
+			name: "reason_inactive_timeout",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "inactive_timeout")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "inactive_timeout")): 5,
+			},
+		},
+		{
+			name: "reason_seek",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "seek")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "seek")): 5,
+			},
+		},
+		{
+			name: "reason_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_unknown",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "unknown")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "unknown")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(5, "canceled")
+				m.GcsExperimentalReaderCancellationBytesCount(2, "deadline_exceeded")
+				m.GcsExperimentalReaderCancellationBytesCount(3, "canceled")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 8,
+				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReaderCancellationBytesCount(-5, "canceled")
+				m.GcsExperimentalReaderCancellationBytesCount(2, "canceled")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["gcs/experimental_reader_cancellation_bytes_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "gcs/experimental_reader_cancellation_bytes_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "gcs/experimental_reader_cancellation_bytes_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
 func TestGcsExperimentalReaderCancellationCount(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4888,7 +4888,7 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 	}
 }
 
-func TestGcsReadBytesCount(t *testing.T) {
+func TestGcsExperimentalReadBytesCount(t *testing.T) {
 	tests := []struct {
 		name     string
 		f        func(m *otelMetrics)
@@ -4897,7 +4897,7 @@ func TestGcsReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Parallel",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Parallel")
+				m.GcsExperimentalReadBytesCount(5, "Parallel")
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Parallel")): 5,
@@ -4906,7 +4906,7 @@ func TestGcsReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Random",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Random")
+				m.GcsExperimentalReadBytesCount(5, "Random")
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Random")): 5,
@@ -4915,7 +4915,7 @@ func TestGcsReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Sequential",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Sequential")
+				m.GcsExperimentalReadBytesCount(5, "Sequential")
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Sequential")): 5,
@@ -4924,7 +4924,7 @@ func TestGcsReadBytesCount(t *testing.T) {
 		{
 			name: "read_type_Unknown",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Unknown")
+				m.GcsExperimentalReadBytesCount(5, "Unknown")
 			},
 			expected: map[attribute.Set]int64{
 				attribute.NewSet(attribute.String("read_type", "Unknown")): 5,
@@ -4932,9 +4932,9 @@ func TestGcsReadBytesCount(t *testing.T) {
 		}, {
 			name: "multiple_attributes_summed",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(5, "Parallel")
-				m.GcsReadBytesCount(2, "Random")
-				m.GcsReadBytesCount(3, "Parallel")
+				m.GcsExperimentalReadBytesCount(5, "Parallel")
+				m.GcsExperimentalReadBytesCount(2, "Random")
+				m.GcsExperimentalReadBytesCount(3, "Parallel")
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 8,
 				attribute.NewSet(attribute.String("read_type", "Random")): 2,
@@ -4943,8 +4943,8 @@ func TestGcsReadBytesCount(t *testing.T) {
 		{
 			name: "negative_increment",
 			f: func(m *otelMetrics) {
-				m.GcsReadBytesCount(-5, "Parallel")
-				m.GcsReadBytesCount(2, "Parallel")
+				m.GcsExperimentalReadBytesCount(-5, "Parallel")
+				m.GcsExperimentalReadBytesCount(2, "Parallel")
 			},
 			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 2},
 		},
@@ -4960,12 +4960,12 @@ func TestGcsReadBytesCount(t *testing.T) {
 			waitForMetricsProcessing()
 
 			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-			metric, ok := metrics["gcs/read_bytes_count"]
+			metric, ok := metrics["gcs/experimental_read_bytes_count"]
 			if len(tc.expected) == 0 {
-				assert.False(t, ok, "gcs/read_bytes_count metric should not be found")
+				assert.False(t, ok, "gcs/experimental_read_bytes_count metric should not be found")
 				return
 			}
-			require.True(t, ok, "gcs/read_bytes_count metric not found")
+			require.True(t, ok, "gcs/experimental_read_bytes_count metric not found")
 			expectedMap := make(map[string]int64)
 			for k, v := range tc.expected {
 				expectedMap[k.Encoded(encoder)] = v
@@ -4973,6 +4973,154 @@ func TestGcsReadBytesCount(t *testing.T) {
 			assert.Equal(t, expectedMap, metric)
 		})
 	}
+}
+
+func TestGcsExperimentalReadTypeTransitionsCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "reason_average_read_size_large_enough_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_average_read_size_large_enough_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_backward_seek_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "backward_seek", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_backward_seek_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "backward_seek", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_forward_seek_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "forward_seek", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_forward_seek_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "forward_seek", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_initial_offset_non_zero_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_initial_offset_non_zero_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
+				m.GcsExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "sequential_to_random")
+				m.GcsExperimentalReadTypeTransitionsCount(3, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 8,
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.GcsExperimentalReadTypeTransitionsCount(-5, "average_read_size_large_enough", "random_to_sequential")
+				m.GcsExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["gcs/experimental_read_type_transitions_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "gcs/experimental_read_type_transitions_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "gcs/experimental_read_type_transitions_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
+func TestGcsReadBytesCount(t *testing.T) {
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
+
+	m.GcsReadBytesCount(1024)
+	m.GcsReadBytesCount(2048)
+	waitForMetricsProcessing()
+
+	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok := metrics["gcs/read_bytes_count"]
+	require.True(t, ok, "gcs/read_bytes_count metric not found")
+	s := attribute.NewSet()
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
+
+	// Test negative increment
+	m.GcsReadBytesCount(-100)
+	waitForMetricsProcessing()
+
+	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok = metrics["gcs/read_bytes_count"]
+	require.True(t, ok, "gcs/read_bytes_count metric not found after negative increment")
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
 }
 
 func TestGcsReadCount(t *testing.T) {

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4975,129 +4975,6 @@ func TestGcsExperimentalReadBytesCount(t *testing.T) {
 	}
 }
 
-func TestGcsExperimentalReaderCancellationBytesCount(t *testing.T) {
-	tests := []struct {
-		name     string
-		f        func(m *otelMetrics)
-		expected map[attribute.Set]int64
-	}{
-		{
-			name: "reason_canceled",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "canceled")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "canceled")): 5,
-			},
-		},
-		{
-			name: "reason_deadline_exceeded",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "deadline_exceeded")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 5,
-			},
-		},
-		{
-			name: "reason_explicit_close",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "explicit_close")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "explicit_close")): 5,
-			},
-		},
-		{
-			name: "reason_forced_recreate",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "forced_recreate")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "forced_recreate")): 5,
-			},
-		},
-		{
-			name: "reason_inactive_timeout",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "inactive_timeout")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "inactive_timeout")): 5,
-			},
-		},
-		{
-			name: "reason_seek",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "seek")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "seek")): 5,
-			},
-		},
-		{
-			name: "reason_sequential_to_random",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "sequential_to_random")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "sequential_to_random")): 5,
-			},
-		},
-		{
-			name: "reason_unknown",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "unknown")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "unknown")): 5,
-			},
-		}, {
-			name: "multiple_attributes_summed",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(5, "canceled")
-				m.GcsExperimentalReaderCancellationBytesCount(2, "deadline_exceeded")
-				m.GcsExperimentalReaderCancellationBytesCount(3, "canceled")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 8,
-				attribute.NewSet(attribute.String("reason", "deadline_exceeded")): 2,
-			},
-		},
-		{
-			name: "negative_increment",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReaderCancellationBytesCount(-5, "canceled")
-				m.GcsExperimentalReaderCancellationBytesCount(2, "canceled")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "canceled")): 2},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			encoder := attribute.DefaultEncoder()
-			m, rd := setupOTel(ctx, t)
-
-			tc.f(m)
-			waitForMetricsProcessing()
-
-			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-			metric, ok := metrics["gcs/experimental_reader_cancellation_bytes_count"]
-			if len(tc.expected) == 0 {
-				assert.False(t, ok, "gcs/experimental_reader_cancellation_bytes_count metric should not be found")
-				return
-			}
-			require.True(t, ok, "gcs/experimental_reader_cancellation_bytes_count metric not found")
-			expectedMap := make(map[string]int64)
-			for k, v := range tc.expected {
-				expectedMap[k.Encoded(encoder)] = v
-			}
-			assert.Equal(t, expectedMap, metric)
-		})
-	}
-}
-
 func TestGcsExperimentalReaderCancellationCount(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -5217,6 +5094,84 @@ func TestGcsExperimentalReaderCancellationCount(t *testing.T) {
 				expectedMap[k.Encoded(encoder)] = v
 			}
 			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
+func TestGcsExperimentalReaderCancellationUnreadBytes(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []int64
+		reason Reason
+	}{
+		{
+			name:   "reason_canceled",
+			values: []int64{100, 200},
+			reason: "canceled",
+		},
+		{
+			name:   "reason_deadline_exceeded",
+			values: []int64{100, 200},
+			reason: "deadline_exceeded",
+		},
+		{
+			name:   "reason_explicit_close",
+			values: []int64{100, 200},
+			reason: "explicit_close",
+		},
+		{
+			name:   "reason_forced_recreate",
+			values: []int64{100, 200},
+			reason: "forced_recreate",
+		},
+		{
+			name:   "reason_inactive_timeout",
+			values: []int64{100, 200},
+			reason: "inactive_timeout",
+		},
+		{
+			name:   "reason_seek",
+			values: []int64{100, 200},
+			reason: "seek",
+		},
+		{
+			name:   "reason_sequential_to_random",
+			values: []int64{100, 200},
+			reason: "sequential_to_random",
+		},
+		{
+			name:   "reason_unknown",
+			values: []int64{100, 200},
+			reason: "unknown",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+			var totalValue int64
+
+			for _, value := range tc.values {
+				m.GcsExperimentalReaderCancellationUnreadBytes(ctx, value, tc.reason)
+				totalValue += value
+			}
+			waitForMetricsProcessing()
+
+			metrics := gatherHistogramMetrics(ctx, t, rd)
+			metric, ok := metrics["gcs/experimental_reader_cancellation_unread_bytes"]
+			require.True(t, ok, "gcs/experimental_reader_cancellation_unread_bytes metric not found")
+
+			attrs := []attribute.KeyValue{
+				attribute.String("reason", string(tc.reason)),
+			}
+			s := attribute.NewSet(attrs...)
+			expectedKey := s.Encoded(encoder)
+			dp, ok := metric[expectedKey]
+			require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
+			assert.Equal(t, uint64(len(tc.values)), dp.Count)
+			assert.Equal(t, totalValue, dp.Sum)
 		})
 	}
 }

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4975,129 +4975,6 @@ func TestGcsExperimentalReadBytesCount(t *testing.T) {
 	}
 }
 
-func TestGcsExperimentalReadTypeTransitionsCount(t *testing.T) {
-	tests := []struct {
-		name     string
-		f        func(m *otelMetrics)
-		expected map[attribute.Set]int64
-	}{
-		{
-			name: "reason_average_read_size_large_enough_transition_type_random_to_sequential",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 5,
-			},
-		},
-		{
-			name: "reason_average_read_size_large_enough_transition_type_sequential_to_random",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "sequential_to_random")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 5,
-			},
-		},
-		{
-			name: "reason_backward_seek_transition_type_random_to_sequential",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "backward_seek", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
-			},
-		},
-		{
-			name: "reason_backward_seek_transition_type_sequential_to_random",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "backward_seek", "sequential_to_random")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
-			},
-		},
-		{
-			name: "reason_forward_seek_transition_type_random_to_sequential",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "forward_seek", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
-			},
-		},
-		{
-			name: "reason_forward_seek_transition_type_sequential_to_random",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "forward_seek", "sequential_to_random")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
-			},
-		},
-		{
-			name: "reason_initial_offset_non_zero_transition_type_random_to_sequential",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")): 5,
-			},
-		},
-		{
-			name: "reason_initial_offset_non_zero_transition_type_sequential_to_random",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "sequential_to_random")
-			},
-			expected: map[attribute.Set]int64{
-				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")): 5,
-			},
-		}, {
-			name: "multiple_attributes_summed",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
-				m.GcsExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "sequential_to_random")
-				m.GcsExperimentalReadTypeTransitionsCount(3, "average_read_size_large_enough", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 8,
-				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 2,
-			},
-		},
-		{
-			name: "negative_increment",
-			f: func(m *otelMetrics) {
-				m.GcsExperimentalReadTypeTransitionsCount(-5, "average_read_size_large_enough", "random_to_sequential")
-				m.GcsExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "random_to_sequential")
-			},
-			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 2},
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			encoder := attribute.DefaultEncoder()
-			m, rd := setupOTel(ctx, t)
-
-			tc.f(m)
-			waitForMetricsProcessing()
-
-			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-			metric, ok := metrics["gcs/experimental_read_type_transitions_count"]
-			if len(tc.expected) == 0 {
-				assert.False(t, ok, "gcs/experimental_read_type_transitions_count metric should not be found")
-				return
-			}
-			require.True(t, ok, "gcs/experimental_read_type_transitions_count metric not found")
-			expectedMap := make(map[string]int64)
-			for k, v := range tc.expected {
-				expectedMap[k.Encoded(encoder)] = v
-			}
-			assert.Equal(t, expectedMap, metric)
-		})
-	}
-}
-
 func TestGcsReadBytesCount(t *testing.T) {
 	ctx := context.Background()
 	encoder := attribute.DefaultEncoder()
@@ -5885,6 +5762,129 @@ func TestReadBlockSizes(t *testing.T) {
 	require.True(t, ok, "DataPoint not found for key: %s", expectedKey)
 	assert.Equal(t, uint64(len(values)), dp.Count)
 	assert.Equal(t, totalValue, dp.Sum)
+}
+
+func TestReadExperimentalReadTypeTransitionsCount(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "reason_average_read_size_large_enough_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_average_read_size_large_enough_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_backward_seek_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "backward_seek", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_backward_seek_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "backward_seek", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "backward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_forward_seek_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "forward_seek", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_forward_seek_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "forward_seek", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "forward_seek"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		},
+		{
+			name: "reason_initial_offset_non_zero_transition_type_random_to_sequential",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "random_to_sequential")): 5,
+			},
+		},
+		{
+			name: "reason_initial_offset_non_zero_transition_type_sequential_to_random",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "initial_offset_non_zero", "sequential_to_random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("reason", "initial_offset_non_zero"), attribute.String("transition_type", "sequential_to_random")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(5, "average_read_size_large_enough", "random_to_sequential")
+				m.ReadExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "sequential_to_random")
+				m.ReadExperimentalReadTypeTransitionsCount(3, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 8,
+				attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "sequential_to_random")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.ReadExperimentalReadTypeTransitionsCount(-5, "average_read_size_large_enough", "random_to_sequential")
+				m.ReadExperimentalReadTypeTransitionsCount(2, "average_read_size_large_enough", "random_to_sequential")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("reason", "average_read_size_large_enough"), attribute.String("transition_type", "random_to_sequential")): 2},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["read/experimental_read_type_transitions_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "read/experimental_read_type_transitions_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "read/experimental_read_type_transitions_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
 }
 
 func TestTestUpdownCounter(t *testing.T) {

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4889,28 +4889,90 @@ func TestGcsDownloadBytesCount(t *testing.T) {
 }
 
 func TestGcsReadBytesCount(t *testing.T) {
-	ctx := context.Background()
-	encoder := attribute.DefaultEncoder()
-	m, rd := setupOTel(ctx, t)
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "read_type_Parallel",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(5, "Parallel")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("read_type", "Parallel")): 5,
+			},
+		},
+		{
+			name: "read_type_Random",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(5, "Random")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("read_type", "Random")): 5,
+			},
+		},
+		{
+			name: "read_type_Sequential",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(5, "Sequential")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("read_type", "Sequential")): 5,
+			},
+		},
+		{
+			name: "read_type_Unknown",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(5, "Unknown")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("read_type", "Unknown")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(5, "Parallel")
+				m.GcsReadBytesCount(2, "Random")
+				m.GcsReadBytesCount(3, "Parallel")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 8,
+				attribute.NewSet(attribute.String("read_type", "Random")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.GcsReadBytesCount(-5, "Parallel")
+				m.GcsReadBytesCount(2, "Parallel")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("read_type", "Parallel")): 2},
+		},
+	}
 
-	m.GcsReadBytesCount(1024)
-	m.GcsReadBytesCount(2048)
-	waitForMetricsProcessing()
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
 
-	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok := metrics["gcs/read_bytes_count"]
-	require.True(t, ok, "gcs/read_bytes_count metric not found")
-	s := attribute.NewSet()
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
+			tc.f(m)
+			waitForMetricsProcessing()
 
-	// Test negative increment
-	m.GcsReadBytesCount(-100)
-	waitForMetricsProcessing()
-
-	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok = metrics["gcs/read_bytes_count"]
-	require.True(t, ok, "gcs/read_bytes_count metric not found after negative increment")
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["gcs/read_bytes_count"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "gcs/read_bytes_count metric should not be found")
+				return
+			}
+			require.True(t, ok, "gcs/read_bytes_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
 }
 
 func TestGcsReadCount(t *testing.T) {


### PR DESCRIPTION
### Description
Reverted the `gcs/read_bytes_count` metric to stay unchanged (zero attributes, original description). Added a new attributed metric `gcs/experimental_read_bytes_count` tracking read bytes categorized by `read_type` attributes (Parallel, Random, Sequential, Unknown).

Additionally, introduced sequential-to-random read access transition reasons tracking:
- Added a new custom counter metric `gcs/experimental_sequential_to_random_transitions_count` mapped to transition reasons: `backward_seek`, `forward_seek`, and `initial_offset_non_zero`.
- Instrumented the read type classifier (`ReadTypeClassifier`) to dynamically classify and atomically switch state (using thread-safe `CompareAndSwap`) on sequential to random transitions.
- Integrated a new mock-based unit test validation suite inside `read_type_classifier_test.go` and updated high-level integration test assertions in both `gcs_metrics_test.go` and `metrics_test.go`.

### Link to the issue in case of a bug fix.
N/A (At user's direct request)

### Testing details
1. Manual - Ran unified compile, code generation, import formatting, vet, and style lint pipeline (`make build`) successfully with 0 warnings/issues.
2. Unit tests - Executed unit test sweeps under `metrics` package (`go test -v ./metrics/...`) and `gcsx` package (`go test -v ./internal/gcsx/... -run TestReadTypeClassifier`) completely successfully.
3. Integration tests - Executed file system integration test suite (`go test -v ./internal/fs/... -run "TestGCSMetrics|TestReadFile"`), fully verifying metrics behaviors under file cache hit/miss cycles, sequential readers, buffered prefetch pipelines, and parallel MRD downloads.

### Any backward incompatible change? If so, please explain.
N/A (Reverted `gcs/read_bytes_count` back to its original signature, making it fully backwards-compatible for all active telemetry consumers).
