### PR TITLE
perf: Optimize LookupInode latency for HNS buckets

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -784,15 +784,51 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 			d.prefetcher.Run(NewFileName(d.Name(), name).GcsObjectName())
 		}
 
-		group.Go(lookUpFile)
 		if d.isBucketHierarchical() {
-			group.Go(lookUpHNSDir)
-		} else {
-			if d.implicitDirs {
-				group.Go(lookUpImplicitOrExplicitDir)
-			} else {
-				group.Go(lookUpExplicitDir)
+			raceCtx, cancel := context.WithCancel(ctx)
+			defer cancel()
+
+			type raceResult struct {
+				core *Core
+				err  error
 			}
+
+			ch := make(chan raceResult, 2)
+
+			go func() {
+				res, err := findExplicitInode(raceCtx, d.Bucket(), NewFileName(d.Name(), name), false)
+				ch <- raceResult{core: res, err: err}
+			}()
+
+			go func() {
+				res, err := findExplicitFolder(raceCtx, d.Bucket(), NewDirName(d.Name(), name), false)
+				ch <- raceResult{core: res, err: err}
+			}()
+
+			var lastErr error
+			for i := 0; i < 2; i++ {
+				select {
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				case res := <-ch:
+					if res.err != nil {
+						lastErr = res.err
+						continue
+					}
+					if res.core != nil {
+						cancel()
+						return res.core, nil
+					}
+				}
+			}
+			return nil, lastErr
+		}
+
+		group.Go(lookUpFile)
+		if d.implicitDirs {
+			group.Go(lookUpImplicitOrExplicitDir)
+		} else {
+			group.Go(lookUpExplicitDir)
 		}
 	}
 

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -785,43 +785,7 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 		}
 
 		if d.isBucketHierarchical() {
-			raceCtx, cancel := context.WithCancel(ctx)
-			defer cancel()
-
-			type raceResult struct {
-				core *Core
-				err  error
-			}
-
-			ch := make(chan raceResult, 2)
-
-			go func() {
-				res, err := findExplicitInode(raceCtx, d.Bucket(), NewFileName(d.Name(), name), false)
-				ch <- raceResult{core: res, err: err}
-			}()
-
-			go func() {
-				res, err := findExplicitFolder(raceCtx, d.Bucket(), NewDirName(d.Name(), name), false)
-				ch <- raceResult{core: res, err: err}
-			}()
-
-			var lastErr error
-			for i := 0; i < 2; i++ {
-				select {
-				case <-ctx.Done():
-					return nil, ctx.Err()
-				case res := <-ch:
-					if res.err != nil {
-						lastErr = res.err
-						continue
-					}
-					if res.core != nil {
-						cancel()
-						return res.core, nil
-					}
-				}
-			}
-			return nil, lastErr
+			return d.lookUpHNSRace(ctx, name)
 		}
 
 		group.Go(lookUpFile)
@@ -840,6 +804,46 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 		return dirResult, nil
 	}
 	return fileResult, nil
+}
+
+func (d *dirInode) lookUpHNSRace(ctx context.Context, name string) (*Core, error) {
+	raceCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	type raceResult struct {
+		core *Core
+		err  error
+	}
+
+	ch := make(chan raceResult, 2)
+
+	go func() {
+		res, err := findExplicitInode(raceCtx, d.Bucket(), NewFileName(d.Name(), name), false)
+		ch <- raceResult{core: res, err: err}
+	}()
+
+	go func() {
+		res, err := findExplicitFolder(raceCtx, d.Bucket(), NewDirName(d.Name(), name), false)
+		ch <- raceResult{core: res, err: err}
+	}()
+
+	var lastErr error
+	for range 2 {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case res := <-ch:
+			if res.err != nil {
+				lastErr = res.err
+				continue
+			}
+			if res.core != nil {
+				cancel()
+				return res.core, nil
+			}
+		}
+	}
+	return nil, lastErr
 }
 
 func (d *dirInode) IsUnlinked() bool {

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -986,17 +986,15 @@ func (t *HNSDirTest) TestLookUpChild_TypeCacheDeprecated_CacheHit() {
 	t.mockBucket.AssertExpectations(t.T())
 }
 
-func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel() {
+func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel_FolderWins() {
 	const name = "race_slower_cancel"
 	dirName := path.Join(dirInodeName, name) + "/"
 	folder := &gcs.Folder{
 		Name: dirName,
 	}
-
 	statStarted := make(chan struct{})
 	statFinished := make(chan struct{})
 	var statObjectCanceled bool
-
 	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			close(statStarted)
@@ -1005,14 +1003,12 @@ func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel() {
 			statObjectCanceled = true
 			close(statFinished)
 		}).Return(nil, nil, &gcs.NotFoundError{Err: errors.New("not found")}).Maybe()
-
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			<-statStarted
 		}).Return(folder, nil)
 
 	result, err := t.in.LookUpChild(t.ctx, name)
