### PR TITLE
feat: update rename, file cache, and kernel reader flows to use IsRapid()

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -173,7 +173,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	//
 	// Note: Change the below check to `(offset + len(dst)) > int64(fileInfoData.FileSize))` if the below
 	// check causes a problem in any edge-case.
-	if bucket.BucketType().RapidWritesEnabled() && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
+	if bucket.BucketType().IsRapid() && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
 		err = util.ErrFallbackToGCS
 		return
 	}

--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -173,7 +173,7 @@ func (fch *CacheHandle) Read(ctx context.Context, bucket gcs.Bucket, object *gcs
 	//
 	// Note: Change the below check to `(offset + len(dst)) > int64(fileInfoData.FileSize))` if the below
 	// check causes a problem in any edge-case.
-	if bucket.BucketType().Zonal && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
+	if bucket.BucketType().RapidWritesEnabled() && object.IsUnfinalized() && offset >= int64(fileInfoData.FileSize) {
 		err = util.ErrFallbackToGCS
 		return
 	}

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -542,8 +542,8 @@ func (job *Job) GetStatus() JobStatus {
 // Compares CRC32 of the downloaded file with the CRC32 from GCS object metadata.
 // In case of mismatch deletes the file and corresponding entry from file cache.
 func (job *Job) validateCRC() (err error) {
-	// Todo (b/446440219): Enable crc check for ZB once it is fixed
-	if !job.fileCacheConfig.EnableCrc || job.bucket.BucketType().Zonal {
+	// Todo (b/446440219): Enable crc check for rapid buckets once it is fixed
+	if !job.fileCacheConfig.EnableCrc || job.bucket.BucketType().IsRapid() {
 		return
 	}
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2535,7 +2535,7 @@ func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, chil
 	default:
 		return fmt.Errorf("child inode (id %v) is not a file or symlink inode", child.ID())
 	}
-	if fs.enableAtomicRenameObject || child.Bucket().BucketType().Zonal {
+	if fs.enableAtomicRenameObject || child.Bucket().BucketType().IsRapid() {
 		return fs.atomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
 	}
 	return fs.nonAtomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -281,10 +281,10 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		} else {
 			logger.Warnf("Cannot apply bucket-type optimizations as ViperConfig is nil")
 		}
-		// Write post mount kernel settings when kernel reader is enabled in GKE environments for
+		// Write post mount kernel settings for rapid buckets when kernel reader is enabled in GKE environments for
 		// non dynamic mounts before user space mounting in GCSFuse. Mounting in GKE is already done at this point but
 		// writing kernel settings early ensures the asynchronous application of these settings happens as early as possible in GKE.
-		if serverCfg.NewConfig.FileSystem.KernelParamsFile != "" && bucketType.Zonal && serverCfg.NewConfig.FileSystem.EnableKernelReader {
+		if serverCfg.NewConfig.FileSystem.KernelParamsFile != "" && bucketType.IsRapid() && serverCfg.NewConfig.FileSystem.EnableKernelReader {
 			kernelParams := kernelparams.NewKernelParamsManager()
 			kernelParams.SetReadAheadKb(int(serverCfg.NewConfig.FileSystem.MaxReadAheadKb))
 			kernelParams.SetCongestionWindowThreshold(int(serverCfg.NewConfig.FileSystem.CongestionThreshold))

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -1094,7 +1094,7 @@ func (f *FileInode) updateReaders() {
 	}
 
 	// This will be a noop for regional bucket.
-	if !f.bucket.BucketType().Zonal {
+	if !f.bucket.BucketType().IsRapid() {
 		return
 	}
 	if err := f.mrdInstance.SetMinObject(minObj); err != nil {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -188,8 +188,8 @@ func (t *FileTest) createBufferedWriteHandler(shouldInitialize bool, openMode ut
 
 func (t *FileTest) validateMrdInstanceMinObject() {
 	t.T().Helper()
-	// Validate only for zonal buckets
-	if t.in.bucket.BucketType().Zonal {
+	// Validate only for rapid buckets
+	if t.in.bucket.BucketType().IsRapid() {
 		// Validate MinObject in inode and MRDInstance points to different copy of MinObject.
 		assert.NotSame(t.T(), &t.in.src, t.in.mrdInstance.GetMinObject())
 		// Validate MinObject in MRDInstance is equal to the MinObject in inode.
@@ -199,8 +199,8 @@ func (t *FileTest) validateMrdInstanceMinObject() {
 
 func (t *FileTest) validateMrdWrapperMinObject() {
 	t.T().Helper()
-	// Validate only for zonal buckets
-	if t.in.bucket.BucketType().Zonal {
+	// Validate only for rapid buckets
+	if t.in.bucket.BucketType().IsRapid() {
 		// Validate MinObject in inode and MRDWrapper points to different copy of MinObject.
 		assert.NotSame(t.T(), &t.in.src, t.in.MRDWrapper.GetMinObject())
 		// Validate MinObject in MRDWrapper is equal to the MinObject in inode.
@@ -599,7 +599,7 @@ func (t *FileTest) TestTruncateNegative() {
 }
 
 func (t *FileTest) TestDestroy_MrdInstanceDestroyed() {
-	if !t.in.bucket.BucketType().Zonal {
+	if !t.in.bucket.BucketType().IsRapid() {
 		return
 	}
 	// Manually initialize MRD pool since FileInode.Read doesn't use it directly.

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -79,6 +79,12 @@ func TestZonalFileCacheReaderTestSuite(t *testing.T) {
 	suite.Run(t, zonalBucketFileCacheReaderTestSuite)
 }
 
+func TestPirloFileCacheReaderTestSuite(t *testing.T) {
+	pirloBucketFileCacheReaderTestSuite := &fileCacheReaderTest{
+		bucketType: gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled}}
+	suite.Run(t, pirloBucketFileCacheReaderTestSuite)
+}
+
 func (t *fileCacheReaderTest) SetupTest() {
 	t.object = &gcs.MinObject{
 		Name:       testObject,
@@ -621,11 +627,11 @@ func (t *fileCacheReaderTest) Test_ReadAt_OffsetBeyondObjectSizeShouldThrowEOFEr
 	assert.ErrorIs(t.T(), err, io.EOF)
 }
 
-func (t *fileCacheReaderTest) skipForNonZonalBucket() {
+func (t *fileCacheReaderTest) skipForNonRapidBucket() {
 	t.T().Helper()
 
-	if !t.bucketType.Zonal {
-		t.T().Skipf("Skipping test for non-zonal bucket type")
+	if !t.bucketType.IsRapid() {
+		t.T().Skipf("Skipping test for non-rapid bucket type")
 	}
 }
 
@@ -656,7 +662,7 @@ func (t *fileCacheReaderTest) waitForDownloadJobToFinish(obj *gcs.MinObject) {
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondCachedSizeAfterSizeIncreasedShouldThrowFallbackError() {
-	t.skipForNonZonalBucket()
+	t.skipForNonRapidBucket()
 	origObjectSize := t.unfinalized_object.Size
 	// First read, which may start a background download job.
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
@@ -681,7 +687,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondC
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondObjectSizeAfterSizeIncreasedShouldThrowEOFError() {
-	t.skipForNonZonalBucket()
+	t.skipForNonRapidBucket()
 	origObjectSize := t.unfinalized_object.Size
 	// First read, which may start a background download job.
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
@@ -705,7 +711,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBeyondO
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondCachedSizeWithIncreasedObjectSizeShouldThrowFallbackError() {
-	t.skipForNonZonalBucket()
+	t.skipForNonRapidBucket()
 	origObjectSize := t.unfinalized_object.Size
 	// First read, which may start a background download job.
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
@@ -730,7 +736,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondObjectSizeWithIncreasedObjectSizeShouldThrowFallbackError() {
-	t.skipForNonZonalBucket()
+	t.skipForNonRapidBucket()
 	origObjectSize := t.unfinalized_object.Size
 	// First read, which may start a background download job.
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
@@ -755,7 +761,7 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 }
 
 func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCachedSizeAndReadBeyondCachedSizeShouldNotThrowError() {
-	t.skipForNonZonalBucket()
+	t.skipForNonRapidBucket()
 	origObjectSize := t.unfinalized_object.Size
 	t.fullyReadOriginalSizeOfUnfinalizedObject(origObjectSize)
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -379,7 +379,7 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 		//MaxResults: , (Field not present in storage.Query of Go Storage Library but present in ListObjectsQuery in Jacobsa code.)
 	}
 	minObjAttrs := []string{"Name", "Size", "Generation", "Metageneration", "Updated", "Metadata", "ContentEncoding", "CRC32C"}
-	if bh.BucketType().Zonal {
+	if bh.BucketType().IsRapid() {
 		// For regional buckets, partial response API fails to populate the Finalized field.(b/398916957)
 		// For objects in regional buckets, this field will be *unset*.
 		minObjAttrs = append(minObjAttrs, "Finalized")

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -348,6 +348,8 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 
 	logger.Infof("GetStorageLayout -> (%s) %v msec", bucketName, duration.Milliseconds())
 
+	// TODO (b/483608308): Once GetStorageLayout starts returning Pirlo bucket type,
+	// update this logic to use the response instead of inferring from clientConfig.
 	pirloState := gcs.PirloStateNone
 	if sh.clientConfig.ExperimentalEnablePirlo {
 		if sh.clientConfig.WriteConfig != nil && sh.clientConfig.WriteConfig.EnableRapidWrites {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -99,6 +99,8 @@ func (testSuite *StorageHandleTest) mockStorageLayout(bucketType gcs.BucketType)
 		storageLayout.LocationType = "multiregion"
 	}
 
+	// TODO (b/483608308): Once GetStorageLayout starts returning Pirlo bucket type,
+	// update this mock to correctly populate the response for Pirlo buckets.
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.Anything, mock.Anything).Return(storageLayout, nil)
 }
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -23,6 +23,7 @@ explicit_dir:
           flat: true
           hns: false
           zonal: false
+          rcu: false
         run_on_gke: true
 
 implicit_dir:
@@ -1175,3 +1176,28 @@ concurrent_operations:
          zonal: true
        run: TestConcurrentListing
        run_on_gke: true
+
+zonal_cache_rcu:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - run: TestZonalCacheRcuSameRegion
+        flags:
+          # TODO: Add the specific GCSFuse flags to test RCU in the SAME region as the VM
+          - "--implicit-dirs,--log-severity=trace"
+        compatible:
+          flat: false
+          hns: false
+          zonal: false
+          rcu: true
+        run_on_gke: true
+      - run: TestZonalCacheRcuDifferentRegion
+        flags:
+          # TODO: Add the specific GCSFuse flags to test RCU in a DIFFERENT region than the VM
+          - "--implicit-dirs,--log-severity=trace"
+        compatible:
+          flat: false
+          hns: false
+          zonal: false
+          rcu: true
+        run_on_gke: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -23,7 +23,6 @@ explicit_dir:
           flat: true
           hns: false
           zonal: false
-          rcu: false
         run_on_gke: true
 
 implicit_dir:
@@ -1176,28 +1175,3 @@ concurrent_operations:
          zonal: true
        run: TestConcurrentListing
        run_on_gke: true
-
-zonal_cache_rcu:
-  - mounted_directory: "${MOUNTED_DIR}"
-    test_bucket: "${BUCKET_NAME}"
-    configs:
-      - run: TestZonalCacheRcuSameRegion
-        flags:
-          # TODO: Add the specific GCSFuse flags to test RCU in the SAME region as the VM
-          - "--implicit-dirs,--log-severity=trace"
-        compatible:
-          flat: false
-          hns: false
-          zonal: false
-          rcu: true
-        run_on_gke: true
-      - run: TestZonalCacheRcuDifferentRegion
-        flags:
-          # TODO: Add the specific GCSFuse flags to test RCU in a DIFFERENT region than the VM
-          - "--implicit-dirs,--log-severity=trace"
-        compatible:
-          flat: false
-          hns: false
-          zonal: false
-          rcu: true
-        run_on_gke: true


### PR DESCRIPTION
### Description
This PR replaces existing `Zonal` bucket type checks with the more inclusive `IsRapid()` check across several key components, including the rename flow, file cache flow, and kernel reader flow. This change ensures that optimizations and behaviors previously reserved for Zonal buckets are now correctly applied to both Zonal and Pirlo buckets.

**Key Changes:**
*   **File Cache Flow:** Updated `internal/cache/file/cache_handle.go` and the downloader job to use `IsRapid()` for handling unfinalized objects and CRC validation.
*   **Kernel Reader Flow:** The file system now applies kernel readahead and congestion window settings for any rapid bucket type during initialization.
*   **Rename Flow:** The logic for atomic renames in `internal/fs/fs.go` now checks for `IsRapid()` to determine if an atomic rename should be performed.

### Link to the issue
b/516229935

### Testing details
1. **Manual** - Done
2. **Unit tests** - Updated
3. **Integration tests** -Automated

### Any backward incompatible change?
NA