### PR TITLE
test: add config dump integration tests

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -129,6 +129,19 @@ func waitForLogFileToContainConfigDump(logFile string) {
 	assertContainsConfigDump(output)
 }
 
+func readStdoutUntilMounted(stdout io.Reader) []byte {
+	var output []byte
+	buf := make([]byte, 4096)
+
+	for !bytes.Contains(output, []byte("successfully mounted")) {
+		n, err := stdout.Read(buf)
+		output = append(output, buf[:n]...)
+		AssertEq(nil, err, "Output so far:\n%s", output)
+	}
+
+	return output
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
@@ -581,15 +594,7 @@ func (t *GcsfuseTest) ForegroundModeDumpsConfigToStdout() {
 		}
 	}()
 
-	var output []byte
-	{
-		buf := make([]byte, 4096)
-		for !bytes.Contains(output, []byte("successfully mounted")) {
-			n, err := stdout.Read(buf)
-			output = append(output, buf[:n]...)
-			AssertEq(nil, err, "Output so far:\n%s", output)
-		}
-	}
+	mountOutput := readStdoutUntilMounted(stdout)
 	mounted = true
 
 	err = util.Unmount(t.dir)
@@ -597,8 +602,8 @@ func (t *GcsfuseTest) ForegroundModeDumpsConfigToStdout() {
 	mounted = false
 
 	remainingOutput, err := io.ReadAll(stdout)
-	AssertEq(nil, err, "Output so far:\n%s", output)
-	output = append(output, remainingOutput...)
+	AssertEq(nil, err, "Output so far:\n%s", mountOutput)
+	output := append(mountOutput, remainingOutput...)
 
 	err = cmd.Wait()
 	AssertEq(nil, err)

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -17,6 +17,7 @@ package integration_test
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -560,8 +561,7 @@ func (t *GcsfuseTest) ForegroundModeDumpsConfigToStdout() {
 		"--foreground",
 		canned.FakeBucketName,
 		t.dir,
-	},
-		nil)
+	}, nil)
 
 	stdout, err := cmd.StdoutPipe()
 	AssertEq(nil, err)
@@ -592,19 +592,23 @@ func (t *GcsfuseTest) ForegroundModeDumpsConfigToStdout() {
 	}
 	mounted = true
 
-	assertContainsConfigDump(output)
-
 	err = util.Unmount(t.dir)
 	AssertEq(nil, err)
 	mounted = false
 
+	remainingOutput, err := io.ReadAll(stdout)
+	AssertEq(nil, err, "Output so far:\n%s", output)
+	output = append(output, remainingOutput...)
+
 	err = cmd.Wait()
 	AssertEq(nil, err)
 	processDone = true
+
+	assertContainsConfigDump(output)
 }
 
 func (t *GcsfuseTest) BackgroundModeDumpsConfigToLogFile() {
-	logFile := filepath.Join(path.Dir(t.dir), path.Base(t.dir)+".log")
+	logFile := filepath.Join(filepath.Dir(t.dir), filepath.Base(t.dir)+".log")
 	defer os.Remove(logFile)
 
 	err := t.runGcsfuse([]string{

--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -99,6 +99,35 @@ func (t *GcsfuseTest) runGcsfuse(args []string) (err error) {
 	return t.runGcsfuseWithEnv(args, nil)
 }
 
+const (
+	configDumpLogMessage      = "GCSFuse Config"
+	configDumpFullConfigLabel = "Full Config"
+)
+
+func assertContainsConfigDump(output []byte) {
+	AssertEq(true, bytes.Contains(output, []byte(configDumpLogMessage)), "output:\n%s", output)
+	AssertEq(true, bytes.Contains(output, []byte(configDumpFullConfigLabel)), "output:\n%s", output)
+}
+
+func waitForLogFileToContainConfigDump(logFile string) {
+	deadline := time.Now().Add(5 * time.Second)
+	var output []byte
+	var err error
+
+	for time.Now().Before(deadline) {
+		output, err = os.ReadFile(logFile)
+		if err == nil &&
+			bytes.Contains(output, []byte(configDumpLogMessage)) &&
+			bytes.Contains(output, []byte(configDumpFullConfigLabel)) {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	AssertEq(nil, err, "log file: %s", logFile)
+	assertContainsConfigDump(output)
+}
+
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
@@ -524,6 +553,80 @@ func (t *GcsfuseTest) ForegroundMode() {
 	// Now the process should exit successfully.
 	err = cmd.Wait()
 	AssertEq(nil, err)
+}
+
+func (t *GcsfuseTest) ForegroundModeDumpsConfigToStdout() {
+	cmd := t.gcsfuseCommand([]string{
+		"--foreground",
+		canned.FakeBucketName,
+		t.dir,
+	},
+		nil)
+
+	stdout, err := cmd.StdoutPipe()
+	AssertEq(nil, err)
+
+	err = cmd.Start()
+	AssertEq(nil, err)
+
+	mounted := false
+	processDone := false
+	defer func() {
+		if mounted {
+			_ = util.Unmount(t.dir)
+		}
+		if !processDone {
+			_ = cmd.Process.Kill()
+			_ = cmd.Wait()
+		}
+	}()
+
+	var output []byte
+	{
+		buf := make([]byte, 4096)
+		for !bytes.Contains(output, []byte("successfully mounted")) {
+			n, err := stdout.Read(buf)
+			output = append(output, buf[:n]...)
+			AssertEq(nil, err, "Output so far:\n%s", output)
+		}
+	}
+	mounted = true
+
+	assertContainsConfigDump(output)
+
+	err = util.Unmount(t.dir)
+	AssertEq(nil, err)
+	mounted = false
+
+	err = cmd.Wait()
+	AssertEq(nil, err)
+	processDone = true
+}
+
+func (t *GcsfuseTest) BackgroundModeDumpsConfigToLogFile() {
+	logFile := filepath.Join(path.Dir(t.dir), path.Base(t.dir)+".log")
+	defer os.Remove(logFile)
+
+	err := t.runGcsfuse([]string{
+		"--log-file",
+		logFile,
+		canned.FakeBucketName,
+		t.dir,
+	})
+	AssertEq(nil, err)
+
+	mounted := true
+	defer func() {
+		if mounted {
+			_ = util.Unmount(t.dir)
+		}
+	}()
+
+	waitForLogFileToContainConfigDump(logFile)
+
+	err = util.Unmount(t.dir)
+	AssertEq(nil, err)
+	mounted = false
 }
 
 func (t *GcsfuseTest) VersionFlags() {


### PR DESCRIPTION
Fixes #2134

## What changed
- Added mounting integration coverage for config dumps in foreground mode without a log file, where logs go to stdout.
- Added mounting integration coverage for config dumps in background mode with `--log-file`, where logs go to the configured log file.
- Assert only stable config-dump markers instead of comparing the full flag/config output.

## Why
Configuration dumps are useful debugging evidence, and this verifies that dumping keeps happening without turning the test into a full config snapshot.

## Validation
- `gofmt -w tools/integration_tests/mounting/gcsfuse_test.go`
- `git diff --check`
- `go test ./tools/integration_tests/mounting`