### PR TITLE
fix: resolve CPU busy-loop in GenBlockPool.Get on exhaustion

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -95,6 +95,10 @@ func NewGenBlockPool[T GenBlock](blockSize int64, maxBlocks int64, reservedBlock
 	}, nil
 }
 
+// Get returns a block. It returns an existing block if it's ready for reuse or
+// creates a new one if required.
+// Not thread-safe, calling from multiple goroutines may lead to memory leaks because
+// of race conditions.
 func (bp *GenBlockPool[T]) Get() (T, error) {
 	// Try to get a block immediately (non-blocking).
 	b, err := bp.TryGet()
@@ -140,30 +144,34 @@ func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
 	return b, nil
 }
 
+const (
+	stateUndecided int32 = iota
+	stateLocalWon
+	stateGlobalWon
+)
+
 func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var winner int32 // 0 = undecided, 1 = local block won, 2 = global permit won
-	acquiredCh := make(chan bool, 1)
+	var winner int32 // stateUndecided, stateLocalWon, or stateGlobalWon
+	acquiredCh := make(chan struct{}, 1)
 
 	go func() {
 		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
 		if err == nil {
-			if atomic.CompareAndSwapInt32(&winner, 0, 2) {
-				acquiredCh <- true
+			if atomic.CompareAndSwapInt32(&winner, stateUndecided, stateGlobalWon) {
+				acquiredCh <- struct{}{}
 			} else {
 				// The local block won the race, so we must release this global permit.
 				bp.globalMaxBlocksSem.Release(1)
 			}
-		} else {
-			acquiredCh <- false
 		}
 	}()
 
 	select {
 	case b := <-bp.freeBlocksCh:
-		if atomic.CompareAndSwapInt32(&winner, 0, 1) {
+		if atomic.CompareAndSwapInt32(&winner, stateUndecided, stateLocalWon) {
 			cancel() // Cancel the Acquire() in the helper goroutine.
 			b.Reuse()
 			return b, nil
@@ -176,30 +184,25 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 		b.Reuse()
 		return b, nil
 
-	case acquired := <-acquiredCh:
-		if acquired {
-			// Non-blocking check: can we reuse a local block instead of allocating?
-			select {
-			case b := <-bp.freeBlocksCh:
-				// We found a local block! Release the global permit and reuse the local block.
+	case <-acquiredCh:
+		// Non-blocking check: can we reuse a local block instead of allocating?
+		select {
+		case b := <-bp.freeBlocksCh:
+			// We found a local block! Release the global permit and reuse the local block.
+			bp.globalMaxBlocksSem.Release(1)
+			b.Reuse()
+			return b, nil
+		default:
+			// No local block available. Proceed with allocating a new one.
+			b, err := bp.createBlockFunc(bp.blockSize)
+			if err != nil {
 				bp.globalMaxBlocksSem.Release(1)
-				b.Reuse()
-				return b, nil
-			default:
-				// No local block available. Proceed with allocating a new one.
-				b, err := bp.createBlockFunc(bp.blockSize)
-				if err != nil {
-					bp.globalMaxBlocksSem.Release(1)
-					var zero T
-					return zero, err
-				}
-				bp.totalBlocks++
-				return b, nil
+				var zero T
+				return zero, err
 			}
+			bp.totalBlocks++
+			return b, nil
 		}
-		// Fallback: if we failed to acquire the global permit, return error.
-		var zero T
-		return zero, CantAllocateAnyBlockError
 	}
 }
 

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync/atomic"
 
 	"golang.org/x/sync/semaphore"
 )
@@ -147,35 +146,24 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var winner atomic.Int32 // stateUndecided, stateLocalWon, or stateGlobalWon
-	acquiredCh := make(chan struct{}, 1)
+	acquiredCh := make(chan struct{}) // Unbuffered channel
 
 	go func() {
-		if err := bp.globalMaxBlocksSem.Acquire(ctx, 1); err != nil {
-			return
+		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
+		if err == nil {
+			select {
+			case acquiredCh <- struct{}{}:
+				// Main thread successfully read the permit signal!
+			case <-ctx.Done():
+				// Main thread took the local block and returned.
+				// We must release the acquired global permit!
+				bp.globalMaxBlocksSem.Release(1)
+			}
 		}
-
-		if winner.CompareAndSwap(stateUndecided, stateGlobalWon) {
-			acquiredCh <- struct{}{}
-			return
-		}
-		// The local block won the race, so we must release this global permit.
-		bp.globalMaxBlocksSem.Release(1)
-
 	}()
 
 	select {
 	case b := <-bp.freeBlocksCh:
-		if winner.CompareAndSwap(stateUndecided, stateLocalWon) {
-			cancel() // Cancel the Acquire() in the helper goroutine.
-			b.Reuse()
-			return b, nil
-		}
-		// The global permit won the race, but we already have a local block in hand!
-		// It is much more efficient to reuse the local block and release the global permit.
-		// This avoids an expensive syscall.Mmap call via createBlockFunc.
-		<-acquiredCh                     // Drain the channel.
-		bp.globalMaxBlocksSem.Release(1) // Release the won global permit.
 		b.Reuse()
 		return b, nil
 
@@ -183,12 +171,10 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 		// Non-blocking check: can we reuse a local block instead of allocating?
 		select {
 		case b := <-bp.freeBlocksCh:
-			// We found a local block! Release the global permit and reuse the local block.
 			bp.globalMaxBlocksSem.Release(1)
 			b.Reuse()
 			return b, nil
 		default:
-			// No local block available. Proceed with allocating a new one.
 			return bp.allocateNewBlock(true)
 		}
 	}

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -134,13 +134,11 @@ func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
 		var zero T
 		return zero, err
 	}
-	b, err := bp.createBlockFunc(bp.blockSize)
+	b, err := bp.allocateNewBlock()
 	if err != nil {
 		bp.globalMaxBlocksSem.Release(1)
-		var zero T
-		return zero, err
+		return b, err
 	}
-	bp.totalBlocks++
 	return b, nil
 }
 
@@ -194,13 +192,11 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 			return b, nil
 		default:
 			// No local block available. Proceed with allocating a new one.
-			b, err := bp.createBlockFunc(bp.blockSize)
+			b, err := bp.allocateNewBlock()
 			if err != nil {
 				bp.globalMaxBlocksSem.Release(1)
-				var zero T
-				return zero, err
+				return b, err
 			}
-			bp.totalBlocks++
 			return b, nil
 		}
 	}
