### PR TITLE
refactor(mounting): remove obsolete list-access-check CLI flag and logic

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -440,8 +440,6 @@ type Config struct {
 
 	DisableAutoconfig bool `yaml:"disable-autoconfig"`
 
-	DisableListAccessCheck bool `yaml:"disable-list-access-check"`
-
 	DummyIo DummyIoConfig `yaml:"dummy-io"`
 
 	EnableAtomicRenameObject bool `yaml:"enable-atomic-rename-object"`
@@ -906,12 +904,6 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("disable-autoconfig", "", false, "Disable optimizing configuration automatically for a machine")
 
 	if err := flagSet.MarkHidden("disable-autoconfig"); err != nil {
-		return err
-	}
-
-	flagSet.BoolP("disable-list-access-check", "", true, "Disables the list object based access check during mount operation")
-
-	if err := flagSet.MarkHidden("disable-list-access-check"); err != nil {
 		return err
 	}
 
@@ -1537,10 +1529,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("disable-autoconfig", flagSet.Lookup("disable-autoconfig")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("disable-list-access-check", flagSet.Lookup("disable-list-access-check")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -167,13 +167,6 @@ params:
     default: false
     hide-flag: true
 
-  - config-path: "disable-list-access-check"
-    flag-name: "disable-list-access-check"
-    type: "bool"
-    usage: "Disables the list object based access check during mount operation"
-    default: true
-    hide-flag: true
-
   - config-path: "dummy-io.enable"
     flag-name: "enable-dummy-io"
     type: "bool"

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -727,40 +727,6 @@ func TestValidateConfigFile_EnableHNSConfigSuccessful(t *testing.T) {
 	}
 }
 
-func TestValidateConfigFile_DisableListAccessCheckSuccessful(t *testing.T) {
-	testCases := []struct {
-		name           string
-		configFile     string
-		expectedConfig *cfg.Config
-	}{
-		{
-			// Test default values.
-			name:       "empty_config_file",
-			configFile: "testdata/empty_file.yaml",
-			expectedConfig: &cfg.Config{
-				DisableListAccessCheck: true,
-			},
-		},
-		{
-			name:       "valid_config_file",
-			configFile: "testdata/valid_config.yaml",
-			expectedConfig: &cfg.Config{
-				DisableListAccessCheck: false,
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			gotConfig, err := getConfigObjectWithConfigFile(t, tc.configFile)
-
-			if assert.NoError(t, err) {
-				assert.EqualValues(t, tc.expectedConfig.DisableListAccessCheck, gotConfig.DisableListAccessCheck)
-			}
-		})
-	}
-}
-
 func TestValidateConfigFile_MetadataCacheConfigSuccessful(t *testing.T) {
 	testCases := []struct {
 		name           string

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -105,7 +105,6 @@ be interacting with the file system.`)
 		ChunkRetryDeadlineSecs:             newConfig.GcsRetries.ChunkRetryDeadlineSecs,
 		ChunkTransferTimeoutSecs:           newConfig.GcsRetries.ChunkTransferTimeoutSecs,
 		TmpObjectPrefix:                    ".gcsfuse_tmp/",
-		DisableListAccessCheck:             newConfig.DisableListAccessCheck,
 		DummyIOCfg:                         newConfig.DummyIo,
 		IsTypeCacheDeprecated:              newConfig.EnableTypeCacheDeprecation,
 		ImplicitDir:                        newConfig.ImplicitDirs,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1703,43 +1703,6 @@ func TestArgsParsing_EnableAtomicRenameObjectFlag(t *testing.T) {
 	}
 }
 
-func TestArgsParsing_DisableListAccessCheckFlag(t *testing.T) {
-	tests := []struct {
-		name                           string
-		args                           []string
-		expectedDisableListAccessCheck bool
-	}{
-		{
-			name:                           "default",
-			args:                           []string{"gcsfuse", "abc", "pqr"},
-			expectedDisableListAccessCheck: true,
-		},
-		{
-			name:                           "normal",
-			args:                           []string{"gcsfuse", "--disable-list-access-check=false", "abc", "pqr"},
-			expectedDisableListAccessCheck: false,
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var gotDisableListAccessCheck bool
-			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
-				gotDisableListAccessCheck = mountInfo.config.DisableListAccessCheck
-				return nil
-			})
-			require.Nil(t, err)
-			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
-
-			err = cmd.Execute()
-
-			if assert.NoError(t, err) {
-				assert.Equal(t, tc.expectedDisableListAccessCheck, gotDisableListAccessCheck)
-			}
-		})
-	}
-}
-
 func TestArgsParsing_EnableNewReaderFlag(t *testing.T) {
 	tests := []struct {
 		name                    string

--- a/cmd/testdata/valid_config.yaml
+++ b/cmd/testdata/valid_config.yaml
@@ -71,7 +71,6 @@ list:
   enable-empty-managed-folders: true
 enable-hns: false
 enable-atomic-rename-object: false
-disable-list-access-check: false
 metadata-cache:
   deprecated-stat-cache-capacity: 200
   deprecated-stat-cache-ttl: 30s

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -70,9 +70,6 @@ type BucketConfig struct {
 	ChunkTransferTimeoutSecs int64
 	TmpObjectPrefix          string
 
-	// Disable Initial ListObject API check during the mount operation.
-	DisableListAccessCheck bool
-
 	// Enable dummy I/O mode for testing purposes, simulated read without
 	// any data read from GCS.
 	// All the metadata operations like object listing and stats are real.
@@ -264,16 +261,6 @@ func (bm *bucketManager) SetUpBucket(
 
 	// Fetch bucket type from storage layout api and set bucket type.
 	b.BucketType()
-
-	// TODO(b/471129209): Cleanup this code after confirming the GetStorageLayout is sufficient for bucket access checks.
-	if !bm.config.DisableListAccessCheck {
-		// Check whether this bucket works, giving the user a warning early if there
-		// is some problem.
-		_, err = b.ListObjects(ctx, &gcs.ListObjectsRequest{MaxResults: 1, IncludeFoldersAsPrefixes: true, Delimiter: "/"})
-		if err != nil {
-			return
-		}
-	}
 
 	// Periodically garbage collect temporary objects
 	go garbageCollect(bm.gcCtx, bm.config.TmpObjectPrefix, sb)

--- a/internal/gcsx/bucket_manager_test.go
+++ b/internal/gcsx/bucket_manager_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	. "github.com/jacobsa/ogletest"
 	"github.com/stretchr/testify/mock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestBucketManager(t *testing.T) { RunTests(t) }
@@ -55,7 +57,9 @@ func (t *BucketManagerTest) SetUp(_ *TestInfo) {
 	t.mockClient = new(storage.MockStorageControlClient)
 	t.fakeStorage = storage.NewFakeStorageWithMockClient(t.mockClient, cfg.HTTP2)
 	t.storageHandle = t.fakeStorage.CreateStorageHandle()
-	t.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).
+	t.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return strings.Contains(req.Name, TestBucketName)
+	}), mock.Anything).
 		Return(&controlpb.StorageLayout{
 			HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
 			LocationType:          "zone",
@@ -155,11 +159,18 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist() {
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
+	// Configure mock to return NotFound error for invalidBucketName layout check
+	t.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return strings.Contains(req.Name, invalidBucketName)
+	}), mock.Anything).
+		Return(nil, status.Errorf(codes.NotFound, "The specified bucket does not exist."))
+
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, false, metrics.NewNoopMetrics())
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))
-	ExpectNe(nil, bucket.Syncer)
+	ExpectTrue(strings.Contains(err.Error(), "storageLayout call failed:"))
+	ExpectTrue(strings.Contains(err.Error(), "code = NotFound desc = The specified bucket does not exist."))
+	ExpectEq(nil, bucket.Syncer)
 }
 
 func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist_IsMultiBucketMountTrue() {
@@ -180,9 +191,16 @@ func (t *BucketManagerTest) TestSetUpBucketMethodWhenBucketDoesNotExist_IsMultiB
 	bm.config = bucketConfig
 	bm.gcCtx = ctx
 
+	// Configure mock to return NotFound error for invalidBucketName layout check
+	t.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return strings.Contains(req.Name, invalidBucketName)
+	}), mock.Anything).
+		Return(nil, status.Errorf(codes.NotFound, "The specified bucket does not exist."))
+
 	bucket, err := bm.SetUpBucket(context.Background(), invalidBucketName, true, metrics.NewNoopMetrics())
 
 	AssertNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "error in iterating through objects: storage: bucket doesn't exist"))
-	ExpectNe(nil, bucket.Syncer)
+	ExpectTrue(strings.Contains(err.Error(), "storageLayout call failed:"))
+	ExpectTrue(strings.Contains(err.Error(), "code = NotFound desc = The specified bucket does not exist."))
+	ExpectEq(nil, bucket.Syncer)
 }


### PR DESCRIPTION
### Description
Cleanup the old code for disable list access check and flag. Flag usage is zero for the last 30 days in GKE: https://screenshot.googleplex.com/AueqegeHAJMeQZF

### Link to the issue in case of a bug fix.
b/471129209

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NONE
