### PR TITLE
fix(patch): benchmarking and unsupported_path test fixes to v3.8.2

### DIFF
--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -61,7 +61,7 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
@@ -110,6 +110,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -117,7 +118,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -54,9 +54,7 @@ type env struct {
 
 func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
 }
 
@@ -105,7 +103,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -114,7 +112,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir, rootDir = setup.MntDir(), setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/stale_handle/setup_test.go
+++ b/tools/integration_tests/stale_handle/setup_test.go
@@ -35,6 +35,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
+	rootDir  string
 )
 
 type env struct {
@@ -98,13 +99,13 @@ func TestMain(m *testing.M) {
 	// flags to be set, as stale handle tests validates content from the bucket.
 	// Note: These tests by default can only be run for non streaming mounts.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
-	mountDir = setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_common_test.go
@@ -44,9 +44,7 @@ type staleFileHandleCommon struct {
 
 func (s *staleFileHandleCommon) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = SetupTestDirectory(testEnv.ctx, testEnv.storageClient, testDirName)
 	s.data = setup.GenerateRandomString(5 * util.MiB)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -69,6 +69,7 @@ list_large_dir:
 operations:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
         - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
@@ -223,6 +224,7 @@ cloud_profiler:
 requester_pays_bucket:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
+    only_dir: "${ONLY_DIR}"
     configs:
       - flags:
           - "--billing-project=gcs-fuse-test-ml"
@@ -657,7 +659,6 @@ interrupt:
 log_rotation:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"
-    log_file: # To be removed
     configs:
       - flags:
           - "--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress=false,--log-severity=trace"
@@ -786,25 +787,23 @@ flag_optimizations:
         run_on_gke: false
 
 unsupported_path:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  only_dir: "${ONLY_DIR}"
-  log_file: # Optional
-  configs:
-  - flags:
-    - "--implicit-dirs,--client-protocol=grpc,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
-    compatible:
-      flat: true
-      hns: true
-      zonal: false
-    run_on_gke: true
-  - flags:
-    - "--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
-    compatible:
-      flat: true
-      hns: true
-      zonal: true
-    run_on_gke: true
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--implicit-dirs,--client-protocol=grpc,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: false
+        run_on_gke: true
+      - flags:
+          - "--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: true
 
 kernel_list_cache:
   - mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -36,6 +36,7 @@ var (
 	mountFunc func(*test_suite.TestConfig, []string) error
 	// mount directory is where our tests run.
 	mountDir string
+	rootDir  string
 )
 
 type env struct {
@@ -99,7 +100,7 @@ func TestMain(m *testing.M) {
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		mountDir = testEnv.cfg.GKEMountedDirectory
+		mountDir, rootDir = testEnv.cfg.GKEMountedDirectory, testEnv.cfg.GKEMountedDirectory
 		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
@@ -108,7 +109,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 
 	// Save mount and root directory variables.
-	mountDir = setup.MntDir()
+	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
 	log.Println("Running static mounting tests...")
 	mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile

--- a/tools/integration_tests/unfinalized_object/tailing_reads_test.go
+++ b/tools/integration_tests/unfinalized_object/tailing_reads_test.go
@@ -51,9 +51,7 @@ func (s *unfinalizedObjectTailingReads) TearDownSuite() {
 
 func (s *unfinalizedObjectTailingReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_object_operations_test.go
@@ -53,9 +53,7 @@ func (s *unfinalizedObjectOperations) TearDownSuite() {
 
 func (s *unfinalizedObjectOperations) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 

--- a/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
+++ b/tools/integration_tests/unfinalized_object/unfinalized_read_test.go
@@ -65,9 +65,7 @@ func (s *unfinalizedObjectReads) TearDownSuite() {
 
 func (s *unfinalizedObjectReads) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, mountFunc)
-	if testEnv.cfg.GKEMountedDirectory == "" {
-		setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
-	}
+	setup.SetMntDir(mountDir)
 	testEnv.testDirPath = client.SetupTestDirectory(s.ctx, s.storageClient, testDirName)
 }
 


### PR DESCRIPTION
### Description
This PR backports two integration test fixes to the `v3.8.2_release` branch for GKE.

1. **Benchmarking Fix (PR #4577):** Prevents `setup.MntDir` from being overwritten by an empty directory during GKE execution.
2. **Unsupported Path Fix (PR #4623):** Resolves test failures in `unsupported_path` caused by path joining logic.

### Linked Issues
- **https://buganizer.corp.google.com/issues/496956438#comment5**