### PR TITLE
refactor: update build script to run daily jobs on latest commit for manual runs.

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -25,8 +25,11 @@ sudo apt-get install -y git
 
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
-# Get the latest commitId of yesterday in the log file.
-commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+# Get the branch name that was cloned by Kokoro
+branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
+# Get the latest commitId. Build gcsfuse and run
+commitId=$(git log -n 1 --pretty=%H)
+echo "Running tests on branch: ${branchName} at commit ID: ${commitId}"
 
 # -----------------------------------------------------------------
 # Helper function to calculate and print execution time

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -27,8 +27,12 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the latest commitId. Build gcsfuse and run
-commitId=$(git log -n 1 --pretty=%H)
+# Get the commitId. Build gcsfuse and run
+if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
+  commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+else
+  commitId=$(git log -n 1 --pretty=%H)
+fi
 echo "Running tests on branch: ${branchName} at commit ID: ${commitId}"
 
 # -----------------------------------------------------------------

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -27,7 +27,9 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the commitId. Build gcsfuse and run
+# Get the commitId. Build gcsfuse and run.
+# - Automated daily runs (initiated by Kokoro scheduler) will run on the last commit of yesterday on the master branch.
+# - Manual runs (initiated by users) will run on the latest commit of the branch (master or feature branch) provided in the manual trigger.
 if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
   commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 else

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -30,7 +30,7 @@ branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1
 commitId=$(git log -n 1 --pretty=%H)
 echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
 
-echo "Building and installing gcsfuse..."
+echo "Building and installing gcsfuse from commit ${commitId}..."
 build_log=$(mktemp)
 if ! ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId > "$build_log" 2>&1; then
     cat "$build_log"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -37,7 +37,7 @@ if ! ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId > "$build_log"
     exit 1
 fi
 
-echo "Checking out commit ${commitId} to ensure tests are run from this commit"
+echo "Checking out commit ${commitId}."
 git checkout $commitId
 
 if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -22,21 +22,27 @@ if [[ $# -gt 0 ]]; then
     exit 1
 fi
 
-readonly BUCKET_LOCATION="us-central1"
-
 cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
-echo "Building and installing gcsfuse..."
-# Get the latest commitId of yesterday in the log file. Build gcsfuse and run
-commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
-./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
+# Get the branch name that was cloned by Kokoro
+branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
+# Get the latest commitId. Build gcsfuse and run
+commitId=$(git log -n 1 --pretty=%H)
+echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
 
-# To execute tests for a specific commitId, ensure you've checked out from that commitId first.
+echo "Building and installing gcsfuse..."
+build_log=$(mktemp)
+if ! ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId > "$build_log" 2>&1; then
+    cat "$build_log"
+    exit 1
+fi
+
+echo "Checking out commit ${commitId} to ensure tests are run from this commit"
 git checkout $commitId
 
 if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then
     echo "Running zonal e2e tests on installed package...."
-    bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package --zonal
+    bash ./tools/integration_tests/improved_run_e2e_tests.sh --test-installed-package --zonal
 else
     if [[ -n "${RUN_TESTS_WITH_ZONAL_BUCKET-}" ]]; then
         echo "Warning: RUN_TESTS_WITH_ZONAL_BUCKET is set to '${RUN_TESTS_WITH_ZONAL_BUCKET}', which is not 'true'. Running regional tests."
@@ -44,5 +50,5 @@ else
         echo "RUN_TESTS_WITH_ZONAL_BUCKET is not set. Running regional tests by default."
     fi
     echo "Running regional e2e tests on installed package...."
-    bash ./tools/integration_tests/improved_run_e2e_tests.sh --bucket-location="$BUCKET_LOCATION" --test-installed-package
+    bash ./tools/integration_tests/improved_run_e2e_tests.sh --test-installed-package
 fi

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -26,7 +26,9 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the commitId. Build gcsfuse and run
+# Get the commitId. Build gcsfuse and run.
+# - Automated daily runs (initiated by Kokoro scheduler) will run on the last commit of yesterday on the master branch.
+# - Manual runs (initiated by users) will run on the latest commit of the branch (master or feature branch) provided in the manual trigger.
 if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
   commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 else

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -26,8 +26,12 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the latest commitId. Build gcsfuse and run
-commitId=$(git log -n 1 --pretty=%H)
+# Get the commitId. Build gcsfuse and run
+if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
+  commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+else
+  commitId=$(git log -n 1 --pretty=%H)
+fi
 echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
 
 echo "Building and installing gcsfuse from commit ${commitId}..."

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -36,13 +36,16 @@ export PATH="/usr/local/google-cloud-sdk/bin:$PATH"
 gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 
 echo "Building and installing gcsfuse..."
-# Get the latest commitId of yesterday in the log file. Build gcsfuse and run
-commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+# Get the branch name that was cloned by Kokoro
+branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
+# Get the latest commitId. Build gcsfuse and run
+commitId=$(git log -n 1 --pretty=%H)
+echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
 ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
 
-## To execute tests for a specific commitId, ensure you've checked out that commitId first.
+echo "Checking out commit ${commitId}."
 git checkout $commitId
-echo "Running e2e tests on installed package...."
+echo "Running TPC e2e tests on installed package...."
 
 # Initiate PRPTST environment to establish a TPC project and associated account.
 gcloud config configurations create prptst

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -37,8 +37,12 @@ gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the latest commitId. Build gcsfuse and run
-commitId=$(git log -n 1 --pretty=%H)
+# Get the commitId. Build gcsfuse and run
+if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
+  commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+else
+  commitId=$(git log -n 1 --pretty=%H)
+fi
 echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
 
 echo "Building and installing gcsfuse from commit ${commitId}..."

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -35,13 +35,18 @@ export PATH="/usr/local/google-cloud-sdk/bin:$PATH"
 # Copy the key file for the TPC service account to use for authentication.
 gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 
-echo "Building and installing gcsfuse..."
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
 # Get the latest commitId. Build gcsfuse and run
 commitId=$(git log -n 1 --pretty=%H)
 echo "Running E2E tests on branch: ${branchName} at commit ID: ${commitId}"
-./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId
+
+echo "Building and installing gcsfuse from commit ${commitId}..."
+build_log=$(mktemp)
+if ! ./perfmetrics/scripts/build_and_install_gcsfuse.sh $commitId > "$build_log" 2>&1; then
+    cat "$build_log"
+    exit 1
+fi
 
 echo "Checking out commit ${commitId}."
 git checkout $commitId

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/tpc_build.sh
@@ -37,7 +37,9 @@ gcloud storage cp gs://gcsfuse-tpc-tests/creds.json /tmp/sa.key.json
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the commitId. Build gcsfuse and run
+# Get the commitId. Build gcsfuse and run.
+# - Automated daily runs (initiated by Kokoro scheduler) will run on the last commit of yesterday on the master branch.
+# - Manual runs (initiated by users) will run on the latest commit of the branch (master or feature branch) provided in the manual trigger.
 if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
   commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
 else


### PR DESCRIPTION
### Description
Use the current latest commit id from the master or branch for the runs initiated via devs where the initiator is not `kokoro`. For the daily runs it continues to use the single last commit of yesterday's as initiator is always `kokoro`. This let's us verify the failures early and also validate failures when the fixes are made to scripts by triggering the daily kokoro builds manual after making changes to master or fix branches.

Example: https://screenshot.googleplex.com/8BbChMxMxqvd6hv

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
