### PR TITLE
test(integration): migrate TPC operations tests to config file

### DIFF
--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"path"
-	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -95,71 +93,13 @@ var (
 	ctx           context.Context
 )
 
-func overrideFilePathsInFlagSet(t *test_suite.TestConfig, GCSFuseTempDirPath string) {
-	for _, flags := range t.Configs {
-		for i := range flags.Flags {
-			// Iterate over the indices of the flags slice
-			flags.Flags[i] = strings.ReplaceAll(flags.Flags[i], "/gcsfuse-tmp", path.Join(GCSFuseTempDirPath, "gcsfuse-tmp"))
-		}
-	}
-}
-
-func RunTestOnTPCEndPoint(cfg test_suite.Config, m *testing.M) int {
-	ctx = context.Background()
-	var err error
-	if storageClient, err = client.CreateStorageClient(ctx); err != nil {
-		log.Fatalf("Error creating storage client: %v\n", err)
-	}
-	cfg.Operations = make([]test_suite.TestConfig, 1)
-	cfg.Operations[0].TestBucket = setup.TestBucket()
-	cfg.Operations[0].GKEMountedDirectory = setup.MountedDirectory()
-	cfg.Operations[0].Configs = make([]test_suite.ConfigItem, 1)
-	cfg.Operations[0].Configs[0].Flags = []string{
-		"--enable-atomic-rename-object=true",
-		"--experimental-enable-json-read=true",
-		"--metadata-cache-ttl-secs=0 --enable-streaming-writes=false",
-		"--kernel-list-cache-ttl-secs=-1 --implicit-dirs=true",
-	}
-	cfg.Operations[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-	var flags [][]string
-
-	// Iterate over the original flags and split each string by spaces
-	for _, flagSet := range cfg.Operations[0].Configs[0].Flags {
-		splitFlags := strings.Fields(flagSet)
-		flags = append(flags, splitFlags)
-	}
-	setup.SetUpTestDirForTestBucket(&cfg.Operations[0])
-	successCodeTPC := static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-	return successCodeTPC
-}
-
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
 
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
-
-	// TODO: b/469970353 : Update tpc_build.sh to run using test_config.yaml file.
-	if setup.TestOnTPCEndPoint() {
-		log.Println("Running TPC tests without config file.")
-		successCodeTPC := RunTestOnTPCEndPoint(cfg, m)
-		os.Exit(successCodeTPC)
-	}
-
 	if len(cfg.Operations) == 0 {
-		log.Println("No configuration found for operations tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.Operations = make([]test_suite.TestConfig, 1)
-		cfg.Operations[0].TestBucket = setup.TestBucket()
-		cfg.Operations[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.Operations[0].Configs = make([]test_suite.ConfigItem, 1)
-		cfg.Operations[0].Configs[0].Flags = []string{
-			"--metadata-cache-ttl-secs=0 --enable-streaming-writes=false",
-			"--kernel-list-cache-ttl-secs=-1 --implicit-dirs=true --enable-metadata-prefetch",
-			"--experimental-enable-json-read=true --enable-atomic-rename-object=true",
-			"--client-protocol=grpc --implicit-dirs=true --enable-atomic-rename-object=true --enable-metadata-prefetch",
-		}
-		cfg.Operations[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		log.Fatal("No configuration found for operations tests in config.")
 	}
 
 	ctx = context.Background()
@@ -180,12 +120,16 @@ func TestMain(m *testing.M) {
 	}
 
 	// 4. Override GKE specific paths with GCSFuse paths if running in GCE environment.
-	overrideFilePathsInFlagSet(&cfg.Operations[0], setup.TestDir())
+	setup.OverrideFilePathsInFlagSet(&cfg.Operations[0], setup.TestDir())
 
 	// Run tests for testBucket
 	// 5. Build the flag sets dynamically from the config.
 	flags := setup.BuildFlagSets(cfg.Operations[0], bucketType, "")
 	setup.SetUpTestDirForTestBucket(&cfg.Operations[0])
+
+	if setup.TestOnTPCEndPoint() {
+		os.Exit(static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m))
+	}
 
 	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -134,6 +134,17 @@ operations:
             same_zone: true
             different_zone: false
         run_on_gke: true
+      - flags:
+          - "--enable-atomic-rename-object=true,--client-protocol=http1"
+          - "--experimental-enable-json-read=true,--client-protocol=http1"
+          - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
+          - "--kernel-list-cache-ttl-secs=-1,--implicit-dirs=true,--client-protocol=http1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        tpc: true
+        run_on_gke: false
 
 write_large_files:
   - mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -607,14 +607,26 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	defer cancel()
 	var opts []option.ClientOption
 	opts = append(opts, experimental.WithGRPCBidiReads())
-	if keyFile != "" {
+	if TestOnTPCEndPoint() {
+		cred, err := auth2.GetCredentials("/tmp/sa.key.json")
+		if err != nil {
+			return "", fmt.Errorf("failed to get credentials for TPC: %w", err)
+		}
+		opts = append(opts, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithAuthCredentials(cred))
+	} else if keyFile != "" {
 		cred, err := auth2.GetCredentials(keyFile)
 		if err != nil {
 			return "", fmt.Errorf("failed to get credentials: %w", err)
 		}
 		opts = append(opts, option.WithAuthCredentials(cred))
 	}
-	storageClient, err := storage.NewGRPCClient(ctx, opts...)
+	var storageClient *storage.Client
+	if TestOnTPCEndPoint() {
+		storageClient, err = storage.NewClient(ctx, opts...)
+	} else {
+		storageClient, err = storage.NewGRPCClient(ctx, opts...)
+	}
+
 	if err != nil {
 		return "", fmt.Errorf("failed to create storage client: %w", err)
 	}
@@ -676,8 +688,8 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 				isCompatible = false
 			}
 		}
-
-		if isCompatible && (run == "" || run == testCase.Run) {
+		tpcMatches := (TestOnTPCEndPoint() == testCase.TPC)
+		if isCompatible && tpcMatches && (run == "" || run == testCase.Run) {
 			// 3. If compatible, process its flags and add them to the result.
 			for _, flagString := range testCase.Flags {
 				flagString = strings.ReplaceAll(flagString, ",", " ")

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -688,8 +688,8 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 				isCompatible = false
 			}
 		}
-		tpcMatches := (TestOnTPCEndPoint() == testCase.TPC)
-		if isCompatible && tpcMatches && (run == "" || run == testCase.Run) {
+		tpcRun := (TestOnTPCEndPoint() == testCase.TPC)
+		if isCompatible && tpcRun && (run == "" || run == testCase.Run) {
 			// 3. If compatible, process its flags and add them to the result.
 			for _, flagString := range testCase.Flags {
 				flagString = strings.ReplaceAll(flagString, ",", " ")

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -612,7 +612,7 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 		if err != nil {
 			return "", fmt.Errorf("failed to get credentials for TPC: %w", err)
 		}
-		opts = append(opts, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithAuthCredentials(cred))
+		opts = append(opts, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithAuthCredentials(cred), option.WithUniverseDomain("apis-tpczero.goog"))
 	} else if keyFile != "" {
 		cred, err := auth2.GetCredentials(keyFile)
 		if err != nil {

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -62,6 +62,7 @@ type ConfigItem struct {
 	Run            string           `yaml:"run,omitempty"`
 	RunOnGKE       bool             `yaml:"run_on_gke"`
 	RunOnPirlo     RunOnPirloConfig `yaml:"run_on_pirlo"`
+	TPC            bool             `yaml:"tpc,omitempty"`
 }
 
 // UnmarshalYAML validates flags during YAML unmarshaling without needing reflection.


### PR DESCRIPTION
### Description
Migrates the `operations` integration tests on the TPC endpoint to execute from the common configuration file (`test_config.yaml`) rather than relying on hardcoded test runner logic.

**Key Changes:**
* Adds a new `TPC` boolean property to `ConfigItem` in `config.go` to identify TPC-specific configurations.
* Declares standard `flat`/`hns`/`zonal` compatibility for TPC configurations in `test_config.yaml`, combined with `tpc: true`.
* Modifies `BuildFlagSets()` in `setup.go` to correctly filter configurations by matching the active endpoint with the config (`tpcMatches := (TestOnTPCEndPoint() == testCase.TPC)`).
* Configures `setup.go` to use specific TPC credentials (`/tmp/sa.key.json`), endpoint (`storage.apis-tpczero.goog:443`), and universe domain (`apis-tpczero.goog`) when `TestOnTPCEndPoint()` is true.
* Conditionally initializes the storage client using standard `storage.NewClient` for TPC endpoints, while retaining `storage.NewGRPCClient` for others.
* Deletes the custom/hardcoded `RunTestOnTPCEndPoint` flow in `operations_test.go` and transitions it to the standard config setup.
* Cleans up redundant local helpers in `operations_test.go` in favor of using package-level ones instead.

### Link to the issue in case of a bug fix.
Fixes b/469970353

### Testing details
1. Manual - Checked local compilation using `go test -c ./tools/integration_tests/operations` and checked general repo lint/compilation using `make buildTest`.
2. Unit tests - N/A
3. Integration tests - N/A (requires TPC endpoint and credentials)

### Any backward incompatible change? If so, please explain.
N/A
