### PR TITLE
fix(test): resolve flag duplication in emulator tests, update GetObject count, and rename proxy log prefix

### DIFF
--- a/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
+++ b/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
@@ -35,11 +35,19 @@ type grpcHeaderValidation struct {
 	proxyProcessId     int
 	proxyServerLogFile string
 	flags              []string
+	baseFlags          []string
 	configPath         string
 	suite.Suite
 }
 
+func (g *grpcHeaderValidation) SetupSuite() {
+	g.baseFlags = make([]string, len(g.flags))
+	copy(g.baseFlags, g.flags)
+}
+
 func (g *grpcHeaderValidation) SetupTest() {
+	g.flags = make([]string, len(g.baseFlags))
+	copy(g.flags, g.baseFlags)
 	g.configPath = "../configs/grpc_header_validation.yaml"
 	g.proxyServerLogFile = setup.CreateProxyServerLogFile(g.T())
 	g.T().Logf("Proxy server log file: %s", g.proxyServerLogFile)
@@ -98,7 +106,7 @@ func (g *grpcHeaderValidation) TestGRPCHeadersInMultipleOperations() {
 	assert.Greater(g.T(), validationCount, 0, "Expected at least one successful metadata validation")
 	assert.Contains(g.T(), logStr, "force_direct_connectivity=ENFORCED")
 	assert.Contains(g.T(), logStr, "direct_connectivity_diagnostic=no_auth")
-	assert.Equal(g.T(), 3, strings.Count(logStr, "/google.storage.v2.Storage/GetObject"), "Expected 3 GetObject calls (1 for each operation)")
+	assert.Equal(g.T(), 4, strings.Count(logStr, "/google.storage.v2.Storage/GetObject"), "Expected 4 GetObject calls (1 verification + 3 operations)")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/BidiWriteObject"), "Expected 1 BidiWriteObject call for writing the file")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/ReadObject"), "Expected 1 ReadObject call for reading the file")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/ListObjects"), "Expected 1 ListObjects call for listing the directory")

--- a/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
+++ b/tools/integration_tests/emulator_tests/write_stall/writes_stall_on_sync_test.go
@@ -141,8 +141,9 @@ func TestChunkTransferTimeout(t *testing.T) {
 					proxyServerLogFile := setup.CreateProxyServerLogFile(t)
 					port, proxyProcessId, err := emulator_tests.StartProxyServer(scenario.configPath, proxyServerLogFile)
 					require.NoError(t, err)
-					setup.AppendProxyEndpointToFlagSet(&flags, port)
-					setup.MountGCSFuseWithGivenMountFunc(flags, mountFunc)
+					localFlags := append([]string{}, flags...)
+					setup.AppendProxyEndpointToFlagSet(&localFlags, port)
+					setup.MountGCSFuseWithGivenMountFunc(localFlags, mountFunc)
 
 					defer func() { // Defer unmount, killing the proxy server and saving log files.
 						setup.UnmountGCSFuse(rootDir)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -57,7 +57,7 @@ const (
 	Charset                           = "abcdefghijklmnopqrstuvwxyz0123456789"
 	PathEnvVariable                   = "PATH"
 	GCSFuseLogFilePrefix              = "gcsfuse-failed-integration-test-logs-"
-	ProxyServerLogFilePrefix          = "proxy-server-failed-integration-test-logs-"
+	ProxyServerLogFilePrefix          = "gcsfuse-failed-integration-test-logs-proxy-server-"
 	zoneMatcherRegex                  = "^[a-z]+-[a-z0-9]+-[a-z]$"
 	regionMatcherRegex                = "^[a-z]+-[a-z0-9]+$"
 	unsupportedCharactersInTestBucket = " "


### PR DESCRIPTION
### Description

This PR resolves a test isolation issue in the gcsfuse emulator integration tests:

1. **Flag Accumulation Bug**: In `grpc_header_validation_test.go` and `writes_stall_on_sync_test.go`, flags were being appended in-place to a suite-level or loop-level slice. Since the test instances are reused across multiple sub-tests, this caused flags (specifically `--custom-endpoint` and `--anonymous-access`) to accumulate, leading to mounting errors (connecting to dead ports of previous test runs). This PR fixes it by copying the base flags before appending local test-specific flags.
2. **Emulator GetObject Count**: Updated the expected `GetObject` call count in `TestGRPCHeadersInMultipleOperations` from 3 to 4. This is because the test runs with gRPC enabled, which triggers a DirectPath verification call (`gcsfuse-dp-object` Stat) during mount that was previously not accounted for in the strict count assertion.
3. **Kokoro Proxy Logs Collection**: Renamed the proxy server log file prefix from `proxy-server-failed-` to `gcsfuse-failed-integration-test-logs-proxy-server-` to match the Kokoro artifact collection pattern in `presubmit.cfg`, ensuring proxy logs are successfully uploaded to GCS on failures.

### Link to the issue in case of a bug fix.

NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Verified that emulator tests pass locally and checks are passing on Kokoro.

### Any backward incompatible change? If so, please explain.

No.