-
 	<-statFinished
 
 	t.mockBucket.AssertExpectations(t.T())
@@ -1035,11 +1031,9 @@ func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel_FileWins() {
 		ContentType:  "plain/text",
 		StorageClass: "DEFAULT",
 	}
-
 	folderStarted := make(chan struct{})
 	folderFinished := make(chan struct{})
 	var folderCanceled bool
-
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			close(folderStarted)
@@ -1048,14 +1042,12 @@ func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel_FileWins() {
 			folderCanceled = true
 			close(folderFinished)
 		}).Return(nil, &gcs.NotFoundError{Err: errors.New("not found")}).Maybe()
-
 	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			<-folderStarted
 		}).Return(minObject, attrs, nil)
 
 	result, err := t.in.LookUpChild(t.ctx, name)
-
 	<-folderFinished
 
 	t.mockBucket.AssertExpectations(t.T())
@@ -1070,7 +1062,6 @@ func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_ErrorPropagation() {
 	const name = "race_error_prop"
 	err1 := errors.New("API error 1")
 	err2 := errors.New("API error 2")
-
 	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, err1)
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, err2)
 
@@ -1088,15 +1079,12 @@ func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_ErrorOnOneSuccessOnOther()
 	folder := &gcs.Folder{
 		Name: dirName,
 	}
-
 	statStarted := make(chan struct{})
 	apiErr := errors.New("connection reset")
-
 	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			close(statStarted)
 		}).Return(nil, nil, apiErr)
-
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			<-statStarted

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/sync/semaphore"
 
-	"golang.org/x/net/context"
+	"context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 )

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -44,7 +44,7 @@ import (
 type hnsDirTest struct {
 	suite.Suite
 	ctx         context.Context
-	bucket      gcsx.SyncerBucket
+	bucket      *gcsx.SyncerBucket
 	in          DirInode
 	mockBucket  *storagemock.TestifyMockBucket
 	typeCache   metadata.TypeCache
@@ -73,12 +73,13 @@ func (t *hnsDirTest) setupTestSuite(hierarchical bool) {
 	t.ctx = context.Background()
 	t.mockBucket = new(storagemock.TestifyMockBucket)
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{Hierarchical: hierarchical})
-	t.bucket = gcsx.NewSyncerBucket(
+	bucket := gcsx.NewSyncerBucket(
 		/*appendThreshold=*/ 1,
 		chunkRetryDeadlineSecs,
 		chunkTransferTimeoutSecs,
 		".gcsfuse_tmp/",
 		t.mockBucket)
+	t.bucket = &bucket
 	t.resetDirInode(false, false, true)
 }
 
@@ -118,7 +119,7 @@ func (t *hnsDirTest) resetDirInodeWithTypeCacheConfigs(implicitDirs, enableNonex
 		implicitDirs,
 		enableNonexistentTypeCache,
 		typeCacheTTL,
-		&t.bucket,
+		t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
 		semaphore.NewWeighted(10),
@@ -166,7 +167,7 @@ func (t *hnsDirTest) createDirInodeWithTypeCacheDeprecationFlag(dirInodeName str
 		false,
 		true,
 		typeCacheTTL,
-		&t.bucket,
+		t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
 		semaphore.NewWeighted(10),
@@ -185,7 +186,7 @@ func (t *hnsDirTest) createDirInodeWithTypeCacheDeprecationFlag(dirInodeName str
 		false,
 		true,
 		typeCacheTTL,
-		&t.bucket,
+		t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
 		semaphore.NewWeighted(10),
@@ -210,7 +211,7 @@ func (t *HNSDirTest) TestShouldFindExplicitHNSFolder() {
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 
 	// Look up with the name.
-	result, err := findExplicitFolder(t.ctx, &t.bucket, NewDirName(t.in.Name(), name), false)
+	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), name), false)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Nil(t.T(), err)
@@ -224,7 +225,7 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, notFoundErr)
 
 	// Look up with the name.
-	result, err := findExplicitFolder(t.ctx, &t.bucket, NewDirName(t.in.Name(), "not-present"), false)
+	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), "not-present"), false)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Nil(t.T(), err)
@@ -287,7 +288,7 @@ func (t *HNSDirTest) TestLookUpChildShouldCheckForHNSDirectoryWhenTypeNotPresent
 	}
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("storage: object doesn't exist")}
-	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, notFoundErr)
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, notFoundErr).Maybe()
 	if !t.in.IsTypeCacheDeprecated() {
 		assert.Equal(t.T(), metadata.UnknownType, t.typeCache.Get(t.fixedTime.Now(), name))
 	}
