### PR TITLE
fix(fs): resolve name length check deadlock and downloader/fake-bucket data races

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -300,6 +300,16 @@ func (fch *CacheHandle) IsSequential(currentOffset int64) bool {
 	return true
 }
 
+func (fch *CacheHandle) UpdateJobSize(newSize uint64) {
+	if fch.fileDownloadJob != nil {
+		fch.fileDownloadJob.UpdateSize(newSize)
+	}
+}
+
+func (fch *CacheHandle) GetDownloadJob() *downloader.Job {
+	return fch.fileDownloadJob
+}
+
 // Close closes the underlying fileHandle pointing to locally downloaded cache file.
 func (fch *CacheHandle) Close() (err error) {
 	if fch.fileHandle != nil {

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -385,13 +385,12 @@ func Test_addFileInfoEntryAndCreateDownloadJob_WhenJobHasFailed(t *testing.T) {
 	cacheDir := path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir")
 	chTestArgs := initializeCacheHandlerTestArgs(t, &cfg.FileCacheConfig{EnableCrc: true}, cacheDir)
 	existingJob := getDownloadJobForTestObject(t, chTestArgs)
-	// Hack to fail the async job
-	correctSize := chTestArgs.object.Size
-	chTestArgs.object.Size = 2
+	// Fail the job by deleting the object from the bucket
+	err := chTestArgs.bucket.DeleteObject(context.Background(), &gcs.DeleteObjectRequest{Name: chTestArgs.object.Name})
+	require.NoError(t, err)
 	jobStatus, err := existingJob.Download(context.Background(), 1, true)
 	require.NoError(t, err)
 	require.Equal(t, downloader.Failed, jobStatus.Name)
-	chTestArgs.object.Size = correctSize
 
 	// Because the job has been failed and file info entry is still present with
 	// size less than the object's size (because the async job failed), new job
@@ -429,13 +428,12 @@ func Test_GetCacheHandle_WhenAsyncDownloadJobHasFailed(t *testing.T) {
 	cacheDir := path.Join(os.Getenv("HOME"), "CacheHandlerTest/dir")
 	chTestArgs := initializeCacheHandlerTestArgs(t, &cfg.FileCacheConfig{EnableCrc: true}, cacheDir)
 	existingJob := getDownloadJobForTestObject(t, chTestArgs)
-	// Hack to fail the async job
-	correctSize := chTestArgs.object.Size
-	chTestArgs.object.Size = 2
+	// Fail the job by deleting the object from the bucket
+	err := chTestArgs.bucket.DeleteObject(context.Background(), &gcs.DeleteObjectRequest{Name: chTestArgs.object.Name})
+	require.NoError(t, err)
 	jobStatus, err := existingJob.Download(context.Background(), 1, true)
 	require.NoError(t, err)
 	require.Equal(t, downloader.Failed, jobStatus.Name)
-	chTestArgs.object.Size = correctSize
 
 	newCacheHandle, err := chTestArgs.cacheHandler.GetCacheHandle(chTestArgs.object, chTestArgs.bucket, false, 0)
 

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -481,7 +481,10 @@ func (job *Job) downloadObjectAsync() {
 	// Truncate as the parallel downloads can create file with size little higher
 	// than the actual object size because writing with O_DIRECT happens in size
 	// multiple of cfg.MinimumAlignSizeForWriting.
-	err = cacheFile.Truncate(int64(job.object.Size))
+	job.mu.Lock()
+	sizeToTruncate := job.object.Size
+	job.mu.Unlock()
+	err = cacheFile.Truncate(int64(sizeToTruncate))
 	if err != nil {
 		err = fmt.Errorf("downloadObjectAsync: error while truncating cache file: %w", err)
 		job.handleError(err)
@@ -621,4 +624,12 @@ func (job *Job) IsExperimentalParallelDownloadsDefaultOn() bool {
 		return true
 	}
 	return false
+}
+
+// UpdateSize updates the size of the object in the job.
+// Acquires and releases LOCK(job.mu)
+func (job *Job) UpdateSize(newSize uint64) {
+	job.mu.Lock()
+	defer job.mu.Unlock()
+	job.object.Size = newSize
 }

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -140,8 +140,23 @@ func NewJob(
 		traceHandle = tracing.NewNoopTracer()
 	}
 
+	// Create a copy of MinObject to prevent data race with the reader thread
+	// which might update the size of the object concurrently.
+	objectCopy := *object
+	if object.CRC32C != nil {
+		crcCopy := *object.CRC32C
+		objectCopy.CRC32C = &crcCopy
+	}
+	if object.Metadata != nil {
+		metadataCopy := make(map[string]string)
+		for k, v := range object.Metadata {
+			metadataCopy[k] = v
+		}
+		objectCopy.Metadata = metadataCopy
+	}
+
 	job = &Job{
-		object:                  object,
+		object:                  &objectCopy,
 		bucket:                  bucket,
 		fileInfoCache:           fileInfoCache,
 		sequentialReadSizeMb:    sequentialReadSizeMb,

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -2177,10 +2177,7 @@ func (fs *fileSystem) createLocalFile(ctx context.Context, parentID fuseops.Inod
 	parent := fs.dirInodeOrDie(parentID)
 
 	defer func() {
-		if err != nil {
-			if child == nil {
-				return
-			}
+		if err != nil && child != nil {
 			// fs.mu lock is already taken
 			delete(fs.localFileInodes, child.Name())
 		}
@@ -2195,6 +2192,10 @@ func (fs *fileSystem) createLocalFile(ctx context.Context, parentID fuseops.Inod
 	}()
 
 	fullName := inode.NewFileName(parent.Name(), name)
+	if len(fullName.GcsObjectName()) > 1024 {
+		err = syscall.ENAMETOOLONG
+		return
+	}
 	child, ok := fs.localFileInodes[fullName]
 
 	if ok && !child.(*inode.FileInode).IsUnlinked() {
@@ -2504,6 +2505,18 @@ func (fs *fileSystem) Rename(
 	childBktOwned, ok := child.(inode.BucketOwnedInode)
 	if !ok { // Won't happen in ideal case.
 		return fmt.Errorf("child inode (id %v) is not owned by any bucket", child.ID())
+	}
+
+	// Construct new full name to validate length.
+	newParentName := newParent.Name()
+	var newFullName inode.Name
+	if child.Name().IsDir() {
+		newFullName = inode.NewDirName(newParentName, op.NewName)
+	} else {
+		newFullName = inode.NewFileName(newParentName, op.NewName)
+	}
+	if len(newFullName.GcsObjectName()) > 1024 {
+		return syscall.ENAMETOOLONG
 	}
 
 	if child.Name().IsDir() {

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -430,7 +430,7 @@ func (fh *FileHandle) isValidReader() bool {
 	// can use it otherwise we must throw it away.
 	if fh.reader != nil && fh.reader.Object().Generation == fh.inode.SourceGeneration().Object {
 		// Update reader object size to source object size.
-		fh.reader.Object().Size = fh.inode.SourceGeneration().Size
+		fh.reader.UpdateObjectSize(fh.inode.SourceGeneration().Size)
 		return true
 	}
 	return false

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -500,6 +500,7 @@ func (t *fileTest) Test_Read_ErrorScenarios() {
 			mockReader := new(gcsx.MockRandomReader)
 			mockReader.On("ReadAt", t.ctx, dst, int64(0)).Return(gcsx.ObjectData{}, tc.returnErr)
 			mockReader.On("Object").Return(&object)
+			mockReader.On("UpdateObjectSize", mock.Anything).Maybe()
 			fh.reader = mockReader
 
 			output, n, err := fh.Read(t.ctx, dst, 0, 200)

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"strings"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
@@ -1077,6 +1078,9 @@ func (d *dirInode) CreateChildFile(ctx context.Context, name string) (*Core, err
 		FileMtimeMetadataKey: d.mtimeClock.Now().UTC().Format(time.RFC3339Nano),
 	}
 	fullName := NewFileName(d.Name(), name)
+	if len(fullName.GcsObjectName()) > 1024 {
+		return nil, syscall.ENAMETOOLONG
+	}
 
 	o, err := d.createNewObject(ctx, fullName, childMetadata, "")
 	if err != nil {
@@ -1161,6 +1165,9 @@ func (d *dirInode) CreateChildSymlink(ctx context.Context, name string, target s
 	// No need to cancel prefetch here as creation of new symlink can not lead to stale data in metadata cache.
 
 	fullName := NewFileName(d.Name(), name)
+	if len(fullName.GcsObjectName()) > 1024 {
+		return nil, syscall.ENAMETOOLONG
+	}
 	var childMetadata map[string]string
 	var content string
 
@@ -1198,6 +1205,9 @@ func (d *dirInode) CreateChildDir(ctx context.Context, name string) (*Core, erro
 	// No need to cancel prefetch here as creation of new directory can not lead to stale data in metadata cache.
 	// Generate the full name for the new directory.
 	fullName := NewDirName(d.Name(), name)
+	if len(fullName.GcsObjectName()) > 1024 {
+		return nil, syscall.ENAMETOOLONG
+	}
 	var m *gcs.MinObject
 	var f *gcs.Folder
 	var err error

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -718,6 +718,14 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
+	assert.NotNil(t.T(), t.reader_unfinalized_object.fileCacheHandle)
+	if t.reader_unfinalized_object.fileCacheHandle != nil {
+		job := t.reader_unfinalized_object.fileCacheHandle.GetDownloadJob()
+		assert.NotNil(t.T(), job)
+		if job != nil {
+			job.UpdateSize(newObjectSize)
+		}
+	}
 	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
 		Buffer: make([]byte, cachedObjectSize+1),
 		Offset: cachedObjectSize / 2,
@@ -743,6 +751,14 @@ func (t *fileCacheReaderTest) Test_ReadAt_UnfinalizedObjectReadFromOffsetBelowCa
 	objectSizeIncrease := uint64(10)
 	newObjectSize := origObjectSize + objectSizeIncrease
 	t.unfinalized_object.Size = newObjectSize
+	assert.NotNil(t.T(), t.reader_unfinalized_object.fileCacheHandle)
+	if t.reader_unfinalized_object.fileCacheHandle != nil {
+		job := t.reader_unfinalized_object.fileCacheHandle.GetDownloadJob()
+		assert.NotNil(t.T(), job)
+		if job != nil {
+			job.UpdateSize(newObjectSize)
+		}
+	}
 	readResponse, err := t.reader_unfinalized_object.ReadAt(t.ctx, &ReadRequest{
 		Buffer: make([]byte, newObjectSize),
 		Offset: cachedObjectSize / 2,

--- a/internal/gcsx/mock_random_reader.go
+++ b/internal/gcsx/mock_random_reader.go
@@ -36,6 +36,10 @@ func (m *MockRandomReader) Object() *gcs.MinObject {
 	return args.Get(0).(*gcs.MinObject)
 }
 
+func (m *MockRandomReader) UpdateObjectSize(newSize uint64) {
+	m.Called(newSize)
+}
+
 func (m *MockRandomReader) Destroy() {
 	m.Called()
 }

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -78,6 +78,9 @@ type RandomReader interface {
 	// Return the record for the object to which the reader is bound.
 	Object() (o *gcs.MinObject)
 
+	// UpdateObjectSize updates the size of the object to which the reader is bound.
+	UpdateObjectSize(newSize uint64)
+
 	// Clean up any resources associated with the reader, which must not be used
 	// again.
 	Destroy()
@@ -424,6 +427,18 @@ func (rr *randomReader) ReadAt(
 func (rr *randomReader) Object() (o *gcs.MinObject) {
 	o = rr.object
 	return
+}
+
+func (rr *randomReader) UpdateObjectSize(newSize uint64) {
+	rr.mu.Lock()
+	rr.object.Size = newSize
+	rr.mu.Unlock()
+
+	rr.fileCacheMu.RLock()
+	defer rr.fileCacheMu.RUnlock()
+	if rr.fileCacheHandle != nil {
+		rr.fileCacheHandle.UpdateJobSize(newSize)
+	}
 }
 
 func (rr *randomReader) Destroy() {

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -1053,7 +1053,10 @@ func (b *bucket) DeleteObject(
 	return
 }
 
+// LOCKS_EXCLUDED(b.mu)
 func (b *bucket) MoveObject(ctx context.Context, req *gcs.MoveObjectRequest) (*gcs.Object, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	// Check that the destination name is legal.
 	err := checkName(req.DstName)
 	if err != nil {


### PR DESCRIPTION
### Description

This PR resolves a deadlock and two data races in GCSFuse:

1. **Deadlock in createFile/createLocalFile**: Added a name length validation check in FUSE operations to return `ENAMETOOLONG` early (as GCS limits name length to 1024 bytes). However, returning an error early in `createLocalFile` triggered a pre-existing lock leak in its `defer` block: if `child` inode was nil and `err` was not nil, it returned without unlocking `fs.mu`. This PR fixes the lock leak to ensure `fs.mu` is always unlocked in the `defer`.
2. **Data Race in downloader Job**: Fixed a concurrent read/write data race on `gcs.MinObject` where the reader thread occasionally updates `Object().Size` while the downloader job thread concurrently reads `object.Size` to truncate the cache file. Fixed by deep-copying `MinObject` in the `NewJob` constructor.
3. **Data Race in fake Bucket**: Added missing mutex locking (`b.mu`) to `MoveObject` in the fake bucket mock helper to ensure thread-safe rename operations during VFS integration tests.

### Link to the issue in case of a bug fix.

NA

### Testing details
1. Manual - NA
2. Unit tests - Verified that `internal/fs` tests (including `OpenTest.IllegalNames`) pass locally with race detector.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

No.
