### PR TITLE
fix(tests): Fix TPC daily run failures caused by --test-bucket unavailability 

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -125,7 +125,7 @@ func SetIsZonalBucketRun(val bool) {
 
 func TestBucket() string {
 	if *testBucket == "" {
-		return os.Getenv("BUCKET_NAME")
+		*testBucket = os.Getenv("BUCKET_NAME")
 	}
 	return *testBucket
 }
@@ -657,6 +657,9 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 }
 
 func SetGlobalVars(cfg *test_suite.TestConfig) {
+	if cfg.TestBucket == "" {
+		cfg.TestBucket = TestBucket()
+	}
 	// TODO: clean global variables after test migration to config file completes.
 	testBucket = &cfg.TestBucket
 	logFile = cfg.LogFile
@@ -769,7 +772,7 @@ func UnmountGCSFuseWithConfig(cfg *test_suite.TestConfig) {
 }
 
 func RunTestsOnlyForStaticMount(mountDir string, t *testing.T) {
-	if strings.Contains(mountDir, TestBucket()) || OnlyDirMounted() != "" {
+	if TestBucket() == "" || strings.Contains(mountDir, TestBucket()) || OnlyDirMounted() != "" {
 		log.Println("This test will run only for static mounting...")
 		t.SkipNow()
 	}

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -411,7 +411,7 @@ func IgnoreTestIfPresubmitFlagIsSet(b *testing.B) {
 
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {
 	ParseSetUpFlags()
- 
+
 	if TestBucket() == "" && *mountedDirectory == "" {
 		log.Print("--testbucket or --mountedDirectory must be specified")
 		os.Exit(1)

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -124,6 +124,9 @@ func SetIsZonalBucketRun(val bool) {
 }
 
 func TestBucket() string {
+	if *testBucket == "" {
+		return os.Getenv("BUCKET_NAME")
+	}
 	return *testBucket
 }
 
@@ -408,8 +411,8 @@ func IgnoreTestIfPresubmitFlagIsSet(b *testing.B) {
 
 func ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet() {
 	ParseSetUpFlags()
-
-	if *testBucket == "" && *mountedDirectory == "" {
+ 
+	if TestBucket() == "" && *mountedDirectory == "" {
 		log.Print("--testbucket or --mountedDirectory must be specified")
 		os.Exit(1)
 	}
@@ -766,7 +769,7 @@ func UnmountGCSFuseWithConfig(cfg *test_suite.TestConfig) {
 }
 
 func RunTestsOnlyForStaticMount(mountDir string, t *testing.T) {
-	if strings.Contains(mountDir, *testBucket) || OnlyDirMounted() != "" {
+	if strings.Contains(mountDir, TestBucket()) || OnlyDirMounted() != "" {
 		log.Println("This test will run only for static mounting...")
 		t.SkipNow()
 	}


### PR DESCRIPTION
### Description
Fix TPC builds as recent migration to config file have broken them.

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NONE
