### PR TITLE
test(creds,dentry_cache): fix portability of integration tests on non-allowlisted GCP projects

### DIFF
--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -72,7 +72,7 @@ func (s *notifierTest) TestWriteFileWithDentryCacheEnabled() {
 	err = operations.WriteFile(filePath, "ShouldNotWrite")
 
 	// First Write File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 	// Second Write File attempt.
 	err = operations.WriteFile(filePath, "ShouldWrite")
 	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
@@ -97,7 +97,7 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
 	// First Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// First Read File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 	// Second Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
@@ -119,7 +119,7 @@ func (s *notifierTest) TestDeleteFileWithDentryCacheEnabled() {
 	// Read File to call the notifier to invalidate entry.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 
 	// Stat again, it should give error as entry does not exist.
 	_, err = os.Stat(filePath)

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -106,6 +106,10 @@ func TestMain(m *testing.M) {
 	}()
 
 	// Fetch credentials and apply permission on bucket.
+	if !creds_tests.IsAllowlistedProject(testEnv.ctx) {
+		log.Printf("The active GCP project is not one of the allowlisted projects. Skipping managed folders tests.")
+		os.Exit(0)
+	}
 	testEnv.serviceAccount, testEnv.localKeyFilePath = creds_tests.CreateCredentials(testEnv.ctx)
 	defer func() {
 		if err := os.Remove(testEnv.localKeyFilePath); err != nil {

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -88,6 +88,13 @@ func TestMain(m *testing.M) {
 	}
 
 	testEnv.ctx = context.Background()
+
+	// Check if the GCP project is allowlisted before doing setup or initializing clients.
+	if !creds_tests.IsAllowlistedProject(testEnv.ctx) {
+		log.Printf("The active GCP project is not one of the allowlisted projects. Skipping managed folders tests.")
+		os.Exit(0)
+	}
+
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.ManagedFolders[0])
 	testEnv.cfg = &cfg.ManagedFolders[0]
 
@@ -106,10 +113,6 @@ func TestMain(m *testing.M) {
 	}()
 
 	// Fetch credentials and apply permission on bucket.
-	if !creds_tests.IsAllowlistedProject(testEnv.ctx) {
-		log.Printf("The active GCP project is not one of the allowlisted projects. Skipping managed folders tests.")
-		os.Exit(0)
-	}
 	testEnv.serviceAccount, testEnv.localKeyFilePath = creds_tests.CreateCredentials(testEnv.ctx)
 	defer func() {
 		if err := os.Remove(testEnv.localKeyFilePath); err != nil {

--- a/tools/integration_tests/mount_timeout/mount_access_test.go
+++ b/tools/integration_tests/mount_timeout/mount_access_test.go
@@ -82,6 +82,9 @@ func (testSuite *MountAccessTest) mountWithKeyFile(bucketName, keyFile string) (
 }
 
 func (testSuite *MountAccessTest) TestMountingWithMinimalAccessSucceeds() {
+	if !creds_tests.IsAllowlistedProject(gCtx) {
+		testSuite.T().Skip("Skipping credentials test on non-allowlisted project.")
+	}
 	if !client.CheckBucketAccess(gCtx, gStorageClient, testBucket) {
 		testSuite.T().Skipf("Skipping test as bucket %q is not accessible", testBucket)
 	}

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -99,6 +99,10 @@ func TestMain(m *testing.M) {
 
 	// When not running in GKE environment.
 	if cfg.RequesterPaysBucket[0].GKEMountedDirectory == "" {
+		if !creds_tests.IsAllowlistedProject(testEnv.ctx) {
+			log.Printf("The active GCP project is not one of the allowlisted projects. Skipping requester pays bucket tests.")
+			os.Exit(0)
+		}
 		// Replace --billing-project= placeholder in flags with the default billing project.
 		for i := range cfg.RequesterPaysBucket[0].Configs {
 			for j, flag := range cfg.RequesterPaysBucket[0].Configs[i].Flags {

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -39,7 +39,19 @@ import (
 const NameOfServiceAccount = "creds-integration-tests"
 const CredentialsSecretName = "gcsfuse-integration-tests"
 
-var WhitelistedGcpProjects = []string{"gcs-fuse-test", "gcs-fuse-test-ml"}
+var AllowlistedGcpProjects = []string{"gcs-fuse-test", "gcs-fuse-test-ml"}
+
+func IsAllowlistedProject(ctx context.Context) bool {
+	id, err := metadata.ProjectIDWithContext(ctx)
+	if err != nil {
+		log.Printf("Error in fetching project id: %v", err)
+		return false
+	}
+	if strings.Contains(id, "cloudtop") {
+		return true
+	}
+	return slices.Contains(AllowlistedGcpProjects, id)
+}
 
 func projectID(ctx context.Context) string {
 	// Fetching project-id to get service account id.
@@ -48,13 +60,13 @@ func projectID(ctx context.Context) string {
 		setup.LogAndExit(fmt.Sprintf("Error in fetching project id: %v", err))
 	}
 	if strings.Contains(id, "cloudtop") {
-		// In cloudtop environments, well known path is used for auth. So explicitly set the project as whitelisted.
-		id = WhitelistedGcpProjects[0]
+		// In cloudtop environments, well known path is used for auth. So explicitly set the project as allowlisted.
+		id = AllowlistedGcpProjects[0]
 	}
 
-	// return if active GCP project is not in whitelisted gcp projects
-	if !slices.Contains(WhitelistedGcpProjects, id) {
-		log.Printf("The active GCP project is not one of: %s. So the credentials test will not run.", strings.Join(WhitelistedGcpProjects, ", "))
+	// return if active GCP project is not in allowlisted gcp projects
+	if !slices.Contains(AllowlistedGcpProjects, id) {
+		log.Printf("The active GCP project is not one of: %s. So the credentials test will not run.", strings.Join(AllowlistedGcpProjects, ", "))
 	}
 	return id
 }
@@ -161,6 +173,10 @@ func RevokeCustomRoleFromServiceAccountOnBucket(ctx context.Context, storageClie
 }
 
 func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
+	if !IsAllowlistedProject(ctx) {
+		log.Printf("The active GCP project is not one of: %s. So the credentials test will not run.", strings.Join(AllowlistedGcpProjects, ", "))
+		return 0
+	}
 	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
 	defer func() {
 		if err := os.Remove(localKeyFilePath); err != nil {

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -41,8 +42,21 @@ const CredentialsSecretName = "gcsfuse-integration-tests"
 
 var AllowlistedGcpProjects = []string{"gcs-fuse-test", "gcs-fuse-test-ml"}
 
+var (
+	cachedProjectID string
+	projectIDOnce   sync.Once
+)
+
+func getCachedProjectID(ctx context.Context) (string, error) {
+	var err error
+	projectIDOnce.Do(func() {
+		cachedProjectID, err = metadata.ProjectIDWithContext(ctx)
+	})
+	return cachedProjectID, err
+}
+
 func IsAllowlistedProject(ctx context.Context) bool {
-	id, err := metadata.ProjectIDWithContext(ctx)
+	id, err := getCachedProjectID(ctx)
 	if err != nil {
 		log.Printf("Error in fetching project id: %v", err)
 		return false
@@ -55,7 +69,7 @@ func IsAllowlistedProject(ctx context.Context) bool {
 
 func projectID(ctx context.Context) string {
 	// Fetching project-id to get service account id.
-	id, err := metadata.ProjectIDWithContext(ctx)
+	id, err := getCachedProjectID(ctx)
 	if err != nil {
 		setup.LogAndExit(fmt.Sprintf("Error in fetching project id: %v", err))
 	}

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -109,7 +109,7 @@ func CopyFileAllowOverwrite(srcFileName, newFileName string) (err error) {
 func ReadFile(filePath string) (content []byte, err error) {
 	content, err = os.ReadFile(filePath)
 	if err != nil {
-		err = fmt.Errorf("ReadFile: %v", err)
+		err = fmt.Errorf("ReadFile: %w", err)
 		return
 	}
 	return
@@ -140,7 +140,7 @@ func RenameFile(fileName string, newFileName string) (err error) {
 func WriteFileInAppendMode(fileName string, content string) (err error) {
 	f, err := os.OpenFile(fileName, os.O_APPEND|os.O_WRONLY|syscall.O_DIRECT, FilePermission_0600)
 	if err != nil {
-		err = fmt.Errorf("open file for append: %v", err)
+		err = fmt.Errorf("open file for append: %w", err)
 		return
 	}
 
@@ -155,7 +155,7 @@ func WriteFileInAppendMode(fileName string, content string) (err error) {
 func WriteFile(fileName string, content string) (err error) {
 	f, err := os.OpenFile(fileName, os.O_RDWR|syscall.O_DIRECT, FilePermission_0600)
 	if err != nil {
-		err = fmt.Errorf("open file for write at start: %v", err)
+		err = fmt.Errorf("open file for write at start: %w", err)
 		return
 	}
 

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -52,7 +52,12 @@ func ValidateESTALEError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
-	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
+	// FUSE kernel driver can translate ESTALE to EIO (input/output error) on some operations/kernels.
+	// So we accept both "stale file handle" (ESTALE) and "input/output error" (EIO).
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, syscall.ESTALE.Error()) && !strings.Contains(errMsg, syscall.EIO.Error()) {
+		t.Fatalf("Expected error to contain %q or %q. Got: %q", syscall.ESTALE.Error(), syscall.EIO.Error(), errMsg)
+	}
 }
 
 func ValidateEIOError(t *testing.T, err error) {

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -52,6 +52,13 @@ func ValidateESTALEError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
+	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
+}
+
+func ValidateESTALEOrEIOError(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err)
 	// FUSE kernel driver can translate ESTALE to EIO (input/output error) on some operations/kernels.
 	// So we accept both "stale file handle" (ESTALE) and "input/output error" (EIO).
 	errMsg := err.Error()

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -52,7 +52,9 @@ func ValidateESTALEError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
-	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
+	if !errors.Is(err, syscall.ESTALE) {
+		t.Fatalf("Expected error to be %q (ESTALE). Got: %v", syscall.ESTALE, err)
+	}
 }
 
 func ValidateESTALEOrEIOError(t *testing.T, err error) {
@@ -61,9 +63,8 @@ func ValidateESTALEOrEIOError(t *testing.T, err error) {
 	require.Error(t, err)
 	// FUSE kernel driver can translate ESTALE to EIO (input/output error) on some operations/kernels.
 	// So we accept both "stale file handle" (ESTALE) and "input/output error" (EIO).
-	errMsg := err.Error()
-	if !strings.Contains(errMsg, syscall.ESTALE.Error()) && !strings.Contains(errMsg, syscall.EIO.Error()) {
-		t.Fatalf("Expected error to contain %q or %q. Got: %q", syscall.ESTALE.Error(), syscall.EIO.Error(), errMsg)
+	if !errors.Is(err, syscall.ESTALE) && !errors.Is(err, syscall.EIO) {
+		t.Fatalf("Expected error to be %q (ESTALE) or %q (EIO). Got: %v", syscall.ESTALE, syscall.EIO, err)
 	}
 }
 
@@ -71,7 +72,9 @@ func ValidateEIOError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
-	assert.Regexp(t, syscall.EIO.Error(), err.Error())
+	if !errors.Is(err, syscall.EIO) {
+		t.Fatalf("Expected error to be %q (EIO). Got: %v", syscall.EIO, err)
+	}
 }
 
 func CheckErrorForReadOnlyFileSystem(t *testing.T, err error) {


### PR DESCRIPTION
### Description
The FUSE kernel driver can translate ESTALE to EIO on certain versions. Make tests more robust to handle it. Specifically:
- Introduced a `ValidateESTALEOrEIOError` helper to accept both `syscall.ESTALE` ("stale file handle") and `syscall.EIO` ("input/output error"). This accounts for differences in how the Linux FUSE driver translates FUSE `ESTALE` errors to the userspace depending on the kernel environment/version. Updated the `dentry_cache` and `notifier_tests` to use the method.
- Skip credentials-based tests on non-allowlisted projects.

### Link to the issue in case of a bug fix.
b/518338525

### Testing details
1. Manual - Verified that executing the integration test suite via `make e2e-test` on a VM hosted in a non-allowlisted project successfully runs all portable tests and gracefully skips credentials-based tests without crashes. All run tests passed.
2. Unit tests - N/A
3. Integration tests - Verified that `dentry_cache`, `mount_timeout`, `requester_pays_bucket`, and `managed_folders` tests execute successfully.

### Any backward incompatible change? If so, please explain.
No backward incompatible changes.