@@ -397,7 +398,7 @@ func (t *HNSDirTest) TestRenameFolderWithGivenName() {
 		false,
 		true,
 		typeCacheTTL,
-		&t.bucket,
+		t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
 		semaphore.NewWeighted(10),
@@ -436,7 +437,7 @@ func (t *HNSDirTest) TestRenameFolderWithNonExistentSourceFolder() {
 		false,
 		true,
 		typeCacheTTL,
-		&t.bucket,
+		t.bucket,
 		&t.fixedTime,
 		&t.fixedTime,
 		semaphore.NewWeighted(10),
@@ -846,7 +847,7 @@ func (t *NonHNSDirTest) TestDeleteChildDir_TypeCacheDeprecated() {
 				true,  // implicitDirs
 				false, // enableNonexistentTypeCache
 				typeCacheTTL,
-				&t.bucket,
+				t.bucket,
 				&t.fixedTime,
 				&t.fixedTime,
 				semaphore.NewWeighted(10),
@@ -885,7 +886,7 @@ func (t *HNSDirTest) TestLookUpChild_TypeCacheDeprecated_File() {
 	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(minObject, attrs, nil)
 	// Mock GetFolder for dir lookup (should return not found or nil)
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("not found")}
-	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, notFoundErr)
+	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, notFoundErr).Maybe()
 
 	entry, err := t.in.LookUpChild(t.ctx, name)
 
@@ -906,7 +907,7 @@ func (t *HNSDirTest) TestLookUpChild_TypeCacheDeprecated_Folder() {
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 	// Mock StatObject for file lookup (should return not found)
 	notFoundErr := &gcs.NotFoundError{Err: errors.New("not found")}
-	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, notFoundErr)
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, notFoundErr).Maybe()
 
 	entry, err := t.in.LookUpChild(t.ctx, name)
 
@@ -943,7 +944,7 @@ func (t *HNSDirTest) TestLookUpChild_TypeCacheDeprecated_CacheMiss() {
 	// Expect actual lookup for dir -> NotFound
 	t.mockBucket.On("GetFolder", mock.Anything, mock.MatchedBy(func(req *gcs.GetFolderRequest) bool {
 		return req.Name == dirObjName && req.FetchOnlyFromCache == false
-	})).Return(nil, &gcs.NotFoundError{}).Once()
+	})).Return(nil, &gcs.NotFoundError{}).Maybe()
 
 	in.Lock()
 	entry, err := in.LookUpChild(t.ctx, name)
