### PR TITLE
test(e2e): pass PROJECT in Makefile to e2e-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,4 +88,4 @@ e2e-test:
 	echo $$ZONE; \
 	REGION=$$(echo $$ZONE | sed 's/-[a-z]$$//'); \
 	echo $$REGION; \
-	tools/integration_tests/improved_run_e2e_tests.sh --bucket-location $$REGION
+	tools/integration_tests/improved_run_e2e_tests.sh --bucket-location $$REGION $(if $(PROJECT),--project-id $(PROJECT))


### PR DESCRIPTION
### Description

Update the `e2e-test` target in the `Makefile` to dynamically pass the `PROJECT` variable as `--project-id $(PROJECT)` to the underlying integration test script `improved_run_e2e_tests.sh`. This allows specifying custom Google Cloud projects for end-to-end testing directly from the Makefile command.

### Link to the issue in case of a bug fix.

N/A

### Testing details
1. Manual - Dry-run verified that the expansion works as expected under different scenarios:
   - `make -n e2e-test PROJECT=my-test-project` -> appends `--project-id my-test-project`
   - `make -n e2e-test` -> appends `--project-id <active-gcloud-project>`
   - `make -n e2e-test PROJECT=""` -> does not append `--project-id`
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

No.
