### PR TITLE
fix(auth): Bypass active universe domain lookup on standard public GCP

### DIFF
--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -17,6 +17,7 @@ package storageutil
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"cloud.google.com/go/auth"
 	"cloud.google.com/go/auth/oauth2adapt"
@@ -47,20 +48,31 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 
 	tokenSrc := oauth2adapt.TokenSourceFromTokenProvider(cred.TokenProvider)
 
-	retryConfig := NewRetryConfig(config, DefaultRetryDeadline, DefaultTotalRetryBudget, DefaultInitialBackoff)
+	var domain string
 
-	apiCall := func(attemptCtx context.Context) (string, error) {
-		d, err := cred.UniverseDomain(attemptCtx)
-		return d, err
-	}
-
-	domain, err := ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", apiCall, logger.LevelInfo)
-	if err != nil {
-		logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)
-		// Setting default universe domain to googleapis.com in case we are unable to fetch the domain.
+	// Under Application Default Credentials (ADC) without custom universe configurations,
+	// the target is commercial GCP (googleapis.com). We bypass the metadata server check
+	// to prevent startup stalls (e.g., on GKE Autopilot startup).
+	if config.KeyFile == "" && config.CustomEndpoint == "" && os.Getenv("GOOGLE_CLOUD_UNIVERSE_DOMAIN") == "" {
+		logger.Infof("Bypassing UniverseDomain metadata server lookup on standard commercial GCP setup")
 		domain = auth2.UniverseDomainDefault
+	} else {
+		retryConfig := NewRetryConfig(config, DefaultRetryDeadline, DefaultTotalRetryBudget, DefaultInitialBackoff)
+
+		apiCall := func(attemptCtx context.Context) (string, error) {
+			d, err := cred.UniverseDomain(attemptCtx)
+			return d, err
+		}
+
+		domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", apiCall, logger.LevelInfo)
+		if err != nil {
+			logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)
+			// Setting default universe domain to googleapis.com in case we are unable to fetch the domain.
+			domain = auth2.UniverseDomainDefault
+		} else {
+			logger.Infof("Success in fetching cred.UniverseDomain: %s", domain)
+		}
 	}
-	logger.Infof("Success in fetching cred.UniverseDomain")
 
 	// Temporary Workaround: We've created a small auth object here that omits the 'quota project ID'
 	// to bypass a known issue (b/442805436) in the current authentication library.


### PR DESCRIPTION
### Description
Under the new library authentication flow, GCSFuse queries the local Metadata Server to resolve the credentials' Universe Domain. During GKE Autopilot scale-up, network initialization timing and lack of metadata server endpoint support on commercial GCP cause this query to persistently time out. GCSFuse wraps this query with its default retry settings (5-minute budget), stalling FUSE volume mounts for 5 minutes during pod creation.

This change bypasses the metadata server query and immediately defaults the domain to "googleapis.com" under standard commercial GCP setups (using ADC with no custom key file, custom endpoint, or custom domain environment variable configured), eliminating the mount stall entirely. For private/sovereign clouds, the active metadata server check and the robust 5-minute retry safety margin are fully preserved.

### Link to the issue in case of a bug fix.
b/500248957

### Testing details
1. Manual: Verified that standard GCP ADC mounts immediately bypass the lookup and log "Bypassing UniverseDomain metadata server lookup...".
2. Unit tests: Verified that all storageutil unit tests pass successfully.
3. Compilation: Verified clean build using "make build".