@@ -219,14 +215,7 @@ func (bp *GenBlockPool[T]) TryGet() (T, error) {
 
 	default:
 		if bp.canAllocateBlock() {
-			b, err := bp.createBlockFunc(bp.blockSize)
-			if err != nil {
-				var zero T
-				return zero, err
-			}
-
-			bp.totalBlocks++
-			return b, nil
+			return bp.allocateNewBlock()
 		}
 		var zero T
 		return zero, CantAllocateAnyBlockError
@@ -248,6 +237,17 @@ func (bp *GenBlockPool[T]) canAllocateBlock() bool {
 	// Otherwise, check if we can acquire a semaphore.
 	semAcquired := bp.globalMaxBlocksSem.TryAcquire(1)
 	return semAcquired
+}
+
+// allocateNewBlock handles the physical allocation of a new block, tracking totalBlocks and returning any system error.
+func (bp *GenBlockPool[T]) allocateNewBlock() (T, error) {
+	b, err := bp.createBlockFunc(bp.blockSize)
+	if err != nil {
+		var zero T
+		return zero, err
+	}
+	bp.totalBlocks++
+	return b, nil
 }
 
 // Release puts the block back into the free blocks channel for reuse.

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -15,8 +15,10 @@
 package block
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 
 	"golang.org/x/sync/semaphore"
 )
@@ -93,30 +95,111 @@ func NewGenBlockPool[T GenBlock](blockSize int64, maxBlocks int64, reservedBlock
 	}, nil
 }
 
