### PR TITLE
test(mount_timeout): skip tests if buckets are not accessible

### DIFF
--- a/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/gcsfuse_mount_timeout_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/util"
@@ -238,6 +239,9 @@ func unmountAndWait(mountDir string) error {
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountMultiRegionUSBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, multiRegionUSBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", multiRegionUSBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -264,6 +268,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountMultiRegionUSBucketWithTimeout(
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountMultiRegionAsiaBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, multiRegionAsiaBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", multiRegionAsiaBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -290,6 +297,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountMultiRegionAsiaBucketWithTimeou
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountDualRegionUSBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, dualRegionUSBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", dualRegionUSBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -316,6 +326,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountDualRegionUSBucketWithTimeout()
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountDualRegionAsiaBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, dualRegionAsiaBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", dualRegionAsiaBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -342,6 +355,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountDualRegionAsiaBucketWithTimeout
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionUSBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, singleRegionUSCentralBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", singleRegionUSCentralBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -368,6 +384,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionUSBucketWithTimeout
 }
 
 func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, singleRegionAsiaEastBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", singleRegionAsiaEastBucket)
+	}
 	testCases := []struct {
 		name           string
 		clientProtocol cfg.Protocol
@@ -394,6 +413,9 @@ func (testSuite *NonZBMountTimeoutTest) TestMountSingleRegionAsiaBucketWithTimeo
 }
 
 func (testSuite *ZBMountTimeoutTest) TestMountSameZoneZonalBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, testSuite.config.sameZoneZonalBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", testSuite.config.sameZoneZonalBucket)
+	}
 	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "SameZoneZonalBucket"))
 
 	err := testSuite.mountOrTimeout(testSuite.config.sameZoneZonalBucket, string(cfg.GRPC), testSuite.config.sameZoneMountTimeout)
@@ -401,6 +423,9 @@ func (testSuite *ZBMountTimeoutTest) TestMountSameZoneZonalBucketWithTimeout() {
 }
 
 func (testSuite *ZBMountTimeoutTest) TestMountCrossZoneZonalBucketWithTimeout() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, testSuite.config.crossZoneZonalBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", testSuite.config.crossZoneZonalBucket)
+	}
 	setup.SetLogFile(fmt.Sprintf("%s%s.txt", logfilePathPrefix, "CrossZoneZonalBucket"))
 
 	err := testSuite.mountOrTimeout(testSuite.config.crossZoneZonalBucket, string(cfg.GRPC), testSuite.config.crossZoneMountTimeout)

--- a/tools/integration_tests/mount_timeout/mount_access_test.go
+++ b/tools/integration_tests/mount_timeout/mount_access_test.go
@@ -21,6 +21,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -81,6 +82,9 @@ func (testSuite *MountAccessTest) mountWithKeyFile(bucketName, keyFile string) (
 }
 
 func (testSuite *MountAccessTest) TestMountingWithMinimalAccessSucceeds() {
+	if !client.CheckBucketAccess(gCtx, gStorageClient, testBucket) {
+		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", testBucket)
+	}
 	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(gCtx)
 	defer func() {
 		if err := os.Remove(localKeyFilePath); err != nil {

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -745,3 +745,17 @@ func ListDirectory(ctx context.Context, client *storage.Client, bucketName, pref
 
 	return uniqueEntries, nil
 }
+
+// CheckBucketAccess checks if the given bucket is accessible using the provided storage client.
+func CheckBucketAccess(ctx context.Context, client *storage.Client, bucketName string) bool {
+	if bucketName == "" {
+		return false
+	}
+	bucket := getBucketHandle(client, bucketName)
+	_, err := bucket.Attrs(ctx)
+	if err != nil {
+		log.Printf("CheckBucketAccess: bucket %q not accessible: %v", bucketName, err)
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
### Description
This PR makes the `mount_timeout` integration tests robust against missing bucket permissions in the test environment.

### Link to the issue in case of a bug fix.
b/518338525

### Testing details
1. Manual - Verified that running the tests in an environment that lacks bucket permissions skips those tests but doesn't skip when permissions are there. Some of the test cases in the former environment still failed but that's due to `permission:secretmanager.versions.access` access not being present.
2. Unit tests - N/A
3. Integration tests - Run via presubmit

### Any backward incompatible change? If so, please explain.
No