### PR TITLE
fix(cache): Prevent stat cache updates with stale, smaller-sized objects

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -163,6 +163,16 @@ func shouldReplace(m *gcs.MinObject, existing entry) bool {
 		return m.MetaGeneration > existing.m.MetaGeneration
 	}
 
+	// Break ties on object size.
+	// Because objects in zonal buckets can be appended without altering their
+	// generation or metageneration, the following case applies exclusively to
+	// zonal buckets.
+	if m.Size < existing.m.Size {
+		// We ignore m.Size < existing.m.Size case as little staleness is expected
+		// on the GCS object's size.
+		return false
+	}
+
 	// Break ties by preferring fresher entries.
 	return true
 }

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -284,6 +284,26 @@ func (t *StatCacheTest) Test_Overwrite_SameGeneration_SameMetadataGen() {
 	assert.Equal(t.T(), m1, t.cache.LookUpOrNil("taco", someTime))
 }
 
+func (t *StatCacheTest) Test_Overwrite_SameGeneration_SameMetadataGen_SmallerSize() {
+	m0 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5, Size: 10}
+	m1 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5, Size: 8}
+
+	t.cache.Insert(m0, expiration)
+	t.cache.Insert(m1, expiration)
+
+	assert.Equal(t.T(), m0, t.cache.LookUpOrNil("taco", someTime))
+}
+
+func (t *StatCacheTest) Test_Overwrite_SameGeneration_SameMetadataGen_LargerSize() {
+	m0 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5, Size: 10}
+	m1 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5, Size: 12}
+
+	t.cache.Insert(m0, expiration)
+	t.cache.Insert(m1, expiration)
+
+	assert.Equal(t.T(), m1, t.cache.LookUpOrNil("taco", someTime))
+}
+
 func (t *StatCacheTest) Test_Overwrite_SameGeneration_OlderMetadataGen() {
 	m0 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 5}
 	m1 := &gcs.MinObject{Name: "taco", Generation: 17, MetaGeneration: 3}


### PR DESCRIPTION
### Description
For Rapid buckets, the control plane may occasionally return stale metadata for unfinalized objects, such as a size of `0 bytes`, even after data has been successfully written and flushed.

Previously, GCSFuse's StatCache would blindly overwrite accurate, larger file sizes with these stale, smaller sizes because the `shouldReplace()` logic only checked if the generation and metageneration matched. While GCSFuse typically protects active inodes in memory, a cache poisoned with a 0-byte size becomes a vulnerability if the active inode is evicted (e.g., due to kernel memory pressure and a `BatchForget` call).

This change modifies the `shouldReplace()` method in the `StatCache` to ignore updates that would decrease the cached object size for the same generation and metageneration. This ensures that the cache always reflects the largest known size for a given object version in a Zonal bucket.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/505585459

### Testing details
1. Manual - Verified manually by running https://paste.googleplex.com/5818311483981824 with and without change. This reproduces the error without change but with fix the issue is fixed.
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
