### PR TITLE
fix(retry): add Unauthenticated to retryable gRPC status codes to Storage Control Client for v3.9.2_release

### DIFF
--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -219,6 +219,8 @@ func storageControlClientGaxRetryOptions(clientConfig *storageutil.StorageClient
 				codes.DeadlineExceeded,
 				codes.Internal,
 				codes.Unknown,
+				// TODO(b/518674297): Please incorporate the correct fix post resolution of oauth2 issue.
+				codes.Unauthenticated,
 			}, gax.Backoff{
 				Max:        clientConfig.MaxRetrySleep,
 				Multiplier: clientConfig.RetryMultiplier,

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -733,6 +733,22 @@ func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRe
 	require.Len(testSuite.T(), gaxOpts, 2)
 }
 
+func (testSuite *ControlClientGaxRetryWrapperTest) TestStorageControlClientGaxRetryOptions_UnauthenticatedIsRetryable() {
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+	gaxOpts := storageControlClientGaxRetryOptions(&clientConfig)
+	var settings gax.CallSettings
+	for _, opt := range gaxOpts {
+		opt.Resolve(&settings)
+	}
+	require.NotNil(testSuite.T(), settings.Retry)
+	retryer := settings.Retry()
+	require.NotNil(testSuite.T(), retryer)
+
+	_, shouldRetryUnauthenticated := retryer.Retry(status.Error(codes.Unauthenticated, "unauthenticated"))
+
+	assert.True(testSuite.T(), shouldRetryUnauthenticated)
+}
+
 func (testSuite *ControlClientGaxRetryWrapperTest) TestAddGaxRetriesForFolderAPIs_NilRawControlClient() {
 	// Arrange
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -39,7 +39,7 @@ func ShouldRetry(err error) (b bool) {
 	// issues. Actual fix will be refresh the token earlier than 1 hr.
 	// Changes will be done post resolution of the below issue:
 	// https://github.com/golang/oauth2/issues/623
-	// TODO: Please incorporate the correct fix post resolution of the above issue.
+	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 	if typed, ok := err.(*googleapi.Error); ok {
 		if typed.Code == 401 {
 			b = true
@@ -50,7 +50,7 @@ func ShouldRetry(err error) (b bool) {
 
 	// This is the same case as above, but for gRPC UNAUTHENTICATED errors. See
 	// https://github.com/golang/oauth2/issues/623
-	// TODO: Please incorporate the correct fix post resolution of the above issue.
+	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 	if status, ok := status.FromError(err); ok {
 		if status.Code() == codes.Unauthenticated {
 			b = true

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -44,6 +44,8 @@ func storageControlClientRetryOptions() []gax.CallOption {
 				codes.DeadlineExceeded,
 				codes.Internal,
 				codes.Unknown,
+				// TODO(b/518674297): Please incorporate the correct fix post resolution of oauth2 issue.
+				codes.Unauthenticated,
 			}, gax.Backoff{
 				Max:        30 * time.Second,
 				Multiplier: 2,


### PR DESCRIPTION
### Description
Patch ACCESS_TOKEN_EXPIRE patch to v3.9.2

### Link to the issue in case of a bug fix.
b/517636259

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NONE