-// Get returns a block. It returns an existing block if it's ready for reuse or
-// creates a new one if required.
-// Not thread-safe, calling from multiple goroutines may lead memory leaks because
-// of race conditions.
 func (bp *GenBlockPool[T]) Get() (T, error) {
-	for {
-		select {
-		case b := <-bp.freeBlocksCh:
-			// Reset the block for reuse.
+	// Try to get a block immediately (non-blocking).
+	b, err := bp.TryGet()
+	if err == nil {
+		return b, nil
+	}
+	if !errors.Is(err, CantAllocateAnyBlockError) {
+		return b, err
+	}
+
+	// 1. At local pool limit: wait exclusively for a local block to be released.
+	if bp.totalBlocks >= bp.maxBlocks {
+		return bp.waitAndGetFromLocalPool()
+	}
+
+	// 2. At 0 blocks: wait exclusively for a global permit to allocate our first block.
+	if bp.totalBlocks == 0 {
+		return bp.waitAndGetFirstBlock()
+	}
+
+	// 3. Between 0 and local limit: wait for EITHER local release OR global permit.
+	return bp.waitAndGetConcurrent()
+}
+
+func (bp *GenBlockPool[T]) waitAndGetFromLocalPool() (T, error) {
+	b := <-bp.freeBlocksCh
+	b.Reuse()
+	return b, nil
+}
+
+func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
+	if err := bp.globalMaxBlocksSem.Acquire(context.Background(), 1); err != nil {
+		var zero T
+		return zero, err
+	}
+	b, err := bp.createBlockFunc(bp.blockSize)
+	if err != nil {
+		bp.globalMaxBlocksSem.Release(1)
+		var zero T
+		return zero, err
+	}
+	bp.totalBlocks++
+	return b, nil
+}
+
+func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var winner int32 // 0 = undecided, 1 = local block won, 2 = global permit won
+	acquiredCh := make(chan bool, 1)
+
+	go func() {
+		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
+		if err == nil {
+			if atomic.CompareAndSwapInt32(&winner, 0, 2) {
+				acquiredCh <- true
+			} else {
+				// The local block won the race, so we must release this global permit.
+				bp.globalMaxBlocksSem.Release(1)
+			}
+		} else {
+			acquiredCh <- false
+		}
+	}()
+
+	select {
+	case b := <-bp.freeBlocksCh:
+		if atomic.CompareAndSwapInt32(&winner, 0, 1) {
+			cancel() // Cancel the Acquire() in the helper goroutine.
 			b.Reuse()
 			return b, nil
+		}
+		// The global permit won the race, but we already have a local block in hand!
+		// It is much more efficient to reuse the local block and release the global permit.
+		// This avoids an expensive syscall.Mmap call via createBlockFunc.
+		<-acquiredCh                     // Drain the channel.
+		bp.globalMaxBlocksSem.Release(1) // Release the won global permit.
+		b.Reuse()
+		return b, nil
 
-		default:
-			if bp.canAllocateBlock() {
+	case acquired := <-acquiredCh:
+		if acquired {
+			// Non-blocking check: can we reuse a local block instead of allocating?
+			select {
+			case b := <-bp.freeBlocksCh:
+				// We found a local block! Release the global permit and reuse the local block.
+				bp.globalMaxBlocksSem.Release(1)
+				b.Reuse()
+				return b, nil
+			default:
+				// No local block available. Proceed with allocating a new one.
 				b, err := bp.createBlockFunc(bp.blockSize)
 				if err != nil {
+					bp.globalMaxBlocksSem.Release(1)
 					var zero T
 					return zero, err
 				}
-
 				bp.totalBlocks++
 				return b, nil
 			}
 		}
+		// Fallback: if we failed to acquire the global permit, return error.
+		var zero T
+		return zero, CantAllocateAnyBlockError
 	}
 }
 

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -136,7 +136,6 @@ func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
 	return bp.allocateNewBlock(true)
 }
 
-
 func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -134,12 +134,7 @@ func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
 		var zero T
 		return zero, err
 	}
