### PR TITLE
fix(syncObject): Fix Unfinalized Zonal Object Sync Failures (Staged Writes & Truncate to Stale Size)

### DIFF
--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -105,6 +105,10 @@ func (t *IntegrationTest) TearDown() {
 }
 
 func (t *IntegrationTest) create(o *gcs.Object) {
+	if o.Finalized.IsZero() {
+		o.Finalized = t.clock.Now()
+	}
+
 	// Set up a reader.
 	rc, err := t.bucket.NewReaderWithReadHandle(
 		t.ctx,

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -193,9 +193,19 @@ func (os *syncer) SyncObject(
 	}
 
 	// If the content hasn't been dirtied (i.e. it is the same size as the source
-	// object, and no bytes within the source object have been dirtied), we're
-	// done.
-	if sr.Size == srcSize && sr.DirtyThreshold == srcSize {
+	// object, and no bytes within the source object have been dirtied).
+	tempFileIsUnmodifiedAndLocalMatchesGCS := sr.Size == srcSize && sr.DirtyThreshold == srcSize
+
+	// We return early if the file is unmodified.
+	//
+	// We handle this for two different object states:
+	// 1. Finalized objects (Standard buckets): We return early if the file is unmodified.
+	// 2. Unfinalized objects (Zonal/Rapid buckets): Unfinalized objects can report a
+	//    stale metadata size of 0. If the local temp file size is 0 and GCS returns 0,
+	//    we cannot distinguish between a genuinely empty file and a file containing
+	//    data that we want to truncate to 0. Thus, we bypass this optimization when
+	//    the local temp file size is 0 to ensure truncate-to-0 is always uploaded.
+	if (!srcObject.Finalized.IsZero() || sr.Size != 0) && tempFileIsUnmodifiedAndLocalMatchesGCS {
 		return
 	}
 

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -180,7 +180,7 @@ func (os *syncer) SyncObject(
 		return os.fullCreator.Create(ctx, objectName, srcObject, sr.Mtime, os.chunkRetryDeadlineSecs, os.chunkTransferTimeoutSecs, content)
 	}
 
-	// TODO(b/520290147): Remomve unfinalized checks once stat results become consistent on zonal buckets.
+	// TODO(b/520290147): Remove unfinalized checks once stat results become consistent on zonal buckets.
 	// Make sure the dirty threshold makes sense.
 	// Note: This check is not needed for unfinalized objects as they are always uploaded in their entirety.
 	srcSize := int64(srcObject.Size)
@@ -207,7 +207,7 @@ func (os *syncer) SyncObject(
 	// object, and no bytes within the source object have been dirtied).
 	tempFileIsUnmodifiedAndLocalMatchesGCS := sr.Size == srcSize && sr.DirtyThreshold == srcSize
 
-	// TODO(b/520290147): Remomve unfinalized checks once stat results become consistent on zonal buckets.
+	// TODO(b/520290147): Remove unfinalized checks once stat results become consistent on zonal buckets.
 	// This check is specifically for finalized objects (Standard buckets) where GCS metadata
 	// size is fully trustworthy. sr.Mtime == nil alone is not sufficient because a file could
 	// be modified (making sr.Mtime non-nil), but then truncated back to its original size (or

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -193,35 +193,35 @@ func (os *syncer) SyncObject(
 		return
 	}
 
+	// We return early if the file is unmodified or content in unchanged.
+	//
+	// Scenario 1: If the local staged file was never written to or truncated, sr.Mtime
+	// remains nil. This is a 100% reliable indicator that no local changes were ever
+	// made, allowing us to always return early safely for both finalized and unfinalized objects.
+	if sr.Mtime == nil {
+		return
+	}
+
+	// Scenario 2: Size and dirty threshold comparison.
 	// If the content hasn't been dirtied (i.e. it is the same size as the source
 	// object, and no bytes within the source object have been dirtied).
 	tempFileIsUnmodifiedAndLocalMatchesGCS := sr.Size == srcSize && sr.DirtyThreshold == srcSize
 
-	// We return early if the file is unmodified.
+	// TODO(b/520290147): Remomve unfinalized checks once stat results become consistent on zonal buckets.
+	// This check is specifically for finalized objects (Standard buckets) where GCS metadata
+	// size is fully trustworthy. sr.Mtime == nil alone is not sufficient because a file could
+	// be modified (making sr.Mtime non-nil), but then truncated back to its original size (or
+	// have its changes reverted) such that it matches the source GCS object size/content exactly.
+	// For finalized objects, this check allows us to still optimize and return early in
+	// such cases, avoiding a redundant upload.
 	//
-	// We handle this for two different object states:
-	// 1. Finalized objects (Standard buckets): We return early if the file is unmodified.
-	// 2. Unfinalized objects (Zonal/Rapid buckets): Unfinalized objects can report a
-	//    stale metadata size Y that is less than their actual size X. If we locally
-	//    truncate the file to Y, both the local size and dirty threshold become Y,
-	//    which matches the stale metadata size Y. We cannot distinguish this from an
-	//    unmodified file of size Y. Thus, we bypass this optimization for
-	//    unfinalized objects to prevent truncations from being silently skipped.
-	//
-	// We use two checks to determine if we can return early:
-	//
-	// - sr.Mtime == nil: If the file was never written to or truncated, sr.Mtime remains
-	//   nil. This is a 100% reliable indicator that no local changes were ever made,
-	//   allowing us to always return early safely for both finalized and unfinalized objects.
-	//
-	// - (!srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS):
-	//   This check is specifically for finalized objects where GCS metadata size is fully
-	//   trustworthy. sr.Mtime == nil alone is not sufficient because a file could be modified
-	//   (making sr.Mtime non-nil), but then truncated back to its original size (or have its
-	//   changes reverted) such that it matches the source GCS object size/content exactly.
-	//   For finalized objects, this check allows us to still optimize and return early in
-	//   such cases, avoiding a redundant upload.
-	if sr.Mtime == nil || (!srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS) {
+	// We bypass this check for unfinalized objects (Zonal/Rapid buckets) because unfinalized
+	// objects can report a stale metadata size Y that is less than their actual size X. If we
+	// locally truncate the file to Y, both the local size and dirty threshold become Y, which
+	// matches the stale metadata size Y. We cannot distinguish this from an unmodified file
+	// of size Y. Thus, we bypass this check for unfinalized objects to prevent truncations
+	// from being silently skipped.
+	if !srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS {
 		return
 	}
 

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -208,9 +208,19 @@ func (os *syncer) SyncObject(
 	//    unmodified file of size Y. Thus, we bypass this optimization for
 	//    unfinalized objects to prevent truncations from being silently skipped.
 	//
-	// In both cases, if the file was never written to or truncated, sr.Mtime remains
-	// nil. This is a 100% reliable indicator that no local changes were ever made,
-	// allowing us to always return early safely.
+	// We use two checks to determine if we can return early:
+	//
+	// - sr.Mtime == nil: If the file was never written to or truncated, sr.Mtime remains
+	//   nil. This is a 100% reliable indicator that no local changes were ever made,
+	//   allowing us to always return early safely for both finalized and unfinalized objects.
+	//
+	// - (!srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS):
+	//   This check is specifically for finalized objects where GCS metadata size is fully
+	//   trustworthy. sr.Mtime == nil alone is not sufficient because a file could be modified
+	//   (making sr.Mtime non-nil), but then truncated back to its original size (or have its
+	//   changes reverted) such that it matches the source GCS object size/content exactly.
+	//   For finalized objects, this check allows us to still optimize and return early in
+	//   such cases, avoiding a redundant upload.
 	if sr.Mtime == nil || (!srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS) {
 		return
 	}

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -180,10 +180,11 @@ func (os *syncer) SyncObject(
 		return os.fullCreator.Create(ctx, objectName, srcObject, sr.Mtime, os.chunkRetryDeadlineSecs, os.chunkTransferTimeoutSecs, content)
 	}
 
+	// TODO(b/520290147): Remomve unfinalized checks once stat results become consistent on zonal buckets.
 	// Make sure the dirty threshold makes sense.
 	// Note: This check is not needed for unfinalized objects as they are always uploaded in their entirety.
 	srcSize := int64(srcObject.Size)
-	if !srcObject.Finalized.IsZero() && sr.DirtyThreshold > srcSize {
+	if !srcObject.IsUnfinalized() && sr.DirtyThreshold > srcSize {
 		err = fmt.Errorf(
 			"stat returned weird DirtyThreshold field: %d vs. %d",
 			sr.DirtyThreshold,
@@ -201,20 +202,19 @@ func (os *syncer) SyncObject(
 	// We handle this for two different object states:
 	// 1. Finalized objects (Standard buckets): We return early if the file is unmodified.
 	// 2. Unfinalized objects (Zonal/Rapid buckets): Unfinalized objects can report a
-	//    stale metadata size of 0. If the local temp file size is 0 and GCS returns 0,
-	//    we cannot distinguish between a genuinely empty file and a file containing
-	//    data that we want to truncate to 0. Thus, we bypass this optimization when
-	//    the local temp file size is 0 to ensure truncate-to-0 is always uploaded.
-	if (!srcObject.Finalized.IsZero() || sr.Size != 0) && tempFileIsUnmodifiedAndLocalMatchesGCS {
+	//    stale metadata size Y that is less than their actual size X. If we locally
+	//    truncate the file to Y, both the local size and dirty threshold become Y,
+	//    which matches the stale metadata size Y. We cannot distinguish this from an
+	//    unmodified file of size Y. Thus, we bypass this optimization for
+	//    unfinalized objects to prevent truncations from being silently skipped.
+	//
+	// In both cases, if the file was never written to or truncated, sr.Mtime remains
+	// nil. This is a 100% reliable indicator that no local changes were ever made,
+	// allowing us to always return early safely.
+	if sr.Mtime == nil || (!srcObject.IsUnfinalized() && tempFileIsUnmodifiedAndLocalMatchesGCS) {
 		return
 	}
 
-	// Sanity check: the branch above should ensure that by the time we get here,
-	// the stat result's mtime is non-nil.
-	if sr.Mtime == nil {
-		err = fmt.Errorf("wacky stat result: %#v", sr)
-		return
-	}
 
 	// Otherwise, we need to create a new generation. If the source object is
 	// long enough, hasn't been dirtied, and has a low enough component count,

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -215,7 +215,6 @@ func (os *syncer) SyncObject(
 		return
 	}
 
-
 	// Otherwise, we need to create a new generation. If the source object is
 	// long enough, hasn't been dirtied, and has a low enough component count,
 	// then we can make the optimization of not rewriting its contents.

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -181,8 +181,9 @@ func (os *syncer) SyncObject(
 	}
 
 	// Make sure the dirty threshold makes sense.
+	// Note: This check is not needed for unfinalized objects as they are always uploaded in their entirety.
 	srcSize := int64(srcObject.Size)
-	if sr.DirtyThreshold > srcSize {
+	if !srcObject.Finalized.IsZero() && sr.DirtyThreshold > srcSize {
 		err = fmt.Errorf(
 			"stat returned weird DirtyThreshold field: %d vs. %d",
 			sr.DirtyThreshold,

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -322,7 +322,6 @@ func (t *SyncerTest) SetUp(ti *TestInfo) {
 	AssertEq(nil, err)
 	t.srcObject.Finalized = time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local)
 
-
 	// Wrap a TempFile around it.
 	t.content, err = NewTempFile(
 		dummyReadCloser{strings.NewReader(srcObjectContents)},

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -419,8 +419,8 @@ func (t *SyncerTest) UnfinalizedObjectReturnsEarlyIfUnmodifiedAndNonZeroSize() {
 	// But it has a correct metadata size (e.g. 4 bytes, matching local content).
 	t.srcObject.Size = uint64(len(srcObjectContents))
 
-	// Since sr.Size == 4 (srcSize), sr.DirtyThreshold == 4 (srcSize),
-	// and sr.Size != 0, it should return early (optimization holds).
+	// Since the local temp file is unmodified (sr.Mtime is nil), it should return
+	// early even though the object is unfinalized.
 	o, err := t.call()
 
 	AssertEq(nil, err)
@@ -428,6 +428,39 @@ func (t *SyncerTest) UnfinalizedObjectReturnsEarlyIfUnmodifiedAndNonZeroSize() {
 	// Neither creator should be called.
 	ExpectFalse(t.fullCreator.called)
 	ExpectFalse(t.appendCreator.called)
+}
+
+func (t *SyncerTest) UnfinalizedObjectDoesNotReturnEarlyOnTruncateToStaleMetadataSize() {
+	var err error
+	t.appendCreator.o = &gcs.Object{}
+	t.appendCreator.err = nil
+
+	// Simulate an unfinalized object (Finalized time is zero).
+	t.srcObject.Finalized = time.Time{}
+	// GCS metadata reports stale size 4 (but actual size was 10).
+	t.srcObject.Size = 4
+
+	// Set up the content with 10 bytes of initial data.
+	t.content, err = NewTempFile(
+		dummyReadCloser{strings.NewReader("1234567890")},
+		"",
+		&t.clock)
+	AssertEq(nil, err)
+
+	// Truncate to 4. This sets size to 4 and dirtyThreshold to 4.
+	// Since we truncated, tf.mtime becomes non-nil.
+	err = t.content.Truncate(4)
+	AssertEq(nil, err)
+
+	// Even though local size matches stale GCS size (4 == 4) and dirtyThreshold (4 == 4)
+	// matches GCS size, since tf.mtime is non-nil and the object is unfinalized,
+	// it should bypass early return and call appendCreator.
+	o, err := t.call()
+
+	AssertEq(nil, err)
+	ExpectEq(t.appendCreator.o, o)
+	ExpectTrue(t.appendCreator.called)
+	ExpectFalse(t.fullCreator.called)
 }
 
 func (t *SyncerTest) NotDirty() {

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -391,23 +391,20 @@ func (t *SyncerTest) UnfinalizedObjectDoesNotReturnEarlyOnTruncateToZero() {
 	var err error
 	t.fullCreator.o = &gcs.Object{}
 	t.fullCreator.err = nil
-
 	// Simulate an unfinalized object (Finalized time is zero).
 	t.srcObject.Finalized = time.Time{}
 	t.srcObject.Size = 0
-
 	// Set up the content with 10 bytes of initial data.
 	t.content, err = NewTempFile(
 		dummyReadCloser{strings.NewReader("1234567890")},
 		"",
 		&t.clock)
 	AssertEq(nil, err)
-
 	// Truncate to 0. This sets size to 0 and dirtyThreshold to 0.
 	err = t.content.Truncate(0)
 	AssertEq(nil, err)
 
-	// Call. Even though sr.Size == 0 (srcSize) and sr.DirtyThreshold == 0 (srcSize),
+	// Even though sr.Size == 0 (srcSize) and sr.DirtyThreshold == 0 (srcSize),
 	// since the object is unfinalized, it should NOT return early but call fullCreator.
 	o, err := t.call()
 
@@ -422,13 +419,12 @@ func (t *SyncerTest) UnfinalizedObjectReturnsEarlyIfUnmodifiedAndNonZeroSize() {
 	// But it has a correct metadata size (e.g. 4 bytes, matching local content).
 	t.srcObject.Size = uint64(len(srcObjectContents))
 
-	// Call. Since sr.Size == 4 (srcSize), sr.DirtyThreshold == 4 (srcSize),
+	// Since sr.Size == 4 (srcSize), sr.DirtyThreshold == 4 (srcSize),
 	// and sr.Size != 0, it should return early (optimization holds).
 	o, err := t.call()
 
 	AssertEq(nil, err)
 	ExpectEq(nil, o)
-
 	// Neither creator should be called.
 	ExpectFalse(t.fullCreator.called)
 	ExpectFalse(t.appendCreator.called)

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -434,19 +434,16 @@ func (t *SyncerTest) UnfinalizedObjectDoesNotReturnEarlyOnTruncateToStaleMetadat
 	var err error
 	t.appendCreator.o = &gcs.Object{}
 	t.appendCreator.err = nil
-
 	// Simulate an unfinalized object (Finalized time is zero).
 	t.srcObject.Finalized = time.Time{}
 	// GCS metadata reports stale size 4 (but actual size was 10).
 	t.srcObject.Size = 4
-
 	// Set up the content with 10 bytes of initial data.
 	t.content, err = NewTempFile(
 		dummyReadCloser{strings.NewReader("1234567890")},
 		"",
 		&t.clock)
 	AssertEq(nil, err)
-
 	// Truncate to 4. This sets size to 4 and dirtyThreshold to 4.
 	// Since we truncated, tf.mtime becomes non-nil.
 	err = t.content.Truncate(4)

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -359,6 +359,33 @@ func (t *SyncerTest) SyncObjectShouldInvokeFullObjectCreatorWhenSrcObjectIsNil()
 	ExpectTrue(t.fullCreator.called)
 	ExpectFalse(t.appendCreator.called)
 }
+
+func (t *SyncerTest) UnfinalizedObjectBypassesDirtyThresholdCheck() {
+	var err error
+	t.fullCreator.o = &gcs.Object{}
+	t.fullCreator.err = nil
+	// Simulate an unfinalized object (Finalized time is zero).
+	t.srcObject.Finalized = time.Time{}
+	t.srcObject.Size = 0
+	// Set up the content to have a dirty threshold of 5.
+	// We populate NewTempFile with 10 bytes of data so tf.dirtyThreshold is initialized to 10.
+	t.content, err = NewTempFile(
+		dummyReadCloser{strings.NewReader("1234567890")},
+		"",
+		&t.clock)
+	AssertEq(nil, err)
+	// Write at offset 5 to make dirtyThreshold = min(10, 5) = 5.
+	_, err = t.content.WriteAt([]byte("hi"), 5)
+	AssertEq(nil, err)
+
+	o, err := t.call()
+
+	// It should bypass the weird dirty threshold error and succeed.
+	AssertEq(nil, err)
+	ExpectEq(t.fullCreator.o, o)
+	ExpectTrue(t.fullCreator.called)
+}
+
 func (t *SyncerTest) NotDirty() {
 	// Call
 	o, err := t.call()

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -320,6 +320,8 @@ func (t *SyncerTest) SetUp(ti *TestInfo) {
 		})
 
 	AssertEq(nil, err)
+	t.srcObject.Finalized = time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local)
+
 
 	// Wrap a TempFile around it.
 	t.content, err = NewTempFile(
@@ -384,6 +386,53 @@ func (t *SyncerTest) UnfinalizedObjectBypassesDirtyThresholdCheck() {
 	AssertEq(nil, err)
 	ExpectEq(t.fullCreator.o, o)
 	ExpectTrue(t.fullCreator.called)
+}
+
+func (t *SyncerTest) UnfinalizedObjectDoesNotReturnEarlyOnTruncateToZero() {
+	var err error
+	t.fullCreator.o = &gcs.Object{}
+	t.fullCreator.err = nil
+
+	// Simulate an unfinalized object (Finalized time is zero).
+	t.srcObject.Finalized = time.Time{}
+	t.srcObject.Size = 0
+
+	// Set up the content with 10 bytes of initial data.
+	t.content, err = NewTempFile(
+		dummyReadCloser{strings.NewReader("1234567890")},
+		"",
+		&t.clock)
+	AssertEq(nil, err)
+
+	// Truncate to 0. This sets size to 0 and dirtyThreshold to 0.
+	err = t.content.Truncate(0)
+	AssertEq(nil, err)
+
+	// Call. Even though sr.Size == 0 (srcSize) and sr.DirtyThreshold == 0 (srcSize),
+	// since the object is unfinalized, it should NOT return early but call fullCreator.
+	o, err := t.call()
+
+	AssertEq(nil, err)
+	ExpectEq(t.fullCreator.o, o)
+	ExpectTrue(t.fullCreator.called)
+}
+
+func (t *SyncerTest) UnfinalizedObjectReturnsEarlyIfUnmodifiedAndNonZeroSize() {
+	// Simulate an unfinalized object (Finalized time is zero).
+	t.srcObject.Finalized = time.Time{}
+	// But it has a correct metadata size (e.g. 4 bytes, matching local content).
+	t.srcObject.Size = uint64(len(srcObjectContents))
+
+	// Call. Since sr.Size == 4 (srcSize), sr.DirtyThreshold == 4 (srcSize),
+	// and sr.Size != 0, it should return early (optimization holds).
+	o, err := t.call()
+
+	AssertEq(nil, err)
+	ExpectEq(nil, o)
+
+	// Neither creator should be called.
+	ExpectFalse(t.fullCreator.called)
+	ExpectFalse(t.appendCreator.called)
 }
 
 func (t *SyncerTest) NotDirty() {

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -110,6 +110,10 @@ type ExtendedObjectAttributes struct {
 	Acl                []*storagev1.ObjectAccessControl
 }
 
+func (o Object) IsUnfinalized() bool {
+	return o.Finalized.IsZero()
+}
+
 func (mo MinObject) HasContentEncodingGzip() bool {
 	return mo.ContentEncoding == ContentEncodingGzip
 }

--- a/internal/storage/gcs/object_test.go
+++ b/internal/storage/gcs/object_test.go
@@ -65,3 +65,15 @@ func (t *ObjectTest) IsNotFinalized() {
 
 	AssertTrue(mo.IsUnfinalized())
 }
+
+func (t *ObjectTest) ObjectIsFinalized() {
+	o := Object{Finalized: time.Date(2025, time.June, 19, 18, 23, 30, 0, time.UTC)}
+
+	AssertFalse(o.IsUnfinalized())
+}
+
+func (t *ObjectTest) ObjectIsNotFinalized() {
+	o := Object{}
+
+	AssertTrue(o.IsUnfinalized())
+}


### PR DESCRIPTION
### Problem & Root Cause
When executing streaming writes (and fallback legacy staged writes) on **Zonal/Rapid buckets**, files exist on GCS in an unfinalized state. This unfinalized state causes two major failures in `syncer.SyncObject`:

1. **Incorrect `DirtyThreshold` Sanity Check Violation:**
   GCS metadata stat queries sometimes report the stale size of unfinalized zonal objects as `X` (`srcSize = X`), even though the object contains actual data that GCSFuse has successfully downloaded and staged locally upto Y (Y > X). 
   When local edits are made, the local staged file has `sr.DirtyThreshold > X`. The sanity check:
   ```go
   if sr.DirtyThreshold > srcSize { ... error("stat returned weird DirtyThreshold") }
   ```
   was triggered because `DirtyThreshold > X` was compared against `srcSize = X`, causing application I/O errors and failing the sync.

2. **Silent Drop of Truncate to X:**
   If a user truncated an unfinalized file to `X` bytes:
   * Local file size `sr.Size` was `X` and `sr.DirtyThreshold` was `X`.
   * GCS metadata size `srcSize` was reported as `X`.
   * The early clean-return check:
     ```go
     if sr.Size == srcSize && sr.DirtyThreshold == srcSize { return }
     ```
     incorrectly matched (`X == X && X == X`), causing GCSFuse to return early and silently drop the truncation. Stale data remained on GCS, violating consistency.

---

### Changes
For Zonal Bucket we bypass the dirty sanity check and only rely on mtime for the early return optimisations.

---

### Link to the issue in case of a bug fix.
b/519352477

### Testing details
1. Manual - Yes
2. Unit tests - Yes
3. Integration tests - part of presubmits

### Any backward incompatible change? If so, please explain.
NONE
