### PR TITLE
perf: set EnableAsyncDIO for kernel reader

### DIFF
--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -186,8 +186,10 @@ func getFuseMountConfig(fsName string, newConfig *cfg.Config) *fuse.MountConfig 
 		// Enables ReadDirPlus, allowing the kernel to retrieve directory entries and their
 		// attributes in a single operation.
 		EnableReaddirplus: newConfig.FileSystem.ExperimentalEnableReaddirplus,
-		// Enable async reads if enable-kernel-reader flag is set to true.
+		// Enable async reads if the kernel reader is enabled
 		EnableAsyncReads: newConfig.FileSystem.EnableKernelReader,
+		// Enable async direct IO if the kernel reader is enabled
+		EnableAsyncDIO: newConfig.FileSystem.EnableKernelReader,
 	}
 
 	if newConfig.Logging.WireLog != "" {

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/googleapis/gax-go/v2 v2.22.0
 	github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec
-	github.com/jacobsa/fuse v0.0.0-20260302145937-f1ba38d60fdf
+	github.com/jacobsa/fuse v0.0.0-20260603130850-6ac65ea4e14c
 	github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd
 	github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff
 	github.com/jacobsa/ogletest v0.0.0-20170503003838-80d50a735a11

--- a/go.sum
+++ b/go.sum
@@ -134,8 +134,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec h1:xsRGrfdnjvJtEMD2ouh8gOGIeDF9LrgXjo+9Q69RVzI=
 github.com/jacobsa/daemonize v0.0.0-20240917082746-f35568b6c3ec/go.mod h1:Ip4fOwzCrnDVuluHBd7FXIMb7SHOKfkt9/UDrYSZvqI=
-github.com/jacobsa/fuse v0.0.0-20260302145937-f1ba38d60fdf h1:1FpPcJSf6jjJGvIltaLwJCpbFCMI9bVUCAAxUSxqWnY=
-github.com/jacobsa/fuse v0.0.0-20260302145937-f1ba38d60fdf/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
+github.com/jacobsa/fuse v0.0.0-20260603130850-6ac65ea4e14c h1:vWgzO4dRprAo0jrqgTLFC9iMP5k5UQzWX8DpMHblGDE=
+github.com/jacobsa/fuse v0.0.0-20260603130850-6ac65ea4e14c/go.mod h1:fcpw1yk/suvFhB8rT9P+pst+NLboWsBLky9csooKjPc=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd h1:9GCSedGjMcLZCrusBZuo4tyKLpKUPenUUqi34AkuFmA=
 github.com/jacobsa/oglematchers v0.0.0-20150720000706-141901ea67cd/go.mod h1:TlmyIZDpGmwRoTWiakdr+HA1Tukze6C6XbRVidYq02M=
 github.com/jacobsa/oglemock v0.0.0-20150831005832-e94d794d06ff h1:2xRHTvkpJ5zJmglXLRqHiZQNjUoOkhUyhTAhEQvPAWw=


### PR DESCRIPTION
Set EnableAsyncDIO for the kernel reader.

This enables the same benefits that we get from EnableAsyncReads but for O_DIRECT reads and writes.