-	b, err := bp.allocateNewBlock()
-	if err != nil {
-		bp.globalMaxBlocksSem.Release(1)
-		return b, err
-	}
-	return b, nil
+	return bp.allocateNewBlock(true)
 }
 
 const (
@@ -152,13 +147,13 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	var winner int32 // stateUndecided, stateLocalWon, or stateGlobalWon
+	var winner atomic.Int32 // stateUndecided, stateLocalWon, or stateGlobalWon
 	acquiredCh := make(chan struct{}, 1)
 
 	go func() {
 		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
 		if err == nil {
-			if atomic.CompareAndSwapInt32(&winner, stateUndecided, stateGlobalWon) {
+			if winner.CompareAndSwap(stateUndecided, stateGlobalWon) {
 				acquiredCh <- struct{}{}
 			} else {
 				// The local block won the race, so we must release this global permit.
@@ -169,7 +164,7 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 
 	select {
 	case b := <-bp.freeBlocksCh:
-		if atomic.CompareAndSwapInt32(&winner, stateUndecided, stateLocalWon) {
+		if winner.CompareAndSwap(stateUndecided, stateLocalWon) {
 			cancel() // Cancel the Acquire() in the helper goroutine.
 			b.Reuse()
 			return b, nil
@@ -192,12 +187,7 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 			return b, nil
 		default:
 			// No local block available. Proceed with allocating a new one.
-			b, err := bp.allocateNewBlock()
-			if err != nil {
-				bp.globalMaxBlocksSem.Release(1)
-				return b, err
-			}
-			return b, nil
+			return bp.allocateNewBlock(true)
 		}
 	}
 }
@@ -215,7 +205,7 @@ func (bp *GenBlockPool[T]) TryGet() (T, error) {
 
 	default:
 		if bp.canAllocateBlock() {
-			return bp.allocateNewBlock()
+			return bp.allocateNewBlock(bp.totalBlocks >= bp.reservedBlocks)
 		}
 		var zero T
 		return zero, CantAllocateAnyBlockError
@@ -240,9 +230,13 @@ func (bp *GenBlockPool[T]) canAllocateBlock() bool {
 }
 
 // allocateNewBlock handles the physical allocation of a new block, tracking totalBlocks and returning any system error.
-func (bp *GenBlockPool[T]) allocateNewBlock() (T, error) {
+// If wasPermitAcquired is true, it releases the global semaphore permit on allocation failure.
+func (bp *GenBlockPool[T]) allocateNewBlock(wasPermitAcquired bool) (T, error) {
 	b, err := bp.createBlockFunc(bp.blockSize)
 	if err != nil {
+		if wasPermitAcquired {
+			bp.globalMaxBlocksSem.Release(1)
+		}
 		var zero T
 		return zero, err
 	}

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -151,15 +151,17 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	acquiredCh := make(chan struct{}, 1)
 
 	go func() {
-		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
-		if err == nil {
-			if winner.CompareAndSwap(stateUndecided, stateGlobalWon) {
-				acquiredCh <- struct{}{}
-			} else {
-				// The local block won the race, so we must release this global permit.
-				bp.globalMaxBlocksSem.Release(1)
-			}
+		if err := bp.globalMaxBlocksSem.Acquire(ctx, 1); err != nil {
+			return
 		}
+
+		if winner.CompareAndSwap(stateUndecided, stateGlobalWon) {
+			acquiredCh <- struct{}{}
+			return
+		}
+		// The local block won the race, so we must release this global permit.
+		bp.globalMaxBlocksSem.Release(1)
+
 	}()
 
 	select {

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -136,11 +136,6 @@ func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
 	return bp.allocateNewBlock(true)
 }
 
-const (
-	stateUndecided int32 = iota
-	stateLocalWon
-	stateGlobalWon
-)
 
 func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -714,18 +713,15 @@ func (t *BlockPoolTest) TestTryGetReleasePermitOnAllocationFailure() {
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
-
-	// Pool has 0 reserved blocks, so any allocation must acquire from global semaphore.
 	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
 
-	// TryGet should fail due to simulated allocation failure.
 	_, err = bp.TryGet()
+
 	require.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
 
-	// Verify that the global semaphore permit was not leaked.
-	// Since the capacity is 1, we should be able to TryAcquire it now.
+	// Verify global semaphore permit was not leaked (we should be able to TryAcquire it now)
 	acquired := globalSem.TryAcquire(1)
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after TryGet allocation failure")
 }
@@ -735,60 +731,44 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
-
-	// Pool has 0 reserved blocks, so allocation must acquire from global semaphore.
 	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
 
-	// Get should fail due to simulated allocation failure.
-	// Since bp.totalBlocks == 0, this will route to waitAndGetFirstBlock() and block on Acquire().
-	// But since the semaphore has 1 permit, it will acquire it immediately and then fail on allocation.
 	_, err = bp.Get()
+
 	require.Error(t.T(), err)
 	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
 
-	// Verify that the global semaphore permit was not leaked.
+	// Verify global semaphore permit was not leaked
 	acquired := globalSem.TryAcquire(1)
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after Get allocation failure on first block")
 }
 
 func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 	globalSem := semaphore.NewWeighted(1)
-
-	var callCount int32
 	failingCreateBlock := func(blockSize int64) (Block, error) {
-		if atomic.AddInt32(&callCount, 1) == 1 {
-			return createBlock(blockSize)
-		}
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
-
-	// maxBlocks = 2, reservedBlocks = 0.
 	bp, err := NewGenBlockPool(1024, 2, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
 
-	// 1. First Get() succeeds and allocates the only global block.
-	b1, err := bp.Get()
-	require.NoError(t.T(), err)
-	require.NotNil(t.T(), b1)
+	// Simulate that 1 block is already allocated and the global semaphore is exhausted
+	bp.totalBlocks = 1
+	acquiredFirst := globalSem.TryAcquire(1)
+	require.True(t.T(), acquiredFirst)
 
-	// 2. Second Get() will see bp.totalBlocks = 1 (between 0 and 2) and freeBlocksCh is empty.
-	// It will call TryGet() which fails (no permit available).
-	// Then it will route to waitAndGetConcurrent() and block waiting.
 	errCh := make(chan error, 1)
 	go func() {
 		_, err := bp.Get()
 		errCh <- err
 	}()
 
-	// Give the goroutine a moment to start and block.
+	// Give the goroutine a moment to start and block
 	time.Sleep(50 * time.Millisecond)
 
-	// 3. Manually release a permit to unblock the waitAndGetConcurrent's Acquire.
-	// Normally this is done by another pool releasing its block.
+	// Release the permit to unblock waitAndGetConcurrent's Acquire
 	globalSem.Release(1)
 
-	// 4. The blocked Get() should wake up, try to allocate, fail, and return the error.
 	select {
 	case err := <-errCh:
 		require.Error(t.T(), err)
@@ -797,8 +777,7 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 		t.T().Fatal("timeout waiting for Get to return error")
 	}
 
-	// 5. Verify that the global semaphore permit was not leaked after the allocation failure.
-	// Since we released 1 permit, and the allocation failed, the permit should be back in the semaphore.
+	// Verify that the global semaphore permit was not leaked after the allocation failure
 	acquired := globalSem.TryAcquire(1)
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after concurrent Get allocation failure")
 }

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -15,7 +15,9 @@
 package block
 
 import (
+	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -632,4 +634,76 @@ func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksFailure() {
 			assert.EqualError(t.T(), err, tt.expectedErrMsg)
 		})
 	}
+}
+
+func (t *BlockPoolTest) TestGetDoesNotDeadlockOnGlobalLimit() {
+	globalSem := semaphore.NewWeighted(1)
+
+	// Pool 1 allocates the only global block.
+	bp1, err := NewGenBlockPool(1024, 1, 0, globalSem, createBlock)
+	require.NoError(t.T(), err)
+	b1, err := bp1.Get()
+	require.NoError(t.T(), err)
+
+	// Pool 2 has maxBlocks = 1, but currently has 0 blocks allocated.
+	bp2, err := NewGenBlockPool(1024, 1, 0, globalSem, createBlock)
+	require.NoError(t.T(), err)
+
+	// Release Pool 1's block after a short delay to free up the global semaphore.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		bp1.Release(b1)
+		_ = bp1.ClearFreeBlockChannel(true)
+	}()
+
+	// Pool 2 should be able to get a block once the global semaphore is released.
+	b2, err := bp2.Get()
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), b2)
+}
+
+func BenchmarkGetReleaseContention(b *testing.B) {
+	globalMaxBlocksSem := semaphore.NewWeighted(10) // Limit global blocks to 10.
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			// Each iteration represents a file session.
+			bp, err := NewGenBlockPool(1024, 2, 1, globalMaxBlocksSem, createBlock)
+			if err != nil {
+				if errors.Is(err, CantAllocateAnyBlockError) {
+					continue
+				}
+				b.Fatal(err)
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(2)
+
+			block1, err := bp.Get()
+			if err != nil {
+				b.Fatal(err)
+			}
+			go func() {
+				time.Sleep(10 * time.Microsecond)
+				bp.Release(block1)
+				wg.Done()
+			}()
+
+			block2, err := bp.Get()
+			if err != nil {
+				b.Fatal(err)
+			}
+			go func() {
+				time.Sleep(10 * time.Microsecond)
+				bp.Release(block2)
+				wg.Done()
+			}()
+
+			wg.Wait()
+			if err := bp.ClearFreeBlockChannel(true); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
 }

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -638,13 +638,11 @@ func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksFailure() {
 
 func (t *BlockPoolTest) TestGetDoesNotDeadlockOnGlobalLimit() {
 	globalSem := semaphore.NewWeighted(1)
-
 	// Pool 1 allocates the only global block.
 	bp1, err := NewGenBlockPool(1024, 1, 0, globalSem, createBlock)
 	require.NoError(t.T(), err)
 	b1, err := bp1.Get()
 	require.NoError(t.T(), err)
-
 	// Pool 2 has maxBlocks = 1, but currently has 0 blocks allocated.
 	bp2, err := NewGenBlockPool(1024, 1, 0, globalSem, createBlock)
 	require.NoError(t.T(), err)
@@ -715,14 +713,11 @@ func (t *BlockPoolTest) TestTryGetReleasePermitOnAllocationFailure() {
 	}
 	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
-
 	_, err = bp.TryGet()
-
 	require.Error(t.T(), err)
-	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
 
-	// Verify global semaphore permit was not leaked (we should be able to TryAcquire it now)
 	acquired := globalSem.TryAcquire(1)
+
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after TryGet allocation failure")
 }
 
@@ -733,14 +728,12 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
 	}
 	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
-
 	_, err = bp.Get()
-
 	require.Error(t.T(), err)
-	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
+
+	acquired := globalSem.TryAcquire(1)
 
 	// Verify global semaphore permit was not leaked
-	acquired := globalSem.TryAcquire(1)
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after Get allocation failure on first block")
 }
 
@@ -751,7 +744,6 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 	}
 	bp, err := NewGenBlockPool(1024, 2, 0, globalSem, failingCreateBlock)
 	require.NoError(t.T(), err)
-
 	// Simulate that 1 block is already allocated and the global semaphore is exhausted
 	bp.totalBlocks = 1
 	acquiredFirst := globalSem.TryAcquire(1)
@@ -762,22 +754,19 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 		_, err := bp.Get()
 		errCh <- err
 	}()
-
 	// Give the goroutine a moment to start and block
 	time.Sleep(50 * time.Millisecond)
-
 	// Release the permit to unblock waitAndGetConcurrent's Acquire
 	globalSem.Release(1)
-
 	select {
 	case err := <-errCh:
 		require.Error(t.T(), err)
-		assert.Contains(t.T(), err.Error(), "simulated allocation failure")
 	case <-time.After(1 * time.Second):
-		t.T().Fatal("timeout waiting for Get to return error")
+		require.FailNow(t.T(), "timeout waiting for Get to return error")
 	}
 
-	// Verify that the global semaphore permit was not leaked after the allocation failure
 	acquired := globalSem.TryAcquire(1)
+
+	// Verify that the global semaphore permit was not leaked after the allocation failure
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after concurrent Get allocation failure")
 }

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -706,4 +707,98 @@ func BenchmarkGetReleaseContention(b *testing.B) {
 			}
 		}
 	})
