### PR TITLE
feat: add experimental large directory warning threshold

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -605,6 +605,8 @@ type FileSystemConfig struct {
 
 	ExperimentalEnableReaddirplus bool `yaml:"experimental-enable-readdirplus"`
 
+	ExperimentalLargeDirWarningThreshold int64 `yaml:"experimental-large-dir-warning-threshold"`
+
 	ExperimentalODirect bool `yaml:"experimental-o-direct"`
 
 	FileMode Octal `yaml:"file-mode"`
@@ -1103,6 +1105,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.IntP("experimental-grpc-conn-pool-size", "", 1, "The number of gRPC channel in grpc client.")
 
 	if err := flagSet.MarkDeprecated("experimental-grpc-conn-pool-size", "Experimental flag: can be removed in a minor release."); err != nil {
+		return err
+	}
+
+	flagSet.IntP("experimental-large-dir-warning-threshold", "", 0, "Logs a warning when a directory listing contains at least this many entries. Set to 0 to disable.")
+
+	if err := flagSet.MarkHidden("experimental-large-dir-warning-threshold"); err != nil {
 		return err
 	}
 
@@ -1708,6 +1716,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("gcs-connection.grpc-conn-pool-size", flagSet.Lookup("experimental-grpc-conn-pool-size")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.experimental-large-dir-warning-threshold", flagSet.Lookup("experimental-large-dir-warning-threshold")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -432,6 +432,13 @@ params:
     default: false
     hide-flag: true
 
+  - config-path: "file-system.experimental-large-dir-warning-threshold"
+    flag-name: "experimental-large-dir-warning-threshold"
+    type: "int"
+    usage: "Logs a warning when a directory listing contains at least this many entries. Set to 0 to disable."
+    default: "0"
+    hide-flag: true
+
   - config-path: "file-system.experimental-o-direct"
     flag-name: "experimental-o-direct"
     type: "bool"

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -154,6 +154,13 @@ func isValidKernelListCacheTTL(TTLSecs int64) error {
 	return nil
 }
 
+func isValidLargeDirWarningThreshold(threshold int64) error {
+	if threshold < 0 {
+		return fmt.Errorf("experimental-large-dir-warning-threshold should be >= 0")
+	}
+	return nil
+}
+
 func isValidMetadataCache(v *viper.Viper, c *MetadataCacheConfig) error {
 	// Validate ttl-secs.
 	if v.IsSet(MetadataCacheTTLConfigKey) {
@@ -389,6 +396,10 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 
 	if err = isValidKernelListCacheTTL(config.FileSystem.KernelListCacheTtlSecs); err != nil {
 		return fmt.Errorf("error parsing kernel-list-cache-ttl-secs config: %w", err)
+	}
+
+	if err = isValidLargeDirWarningThreshold(config.FileSystem.ExperimentalLargeDirWarningThreshold); err != nil {
+		return fmt.Errorf("error parsing experimental-large-dir-warning-threshold config: %w", err)
 	}
 
 	if err = isValidMetadataCache(v, &config.MetadataCache); err != nil {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -504,6 +504,17 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 			},
 		},
 		{
+			name: "large_dir_warning_threshold_negative",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				FileSystem: FileSystemConfig{ExperimentalLargeDirWarningThreshold: -1},
+			},
+		},
+		{
 			name: "read_stall_req_increase_rate_negative",
 			config: &Config{
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
@@ -39,6 +40,10 @@ type DirEntry interface {
 
 type dirent fuseutil.Dirent
 type direntPlus fuseutil.DirentPlus
+
+type largeDirWarningThresholdProvider interface {
+	LargeDirWarningThreshold() int64
+}
 
 // For Dirent
 func (d *dirent) EntryName() string                  { return d.Name }
@@ -154,6 +159,23 @@ func (dh *DirHandle) checkInvariants() {
 // by name.
 func compareEntriesByName[T DirEntry](a, b T) int {
 	return cmp.Compare(a.EntryName(), b.EntryName())
+}
+
+func maybeLogLargeDirWarning(in inode.DirInode, entryCount int) {
+	provider, ok := in.(largeDirWarningThresholdProvider)
+	if !ok {
+		return
+	}
+	threshold := provider.LargeDirWarningThreshold()
+	if threshold <= 0 || int64(entryCount) < threshold {
+		return
+	}
+
+	logger.Warnf(
+		"Directory %q contains %d entries, meeting experimental large directory warning threshold %d.",
+		in.Name().GcsObjectName(),
+		entryCount,
+		threshold)
 }
 
 // Resolve name conflicts between file objects and directory objects (e.g. the
@@ -297,6 +319,7 @@ func readAllEntries(
 	if err != nil {
 		return nil, err
 	}
+	maybeLogLargeDirWarning(in, len(entries))
 
 	// Return a bogus inode ID for each entry, but not the root inode ID.
 	//
@@ -458,6 +481,7 @@ func (dh *DirHandle) ReadDirPlus(op *fuseops.ReadDirPlusOp, entries []fuseutil.D
 		if err != nil {
 			return
 		}
+		maybeLogLargeDirWarning(dh.in, len(entries))
 		// Update state.
 		dh.entriesPlus = entries
 		dh.entriesPlusValid = true

--- a/internal/fs/handle/dir_handle_test.go
+++ b/internal/fs/handle/dir_handle_test.go
@@ -15,13 +15,17 @@
 package handle
 
 import (
+	"bytes"
 	"context"
+	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
 	cfg2 "github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
@@ -73,8 +77,13 @@ func (t *DirHandleTest) TearDown() {}
 // Helpers
 // //////////////////////////////////////////////////////////////////////
 func (t *DirHandleTest) resetDirHandle() {
+	t.resetDirHandleWithLargeDirWarningThreshold(0)
+}
+
+func (t *DirHandleTest) resetDirHandleWithLargeDirWarningThreshold(threshold int64) {
 	cfg := &cfg2.Config{
 		List:                         cfg2.ListConfig{EnableEmptyManagedFolders: true},
+		FileSystem:                   cfg2.FileSystemConfig{ExperimentalLargeDirWarningThreshold: threshold},
 		MetadataCache:                cfg2.MetadataCacheConfig{TypeCacheMaxSizeMb: 0},
 		EnableHns:                    false,
 		EnableUnsupportedPathSupport: true,
@@ -193,6 +202,38 @@ func (t *DirHandleTest) EnsureEntriesWithOnlyGCSFiles() {
 	AssertEq(2, len(t.dh.entries))
 	t.validateEntry(t.dh.entries[0], "gcsObject1", fuseutil.DT_File)
 	t.validateEntry(t.dh.entries[1], "gcsObject2", fuseutil.DT_File)
+}
+
+func (t *DirHandleTest) EnsureEntriesLogsLargeDirectoryWarningWhenThresholdIsMet() {
+	t.resetDirHandleWithLargeDirWarningThreshold(2)
+	_, err := storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject1", nil)
+	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
+	AssertEq(nil, err)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stderr)
+
+	err = t.dh.ensureEntries(t.ctx, nil)
+
+	AssertEq(nil, err)
+	AssertTrue(strings.Contains(buf.String(), "experimental large directory warning threshold"))
+	AssertTrue(strings.Contains(buf.String(), "contains 2 entries"))
+}
+
+func (t *DirHandleTest) EnsureEntriesDoesNotLogLargeDirectoryWarningWhenDisabled() {
+	_, err := storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject1", nil)
+	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(t.ctx, t.bucket, "testDir/gcsObject2", nil)
+	AssertEq(nil, err)
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stderr)
+
+	err = t.dh.ensureEntries(t.ctx, nil)
+
+	AssertEq(nil, err)
+	AssertFalse(strings.Contains(buf.String(), "experimental large directory warning threshold"))
 }
 
 func (t *DirHandleTest) EnsureEntriesWithOnlyLocalFiles() {
@@ -394,6 +435,32 @@ func (t *DirHandleTest) ReadDirPlusResponseForNoFile() {
 	AssertEq(0, op.BytesRead)
 	AssertTrue(t.dh.entriesPlusValid)
 	AssertEq(0, len(t.dh.entriesPlus))
+}
+
+func (t *DirHandleTest) ReadDirPlusLogsLargeDirectoryWarningWhenThresholdIsMet() {
+	t.resetDirHandleWithLargeDirWarningThreshold(2)
+	op := &fuseops.ReadDirPlusOp{
+		ReadDirOp: fuseops.ReadDirOp{Dst: make([]byte, 1024)},
+	}
+	gcsEntries := []fuseutil.DirentPlus{
+		{
+			Dirent: fuseutil.Dirent{Name: "gcsObject1", Type: fuseutil.DT_File},
+			Entry:  fuseops.ChildInodeEntry{Child: 1001},
+		},
+		{
+			Dirent: fuseutil.Dirent{Name: "gcsObject2", Type: fuseutil.DT_File},
+			Entry:  fuseops.ChildInodeEntry{Child: 1002},
+		},
+	}
+	var buf bytes.Buffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stderr)
+
+	err := t.dh.ReadDirPlus(op, gcsEntries, nil)
+
+	AssertEq(nil, err)
+	AssertTrue(strings.Contains(buf.String(), "experimental large directory warning threshold"))
+	AssertTrue(strings.Contains(buf.String(), "contains 2 entries"))
 }
 
 func (t *DirHandleTest) ReadDirPlusSameNameLocalAndGCSFile() {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -273,6 +273,7 @@ type dirInode struct {
 	includeFoldersAsPrefixes   bool
 	enableNonexistentTypeCache bool
 	isHNSEnabled               bool
+	largeDirWarningThreshold   int64
 
 	// activeWriters tracks the number of ongoing write operations in this directory.
 	// It is used to prevent metadata prefetching while writes are in progress.
@@ -351,6 +352,7 @@ func NewDirInode(
 		ctx:                                    ctx,
 		cancel:                                 cancel,
 		metadataCacheTtlSecs:                   cfg.MetadataCache.TtlSecs,
+		largeDirWarningThreshold:               cfg.FileSystem.ExperimentalLargeDirWarningThreshold,
 	}
 
 	// Init Prefetcher only if it is enabled, stat cache ttl != 0 and stat cache size != 0.
@@ -590,6 +592,10 @@ func (d *dirInode) ID() fuseops.InodeID {
 
 func (d *dirInode) Name() Name {
 	return d.name
+}
+
+func (d *dirInode) LargeDirWarningThreshold() int64 {
+	return d.largeDirWarningThreshold
 }
 
 // LOCKS_REQUIRED(d)


### PR DESCRIPTION
## What

Adds a hidden experimental `--experimental-large-dir-warning-threshold` flag / config field under `file-system`. When the threshold is greater than zero, directory reads log a warning after the final directory entry list reaches or exceeds the threshold. A value of `0` keeps the behavior disabled.

This covers the warning signal requested in #4696 without changing write-path behavior or claiming to solve the full large-directory guard/streaming work.

## Validation

- `go test ./cfg`
- `docker run --rm -v "$PWD":/work -v gcsfuse-go-mod-cache:/go/pkg/mod -v gcsfuse-go-build-cache:/root/.cache/go-build -w /work golang:1.26.3 go test ./cfg ./internal/fs/inode ./internal/fs/handle`
- `git diff --check`

Updates #4696