### PR TITLE
feat(cfg): add safe configuration and storage API for MRD connection pool autoscaling

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -718,7 +718,15 @@ type MetricsConfig struct {
 }
 
 type MrdConfig struct {
+	MaxConnections int64 `yaml:"max-connections"`
+
+	MinConnections int64 `yaml:"min-connections"`
+
 	PoolSize int64 `yaml:"pool-size"`
+
+	TargetPendingBytes int64 `yaml:"target-pending-bytes"`
+
+	TargetPendingRanges int64 `yaml:"target-pending-ranges"`
 }
 
 type ReadConfig struct {
@@ -1267,9 +1275,33 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.IntP("mrd-max-connections", "", 0, "The maximum number of concurrent TCP connections allowed for Multi-Range Downloader.")
+
+	if err := flagSet.MarkHidden("mrd-max-connections"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("mrd-min-connections", "", 0, "The minimum number of concurrent TCP connections allowed for Multi-Range Downloader.")
+
+	if err := flagSet.MarkHidden("mrd-min-connections"); err != nil {
+		return err
+	}
+
 	flagSet.IntP("mrd-pool-size", "", 4, "Specifies the MRD pool size to be used for zonal buckets. The value should be more than 0.")
 
 	if err := flagSet.MarkHidden("mrd-pool-size"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("mrd-target-pending-bytes", "", 0, "The target threshold for pending bytes to trigger Multi-Range Downloader autoscaling.")
+
+	if err := flagSet.MarkHidden("mrd-target-pending-bytes"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("mrd-target-pending-ranges", "", 0, "The target threshold for pending ranges to trigger Multi-Range Downloader autoscaling.")
+
+	if err := flagSet.MarkHidden("mrd-target-pending-ranges"); err != nil {
 		return err
 	}
 
@@ -1884,7 +1916,23 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	if err := v.BindPFlag("mrd.max-connections", flagSet.Lookup("mrd-max-connections")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("mrd.min-connections", flagSet.Lookup("mrd-min-connections")); err != nil {
+		return err
+	}
+
 	if err := v.BindPFlag("mrd.pool-size", flagSet.Lookup("mrd-pool-size")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("mrd.target-pending-bytes", flagSet.Lookup("mrd-target-pending-bytes")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("mrd.target-pending-ranges", flagSet.Lookup("mrd-target-pending-ranges")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -718,10 +718,6 @@ type MetricsConfig struct {
 }
 
 type MrdConfig struct {
-	MaxConnections int64 `yaml:"max-connections"`
-
-	MinConnections int64 `yaml:"min-connections"`
-
 	PoolSize int64 `yaml:"pool-size"`
 
 	TargetPendingBytes int64 `yaml:"target-pending-bytes"`
@@ -1275,31 +1271,19 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("mrd-max-connections", "", 0, "The maximum number of concurrent TCP connections allowed for Multi-Range Downloader.")
-
-	if err := flagSet.MarkHidden("mrd-max-connections"); err != nil {
-		return err
-	}
-
-	flagSet.IntP("mrd-min-connections", "", 0, "The minimum number of concurrent TCP connections allowed for Multi-Range Downloader.")
-
-	if err := flagSet.MarkHidden("mrd-min-connections"); err != nil {
-		return err
-	}
-
 	flagSet.IntP("mrd-pool-size", "", 4, "Specifies the MRD pool size to be used for zonal buckets. The value should be more than 0.")
 
 	if err := flagSet.MarkHidden("mrd-pool-size"); err != nil {
 		return err
 	}
 
-	flagSet.IntP("mrd-target-pending-bytes", "", 0, "The target threshold for pending bytes to trigger Multi-Range Downloader autoscaling.")
+	flagSet.IntP("mrd-target-pending-bytes", "", 10485760, "The target threshold for pending bytes to trigger Multi-Range Downloader autoscaling.")
 
 	if err := flagSet.MarkHidden("mrd-target-pending-bytes"); err != nil {
 		return err
 	}
 
-	flagSet.IntP("mrd-target-pending-ranges", "", 0, "The target threshold for pending ranges to trigger Multi-Range Downloader autoscaling.")
+	flagSet.IntP("mrd-target-pending-ranges", "", 20, "The target threshold for pending ranges to trigger Multi-Range Downloader autoscaling.")
 
 	if err := flagSet.MarkHidden("mrd-target-pending-ranges"); err != nil {
 		return err
@@ -1913,14 +1897,6 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metrics.workers", flagSet.Lookup("metrics-workers")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("mrd.max-connections", flagSet.Lookup("mrd-max-connections")); err != nil {
-		return err
-	}
-
-	if err := v.BindPFlag("mrd.min-connections", flagSet.Lookup("mrd-min-connections")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1121,12 +1121,40 @@ params:
     default: "3"
     hide-flag: true
 
+  - config-path: "mrd.max-connections"
+    flag-name: "mrd-max-connections"
+    type: "int"
+    usage: "The maximum number of concurrent TCP connections allowed for Multi-Range Downloader."
+    default: "0"
+    hide-flag: true
+
+  - config-path: "mrd.min-connections"
+    flag-name: "mrd-min-connections"
+    type: "int"
+    usage: "The minimum number of concurrent TCP connections allowed for Multi-Range Downloader."
+    default: "0"
+    hide-flag: true
+
   - config-path: "mrd.pool-size"
     flag-name: "mrd-pool-size"
     type: "int"
     usage: >-
       Specifies the MRD pool size to be used for zonal buckets. The value should be more than 0.
     default: "4"
+    hide-flag: true
+
+  - config-path: "mrd.target-pending-bytes"
+    flag-name: "mrd-target-pending-bytes"
+    type: "int"
+    usage: "The target threshold for pending bytes to trigger Multi-Range Downloader autoscaling."
+    default: "0"
+    hide-flag: true
+
+  - config-path: "mrd.target-pending-ranges"
+    flag-name: "mrd-target-pending-ranges"
+    type: "int"
+    usage: "The target threshold for pending ranges to trigger Multi-Range Downloader autoscaling."
+    default: "0"
     hide-flag: true
 
   - config-path: "only-dir"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1121,40 +1121,26 @@ params:
     default: "3"
     hide-flag: true
 
-  - config-path: "mrd.max-connections"
-    flag-name: "mrd-max-connections"
-    type: "int"
-    usage: "The maximum number of concurrent TCP connections allowed for Multi-Range Downloader."
-    default: "0"
-    hide-flag: true
-
-  - config-path: "mrd.min-connections"
-    flag-name: "mrd-min-connections"
-    type: "int"
-    usage: "The minimum number of concurrent TCP connections allowed for Multi-Range Downloader."
-    default: "0"
-    hide-flag: true
-
   - config-path: "mrd.pool-size"
     flag-name: "mrd-pool-size"
     type: "int"
     usage: >-
       Specifies the MRD pool size to be used for zonal buckets. The value should be more than 0.
-    default: "4"
+    default: 4
     hide-flag: true
 
   - config-path: "mrd.target-pending-bytes"
     flag-name: "mrd-target-pending-bytes"
     type: "int"
     usage: "The target threshold for pending bytes to trigger Multi-Range Downloader autoscaling."
-    default: "0"
+    default: 10485760
     hide-flag: true
 
   - config-path: "mrd.target-pending-ranges"
     flag-name: "mrd-target-pending-ranges"
     type: "int"
     usage: "The target threshold for pending ranges to trigger Multi-Range Downloader autoscaling."
-    default: "0"
+    default: 20
     hide-flag: true
 
   - config-path: "only-dir"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -166,6 +166,19 @@ func resolveGCSRetriesConfig(c *GcsRetriesConfig) {
 	}
 }
 
+func resolveMrdConfig(v *viper.Viper, c *MrdConfig) {
+	if !v.IsSet("mrd.target-pending-ranges") && c.TargetPendingRanges == 0 {
+		if c.TargetPendingBytes == 0 {
+			c.TargetPendingRanges = 20
+		}
+	}
+	if !v.IsSet("mrd.target-pending-bytes") && c.TargetPendingBytes == 0 {
+		if c.TargetPendingRanges == 0 || c.TargetPendingRanges == 20 {
+			c.TargetPendingBytes = 10 * 1024 * 1024 // 10MB
+		}
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	var err error
@@ -187,6 +200,6 @@ func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	resolveParallelDownloadsValue(v, &c.FileCache, c)
 	resolveFileCacheAndBufferedReadConflict(v, c)
 	resolveGCSRetriesConfig(&c.GcsRetries)
-
+	resolveMrdConfig(v, &c.Mrd)
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -901,3 +901,111 @@ func TestRationalize_MetadataCacheConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestRationalize_MrdConfig(t *testing.T) {
+	testCases := []struct {
+		name              string
+		setupViper        func(v *viper.Viper)
+		config            *Config
+		expectedMrdConfig MrdConfig
+	}{
+		{
+			name:       "default_values_no_user_input",
+			setupViper: func(v *viper.Viper) {},
+			config: &Config{
+				Mrd: MrdConfig{
+					PoolSize: 4,
+				},
+			},
+			expectedMrdConfig: MrdConfig{
+				PoolSize:            4,
+				TargetPendingRanges: 20,
+				TargetPendingBytes:  10 * 1024 * 1024,
+			},
+		},
+		{
+			name: "user_configured_dynamic_pool_only_bytes",
+			setupViper: func(v *viper.Viper) {
+				v.Set("mrd.target-pending-bytes", 1024)
+			},
+			config: &Config{
+				Mrd: MrdConfig{
+					PoolSize:            4,
+					TargetPendingBytes:  1024,
+					TargetPendingRanges: 0,
+				},
+			},
+			expectedMrdConfig: MrdConfig{
+				PoolSize:            4,
+				TargetPendingRanges: 0,
+				TargetPendingBytes:  1024,
+			},
+		},
+		{
+			name: "user_configured_dynamic_pool_only_ranges",
+			setupViper: func(v *viper.Viper) {
+				v.Set("mrd.target-pending-ranges", 5)
+			},
+			config: &Config{
+				Mrd: MrdConfig{
+					PoolSize:            4,
+					TargetPendingRanges: 5,
+					TargetPendingBytes:  0,
+				},
+			},
+			expectedMrdConfig: MrdConfig{
+				PoolSize:            4,
+				TargetPendingRanges: 5,
+				TargetPendingBytes:  0,
+			},
+		},
+		{
+			name: "user_configured_only_pool_size",
+			setupViper: func(v *viper.Viper) {
+				v.Set("mrd.pool-size", 8)
+			},
+			config: &Config{
+				Mrd: MrdConfig{
+					PoolSize: 8,
+				},
+			},
+			expectedMrdConfig: MrdConfig{
+				PoolSize:            8,
+				TargetPendingRanges: 20,
+				TargetPendingBytes:  10 * 1024 * 1024,
+			},
+		},
+		{
+			// Setting both triggers to 0 disables autoscaling, which instructs the
+			// downloader wrapper to configure a static connection pool of size PoolSize.
+			name: "user_explicitly_disables_triggers",
+			setupViper: func(v *viper.Viper) {
+				v.Set("mrd.target-pending-ranges", 0)
+				v.Set("mrd.target-pending-bytes", 0)
+			},
+			config: &Config{
+				Mrd: MrdConfig{
+					PoolSize:            4,
+					TargetPendingRanges: 0,
+					TargetPendingBytes:  0,
+				},
+			},
+			expectedMrdConfig: MrdConfig{
+				PoolSize:            4,
+				TargetPendingRanges: 0,
+				TargetPendingBytes:  0,
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			tc.setupViper(v)
+			err := Rationalize(v, tc.config, []string{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedMrdConfig, tc.config.Mrd)
+		})
+	}
+}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -300,6 +300,21 @@ func isValidMRDConfig(mrdConfig *MrdConfig) error {
 	if mrdConfig.PoolSize < 1 {
 		return fmt.Errorf("invalid value of mrd-pool-size: %d; should be >=1", mrdConfig.PoolSize)
 	}
+	if mrdConfig.MinConnections < 0 {
+		return fmt.Errorf("invalid value of min-connections: %d; should be >=0", mrdConfig.MinConnections)
+	}
+	if mrdConfig.MaxConnections < 0 {
+		return fmt.Errorf("invalid value of max-connections: %d; should be >=0", mrdConfig.MaxConnections)
+	}
+	if mrdConfig.MinConnections > 0 && mrdConfig.MaxConnections > 0 && mrdConfig.MinConnections > mrdConfig.MaxConnections {
+		return fmt.Errorf("min-connections (%d) cannot be greater than max-connections (%d)", mrdConfig.MinConnections, mrdConfig.MaxConnections)
+	}
+	if mrdConfig.TargetPendingRanges < 0 {
+		return fmt.Errorf("invalid value of target-pending-ranges: %d; should be >=0", mrdConfig.TargetPendingRanges)
+	}
+	if mrdConfig.TargetPendingBytes < 0 {
+		return fmt.Errorf("invalid value of target-pending-bytes: %d; should be >=0", mrdConfig.TargetPendingBytes)
+	}
 	return nil
 }
 

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -300,18 +300,6 @@ func isValidMRDConfig(mrdConfig *MrdConfig) error {
 	if mrdConfig.PoolSize < 1 {
 		return fmt.Errorf("invalid value of mrd-pool-size: %d; should be >=1", mrdConfig.PoolSize)
 	}
-	if mrdConfig.MinConnections < 0 {
-		return fmt.Errorf("invalid value of min-connections: %d; should be >=0", mrdConfig.MinConnections)
-	}
-	if mrdConfig.MaxConnections < 0 {
-		return fmt.Errorf("invalid value of max-connections: %d; should be >=0", mrdConfig.MaxConnections)
-	}
-	if mrdConfig.MinConnections > 0 && mrdConfig.MaxConnections == 0 {
-		return fmt.Errorf("max-connections must be specified when min-connections (%d) is set", mrdConfig.MinConnections)
-	}
-	if mrdConfig.MinConnections > 0 && mrdConfig.MaxConnections > 0 && mrdConfig.MinConnections > mrdConfig.MaxConnections {
-		return fmt.Errorf("min-connections (%d) cannot be greater than max-connections (%d)", mrdConfig.MinConnections, mrdConfig.MaxConnections)
-	}
 	if mrdConfig.TargetPendingRanges < 0 {
 		return fmt.Errorf("invalid value of target-pending-ranges: %d; should be >=0", mrdConfig.TargetPendingRanges)
 	}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -306,6 +306,9 @@ func isValidMRDConfig(mrdConfig *MrdConfig) error {
 	if mrdConfig.MaxConnections < 0 {
 		return fmt.Errorf("invalid value of max-connections: %d; should be >=0", mrdConfig.MaxConnections)
 	}
+	if mrdConfig.MinConnections > 0 && mrdConfig.MaxConnections == 0 {
+		return fmt.Errorf("max-connections must be specified when min-connections (%d) is set", mrdConfig.MinConnections)
+	}
 	if mrdConfig.MinConnections > 0 && mrdConfig.MaxConnections > 0 && mrdConfig.MinConnections > mrdConfig.MaxConnections {
 		return fmt.Errorf("min-connections (%d) cannot be greater than max-connections (%d)", mrdConfig.MinConnections, mrdConfig.MaxConnections)
 	}

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -876,6 +876,58 @@ func Test_isValidMRDConfig(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid_min_connections_negative",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MinConnections: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_max_connections_negative",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MaxConnections: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_min_connections_greater_than_max",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MinConnections: 5,
+				MaxConnections: 2,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_target_pending_ranges_negative",
+			mrdConfig: MrdConfig{
+				PoolSize:            1,
+				TargetPendingRanges: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_target_pending_bytes_negative",
+			mrdConfig: MrdConfig{
+				PoolSize:           1,
+				TargetPendingBytes: -1,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid_autoscaling_params",
+			mrdConfig: MrdConfig{
+				PoolSize:            1,
+				MinConnections:      2,
+				MaxConnections:      5,
+				TargetPendingRanges: 1,
+				TargetPendingBytes:  1024,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -877,58 +877,6 @@ func Test_isValidMRDConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "invalid_min_connections_negative",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MinConnections: -1,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid_max_connections_negative",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MaxConnections: -1,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid_min_connections_greater_than_max",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MinConnections: 5,
-				MaxConnections: 2,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid_min_connections_without_max_connections_large",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MinConnections: 5,
-				MaxConnections: 0,
-			},
-			wantErr: true,
-		},
-		{
-			name: "invalid_min_connections_without_max_connections_small",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MinConnections: 2,
-				MaxConnections: 0,
-			},
-			wantErr: true,
-		},
-		{
-			name: "valid_both_connections_zero",
-			mrdConfig: MrdConfig{
-				PoolSize:       1,
-				MinConnections: 0,
-				MaxConnections: 0,
-			},
-			wantErr: false,
-		},
-		{
 			name: "invalid_target_pending_ranges_negative",
 			mrdConfig: MrdConfig{
 				PoolSize:            1,
@@ -943,17 +891,6 @@ func Test_isValidMRDConfig(t *testing.T) {
 				TargetPendingBytes: -1,
 			},
 			wantErr: true,
-		},
-		{
-			name: "valid_autoscaling_params",
-			mrdConfig: MrdConfig{
-				PoolSize:            1,
-				MinConnections:      2,
-				MaxConnections:      5,
-				TargetPendingRanges: 1,
-				TargetPendingBytes:  1024,
-			},
-			wantErr: false,
 		},
 	}
 

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -902,6 +902,33 @@ func Test_isValidMRDConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "invalid_min_connections_without_max_connections_large",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MinConnections: 5,
+				MaxConnections: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "invalid_min_connections_without_max_connections_small",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MinConnections: 2,
+				MaxConnections: 0,
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid_both_connections_zero",
+			mrdConfig: MrdConfig{
+				PoolSize:       1,
+				MinConnections: 0,
+				MaxConnections: 0,
+			},
+			wantErr: false,
+		},
+		{
 			name: "invalid_target_pending_ranges_negative",
 			mrdConfig: MrdConfig{
 				PoolSize:            1,

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -243,6 +243,12 @@ type MultiRangeDownloaderRequest struct {
 
 	// ReadHandle associated with the object. This would be periodically refreshed.
 	ReadHandle []byte
+
+	// Multistream autoscaling settings.
+	MinConnections      int
+	MaxConnections      int
+	TargetPendingRanges int
+	TargetPendingBytes  int
 }
 
 type StatObjectRequest struct {

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -245,10 +245,10 @@ type MultiRangeDownloaderRequest struct {
 	ReadHandle []byte
 
 	// Multistream autoscaling settings.
-	MinConnections      int
-	MaxConnections      int
-	TargetPendingRanges int
-	TargetPendingBytes  int
+	MinConnections      int64
+	MaxConnections      int64
+	TargetPendingRanges int64
+	TargetPendingBytes  int64
 }
 
 type StatObjectRequest struct {


### PR DESCRIPTION
### Description

This PR introduces the new configuration parameters, validation logic, and storage layer interface fields for the Multi-Range Downloader (MRD) connection pool autoscaling feature.

Specifically, it adds:
* `mrd.target-pending-bytes` (hidden): The target threshold for pending bytes to trigger autoscaling.
* `mrd.target-pending-ranges` (hidden): The target threshold for pending ranges to trigger autoscaling.

Note: In this simplified approach, the `min-connections` and `max-connections` configuration options are not exposed to the user. Instead:
* `min-connections` defaults to `1` internally.
* `max-connections` defaults to the user-configured `mrd.pool-size`.
This ensures that the connection pool autoscaling behavior is controlled safely through the existing `pool-size` config.

### Default Values
If the user does not explicitly override the settings, GCSFuse defaults to the following autoscaling parameters:
* `mrd.pool-size` (acting as maximum connections): `4`
* Minimum connections: `1`
* `mrd.target-pending-ranges`: `20`
* `mrd.target-pending-bytes`: `10MB` (10,485,760 bytes)

This PR is the first of a multi-part series splitting the overall connection pool autoscaling implementation. It is purely declarative and safe; because these fields are not yet wired up in the downloader wrapper or instance code, they have zero functional runtime impact on existing codepaths.

### Link to the issue in case of a bug fix.

b/504489809

### Testing details
1. Manual - Verified clean compilation of the entire codebase (`go build ./...` and basic layout validation).
2. Unit tests - Verified that all `cfg` package unit tests pass successfully, covering the new configuration boundaries and combinations.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

N/A
