### PR TITLE
ci(e2e): fix gcloud CLI installation failure on RHEL/Rocky 9

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -44,7 +44,7 @@ if [ -f /etc/os-release ]; then
          if [[ $VERSION_ID =~ ^[89] ]]; then
             echo "Detected version 8/9. Installing Python 3.11 and dependencies..."
             # 'sqlite' and 'libxcrypt-compat' are required dependencies for the gcloud installer on version 9.
-            sudo yum install -y python311 sqlite libxcrypt-compat
+            sudo dnf install -y python3.11 sqlite libxcrypt-compat
             PYTHON_BIN="/usr/bin/python3.11"
         else
             # Default behavior for other versions

--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -42,8 +42,9 @@ if [ -f /etc/os-release ]; then
         
         # Check if we are on version 8 or 9 to install 3.11
          if [[ $VERSION_ID =~ ^[89] ]]; then
-            echo "Detected version 8/9. Installing Python 3.11..."
-            sudo yum install -y python311
+            echo "Detected version 8/9. Installing Python 3.11 and dependencies..."
+            # 'sqlite' and 'libxcrypt-compat' are required dependencies for the gcloud installer on version 9.
+            sudo yum install -y python311 sqlite libxcrypt-compat
             PYTHON_BIN="/usr/bin/python3.11"
         else
             # Default behavior for other versions


### PR DESCRIPTION
### Description
This PR fixes an issue where the E2E test VMs running RHEL 9 / Rocky 9 (both ARM64 and AMD64) fail during the startup script phase. 

The failure occurs when installing the Google Cloud CLI (`gcloud`) using Python 3.11, resulting in the following crash:
> `ImportError: /usr/lib64/python3.11/lib-dynload/_sqlite3...: undefined symbol: sqlite3_deserialize`

To fix this, `sqlite` and `libxcrypt-compat` have been added to the `yum install` list. Explicitly installing `sqlite` natively on RHEL 9 updates the system libraries so that Python 3.11 can find the `sqlite3_deserialize` symbol it expects, allowing the installer to succeed cleanly.

### Link to the issue in case of a bug fix.
b/516801501

### Testing details
1. Manual - Verified the updated `e2e_test.sh` startup script execution on a clean RHEL 9 VM. The Google Cloud CLI installs successfully with Python 3.11 without the SQLite module error.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
