### PR TITLE
fix(retry): add Unauthenticated to retryable gRPC status codes to handle transient token expiration in storage control client

### DIFF
--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -219,6 +219,8 @@ func storageControlClientGaxRetryOptions(clientConfig *storageutil.StorageClient
 				codes.DeadlineExceeded,
 				codes.Internal,
 				codes.Unknown,
+				// TODO(b/518674297): Please incorporate the correct fix post resolution of oauth2 issue.
+				codes.Unauthenticated,
 			}, gax.Backoff{
 				Max:        clientConfig.MaxRetrySleep,
 				Multiplier: clientConfig.RetryMultiplier,

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -733,6 +733,29 @@ func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRe
 	require.Len(testSuite.T(), gaxOpts, 2)
 }
 
+func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRetryOptions_UnauthenticatedIsRetryable() {
+	// Arrange
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+	gaxOpts := storageControlClientGaxRetryOptions(&clientConfig)
+	var settings gax.CallSettings
+	for _, opt := range gaxOpts {
+		opt.Resolve(&settings)
+	}
+	require.NotNil(testSuite.T(), settings.Retry)
+	retryer := settings.Retry()
+	require.NotNil(testSuite.T(), retryer)
+
+	// Act
+	_, shouldRetryUnauthenticated := retryer.Retry(status.Error(codes.Unauthenticated, "unauthenticated"))
+	_, shouldRetryUnavailable := retryer.Retry(status.Error(codes.Unavailable, "unavailable"))
+	_, shouldRetryNotFound := retryer.Retry(status.Error(codes.NotFound, "not found"))
+
+	// Assert
+	assert.True(testSuite.T(), shouldRetryUnauthenticated)
+	assert.True(testSuite.T(), shouldRetryUnavailable)
+	assert.False(testSuite.T(), shouldRetryNotFound)
+}
+
 func (testSuite *ControlClientGaxRetryWrapperTest) TestAddGaxRetriesForFolderAPIs_NilRawControlClient() {
 	// Arrange
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -734,7 +734,6 @@ func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRe
 }
 
 func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRetryOptions_UnauthenticatedIsRetryable() {
-	// Arrange
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 	gaxOpts := storageControlClientGaxRetryOptions(&clientConfig)
 	var settings gax.CallSettings
@@ -745,15 +744,9 @@ func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRe
 	retryer := settings.Retry()
 	require.NotNil(testSuite.T(), retryer)
 
-	// Act
 	_, shouldRetryUnauthenticated := retryer.Retry(status.Error(codes.Unauthenticated, "unauthenticated"))
-	_, shouldRetryUnavailable := retryer.Retry(status.Error(codes.Unavailable, "unavailable"))
-	_, shouldRetryNotFound := retryer.Retry(status.Error(codes.NotFound, "not found"))
 
-	// Assert
 	assert.True(testSuite.T(), shouldRetryUnauthenticated)
-	assert.True(testSuite.T(), shouldRetryUnavailable)
-	assert.False(testSuite.T(), shouldRetryNotFound)
 }
 
 func (testSuite *ControlClientGaxRetryWrapperTest) TestAddGaxRetriesForFolderAPIs_NilRawControlClient() {

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -36,7 +36,7 @@ const (
 	retryTransient
 	// retry401 indicates a 401 Unauthorized error which requires a retry due to credentials refresh.
 	retry401
-	// retryUnauthenticated indicates a gRPC Unauthenticated error which requires a retry.
+	// retryUnauthenticated indicates a gRPC Unauthenticated error which requires a retry due to credentials refresh.
 	retryUnauthenticated
 )
 
@@ -51,7 +51,7 @@ func determineRetryAction(err error) retryAction {
 	// issues. Actual fix will be refresh the token earlier than 1 hr.
 	// Changes will be done post resolution of the below issue:
 	// https://github.com/golang/oauth2/issues/623
-	// TODO: Please incorporate the correct fix post resolution of the above issue.
+	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 	if typed, ok := err.(*googleapi.Error); ok {
 		if typed.Code == 401 {
 			return retry401
@@ -60,7 +60,7 @@ func determineRetryAction(err error) retryAction {
 
 	// This is the same case as above, but for gRPC UNAUTHENTICATED errors. See
 	// https://github.com/golang/oauth2/issues/623
-	// TODO: Please incorporate the correct fix post resolution of the above issue.
+	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 	if status, ok := status.FromError(err); ok {
 		if status.Code() == codes.Unauthenticated {
 			return retryUnauthenticated

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -44,6 +44,8 @@ func storageControlClientRetryOptions() []gax.CallOption {
 				codes.DeadlineExceeded,
 				codes.Internal,
 				codes.Unknown,
+				// TODO(b/518674297): Please incorporate the correct fix post resolution of oauth2 issue.
+				codes.Unauthenticated,
 			}, gax.Backoff{
 				Max:        30 * time.Second,
 				Multiplier: 2,


### PR DESCRIPTION
### Description
This PR adds support for retrying gRPC Unauthenticated errors in the Storage Control Client to handle transient credential/token expirations. It also aligns the documentation and code comments across different retry mechanism.

### Link to the issue in case of a bug fix.
b/517636259

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - Part of pre-submit

### Any backward incompatible change? If so, please explain.
NONE