+}
+
+func (t *BlockPoolTest) TestTryGetReleasePermitOnAllocationFailure() {
+	globalSem := semaphore.NewWeighted(1)
+	failingCreateBlock := func(blockSize int64) (Block, error) {
+		return nil, fmt.Errorf("simulated allocation failure")
+	}
+
+	// Pool has 0 reserved blocks, so any allocation must acquire from global semaphore.
+	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
+	require.NoError(t.T(), err)
+
+	// TryGet should fail due to simulated allocation failure.
+	_, err = bp.TryGet()
+	require.Error(t.T(), err)
+	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
+
+	// Verify that the global semaphore permit was not leaked.
+	// Since the capacity is 1, we should be able to TryAcquire it now.
+	acquired := globalSem.TryAcquire(1)
+	assert.True(t.T(), acquired, "global semaphore permit was leaked after TryGet allocation failure")
+}
+
+func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
+	globalSem := semaphore.NewWeighted(1)
+	failingCreateBlock := func(blockSize int64) (Block, error) {
+		return nil, fmt.Errorf("simulated allocation failure")
+	}
+
+	// Pool has 0 reserved blocks, so allocation must acquire from global semaphore.
+	bp, err := NewGenBlockPool(1024, 1, 0, globalSem, failingCreateBlock)
+	require.NoError(t.T(), err)
+
+	// Get should fail due to simulated allocation failure.
+	// Since bp.totalBlocks == 0, this will route to waitAndGetFirstBlock() and block on Acquire().
+	// But since the semaphore has 1 permit, it will acquire it immediately and then fail on allocation.
+	_, err = bp.Get()
+	require.Error(t.T(), err)
+	assert.Contains(t.T(), err.Error(), "simulated allocation failure")
+
+	// Verify that the global semaphore permit was not leaked.
+	acquired := globalSem.TryAcquire(1)
+	assert.True(t.T(), acquired, "global semaphore permit was leaked after Get allocation failure on first block")
+}
+
+func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
+	globalSem := semaphore.NewWeighted(1)
+	
+	var callCount int32
+	failingCreateBlock := func(blockSize int64) (Block, error) {
+		if atomic.AddInt32(&callCount, 1) == 1 {
+			return createBlock(blockSize)
+		}
+		return nil, fmt.Errorf("simulated allocation failure")
+	}
+
+	// maxBlocks = 2, reservedBlocks = 0.
+	bp, err := NewGenBlockPool(1024, 2, 0, globalSem, failingCreateBlock)
+	require.NoError(t.T(), err)
+
+	// 1. First Get() succeeds and allocates the only global block.
+	b1, err := bp.Get()
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), b1)
+
+	// 2. Second Get() will see bp.totalBlocks = 1 (between 0 and 2) and freeBlocksCh is empty.
+	// It will call TryGet() which fails (no permit available).
+	// Then it will route to waitAndGetConcurrent() and block waiting.
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := bp.Get()
+		errCh <- err
+	}()
+
+	// Give the goroutine a moment to start and block.
+	time.Sleep(50 * time.Millisecond)
+
+	// 3. Manually release a permit to unblock the waitAndGetConcurrent's Acquire.
+	// Normally this is done by another pool releasing its block.
+	globalSem.Release(1)
+
+	// 4. The blocked Get() should wake up, try to allocate, fail, and return the error.
+	select {
+	case err := <-errCh:
+		require.Error(t.T(), err)
+		assert.Contains(t.T(), err.Error(), "simulated allocation failure")
+	case <-time.After(1 * time.Second):
+		t.T().Fatal("timeout waiting for Get to return error")
+	}
+
+	// 5. Verify that the global semaphore permit was not leaked after the allocation failure.
+	// Since we released 1 permit, and the allocation failed, the permit should be back in the semaphore.
+	acquired := globalSem.TryAcquire(1)
+	assert.True(t.T(), acquired, "global semaphore permit was leaked after concurrent Get allocation failure")
 }

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -754,7 +754,7 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
 
 func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 	globalSem := semaphore.NewWeighted(1)