@@ -983,4 +984,130 @@ func (t *HNSDirTest) TestLookUpChild_TypeCacheDeprecated_CacheHit() {
 	require.NotNil(t.T(), entry)
 	assert.Equal(t.T(), objName, entry.FullName.GcsObjectName())
 	t.mockBucket.AssertExpectations(t.T())
+}
+
+func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel() {
+	const name = "race_slower_cancel"
+	dirName := path.Join(dirInodeName, name) + "/"
+	folder := &gcs.Folder{
+		Name: dirName,
+	}
+
+	statStarted := make(chan struct{})
+	statFinished := make(chan struct{})
+	var statObjectCanceled bool
+
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(statStarted)
+			ctx := args.Get(0).(context.Context)
+			<-ctx.Done()
+			statObjectCanceled = true
+			close(statFinished)
+		}).Return(nil, nil, &gcs.NotFoundError{Err: errors.New("not found")}).Maybe()
+
+	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-statStarted
+		}).Return(folder, nil)
+
+	result, err := t.in.LookUpChild(t.ctx, name)
+
+	<-statFinished
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), result)
+	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
+	assert.Equal(t.T(), dirName, result.Folder.Name)
+	assert.True(t.T(), statObjectCanceled)
+}
+
+func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_SlowerCancel_FileWins() {
+	const name = "race_file_wins"
+	fileName := path.Join(dirInodeName, name)
+	minObject := &gcs.MinObject{
+		Name:           fileName,
+		MetaGeneration: int64(1),
+		Generation:     int64(2),
+	}
+	attrs := &gcs.ExtendedObjectAttributes{
+		ContentType:  "plain/text",
+		StorageClass: "DEFAULT",
+	}
+
+	folderStarted := make(chan struct{})
+	folderFinished := make(chan struct{})
+	var folderCanceled bool
+
+	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(folderStarted)
+			ctx := args.Get(0).(context.Context)
+			<-ctx.Done()
+			folderCanceled = true
+			close(folderFinished)
+		}).Return(nil, &gcs.NotFoundError{Err: errors.New("not found")}).Maybe()
+
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-folderStarted
+		}).Return(minObject, attrs, nil)
+
+	result, err := t.in.LookUpChild(t.ctx, name)
+
+	<-folderFinished
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), result)
+	assert.Equal(t.T(), fileName, result.FullName.GcsObjectName())
+	assert.Equal(t.T(), fileName, result.MinObject.Name)
+	assert.True(t.T(), folderCanceled)
+}
+
+func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_ErrorPropagation() {
+	const name = "race_error_prop"
+	err1 := errors.New("API error 1")
+	err2 := errors.New("API error 2")
+
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).Return(nil, nil, err1)
+	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, err2)
+
+	result, err := t.in.LookUpChild(t.ctx, name)
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.Nil(t.T(), result)
+	assert.Error(t.T(), err)
+	assert.True(t.T(), strings.Contains(err.Error(), "API error 1") || strings.Contains(err.Error(), "API error 2"))
+}
+
+func (t *HNSDirTest) TestLookUpChild_HNS_RaceSelector_ErrorOnOneSuccessOnOther() {
+	const name = "race_err_and_success"
+	dirName := path.Join(dirInodeName, name) + "/"
+	folder := &gcs.Folder{
+		Name: dirName,
+	}
+
+	statStarted := make(chan struct{})
+	apiErr := errors.New("connection reset")
+
+	t.mockBucket.On("StatObject", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			close(statStarted)
+		}).Return(nil, nil, apiErr)
+
+	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).
+		Run(func(args mock.Arguments) {
+			<-statStarted
+			time.Sleep(10 * time.Millisecond)
+		}).Return(folder, nil)
+
+	result, err := t.in.LookUpChild(t.ctx, name)
+
+	t.mockBucket.AssertExpectations(t.T())
+	assert.Nil(t.T(), err)
+	assert.NotNil(t.T(), result)
+	assert.Equal(t.T(), dirName, result.FullName.GcsObjectName())
+	assert.Equal(t.T(), dirName, result.Folder.Name)
 }

--- a/internal/storage/mock/testify_mock_bucket.go
+++ b/internal/storage/mock/testify_mock_bucket.go
@@ -89,6 +89,9 @@ func (m *TestifyMockBucket) ComposeObjects(ctx context.Context, req *gcs.Compose
 }
 
 func (m *TestifyMockBucket) StatObject(ctx context.Context, req *gcs.StatObjectRequest) (*gcs.MinObject, *gcs.ExtendedObjectAttributes, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, nil, err
+	}
 	args := m.Called(ctx, req)
 	if args.Get(2) != nil {
 		return nil, nil, args.Error(2)
@@ -125,6 +128,9 @@ func (m *TestifyMockBucket) DeleteFolder(ctx context.Context, folderName string)
 }
 
 func (m *TestifyMockBucket) GetFolder(ctx context.Context, req *gcs.GetFolderRequest) (*gcs.Folder, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 	args := m.Called(ctx, req)
 	if args.Get(0) != nil {
 		return args.Get(0).(*gcs.Folder), nil


### PR DESCRIPTION
### Description
Optimize LookupInode latency for Hierarchical Namespace (HNS) buckets by executing GetFolder and StatObject calls concurrently as a race.

### Perf

| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 515.92MiB/s  | 1.22MiB/s  |  78.22MiB/s  |  1.18MiB/s   |
|   PR   |  0.25MiB   | 536.51MiB/s  |  1.2MiB/s  |  75.59MiB/s  |  1.11MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 4262.88MiB/s | 75.17MiB/s | 1455.23MiB/s |  77.46MiB/s  |
|   PR   | 48.828MiB  | 4368.66MiB/s | 77.37MiB/s | 1508.1MiB/s  |  77.88MiB/s  |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 4478.25MiB/s | 35.42MiB/s | 926.34MiB/s  |  39.27MiB/s  |
|   PR   | 976.562MiB | 4347.76MiB/s | 35.53MiB/s | 1215.01MiB/s |  38.9MiB/s   |

### Link to the issue in case of a bug fix.
b/525307797

### Testing details
1. Manual - N/A
2. Unit tests - N/A
3. Integration tests - Ran as part of presubmit

### Any backward incompatible change? If so, please explain.
None