-	
+
 	var callCount int32
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		if atomic.AddInt32(&callCount, 1) == 1 {


### PR DESCRIPTION
### Problem
When write operations take longer to complete, GCSFuse cannot release memory blocks back to the pool quickly and the block pool remains exhausted for longer periods.

During these periods, write threads calling `GenBlockPool.Get()` spend their time spinning in a CPU busy-loop (the `default` branch in the `select` loop), leading to near-permanent CPU starvation of the GCSFuse 

### Solution 
We removed the busy-loop. When the pool is exhausted and no new blocks can be allocated, the write thread blocks cleanly (using Go's sleeping channel/mutex mechanisms, consuming **0% CPU**). 

### Perf impact
#### Before fix
In an Orbax checkpoint writes workload, the GetBlockPool was taking ~50% of CPU for the `WriteFile operation`
<img width="3764" height="1716" alt="image" src="https://github.com/user-attachments/assets/cd4440b6-8d28-4572-9aef-771fb4b73a24" />

#### After fix
The entire call disappears from the profile. The common `appendBuffer` call that was taking 53% of the CPU earlier now takes only 5%
<img width="2504" height="759" alt="image" src="https://github.com/user-attachments/assets/5907a6a6-95e4-473f-a9e6-2fbf6a46d5e8" />


### Link to the issue in case of a bug fix.
b/524416466

### Testing details
Manual - Tested manually by adding logs.
Unit tests - Added
Integration tests - NA

### Any backward incompatible change? If so, please explain.
No