### PR TITLE
feat(metrics): Adding the metadata_cache read count metric

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -15,7 +15,10 @@
 package metadata
 
 import (
+	"fmt"
 	"math"
+	"runtime"
+	"strings"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -312,6 +315,7 @@ func (sc *statCacheBucketView) LookUpFolder(
 func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (bool, *entry) {
 	value := sc.sharedCache.LookUp(sc.key(key))
 	if value == nil {
+		logger.Infof("MetadataCache: sharedCacheLookup miss for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr, getBriefStack())
 		sc.metricHandle.MetadataCacheReadCount(1, false, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr)
 		return false, nil
 	}
@@ -331,13 +335,44 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 
 	// Has this entry expired?
 	if e.expiration.Before(now) {
+		logger.Infof("MetadataCache: sharedCacheLookup expired for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailTtlExpiredAttr, getBriefStack())
 		sc.Erase(key)
 		sc.metricHandle.MetadataCacheReadCount(1, false, entryStatus, metrics.LookupDetailTtlExpiredAttr)
 		return false, nil
 	}
 
+	logger.Infof("MetadataCache: sharedCacheLookup hit for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailFoundAttr, getBriefStack())
 	sc.metricHandle.MetadataCacheReadCount(1, true, entryStatus, metrics.LookupDetailFoundAttr)
 	return true, &e
+}
+
+func getBriefStack() string {
+	var pcs [16]uintptr
+	n := runtime.Callers(3, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	var sb strings.Builder
+	for {
+		frame, more := frames.Next()
+		if sb.Len() > 0 {
+			sb.WriteString(" -> ")
+		}
+
+		file := frame.File
+		if idx := strings.LastIndex(file, "/"); idx != -1 {
+			file = file[idx+1:]
+		}
+
+		funcName := frame.Function
+		if idx := strings.LastIndex(funcName, "/"); idx != -1 {
+			funcName = funcName[idx+1:]
+		}
+
+		sb.WriteString(fmt.Sprintf("%s (%s:%d)", funcName, file, frame.Line))
+		if !more {
+			break
+		}
+	}
+	return sb.String()
 }
 
 func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time) {

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -194,15 +194,44 @@ func (sc *statCacheBucketView) key(objectName string) string {
 	return objectName
 }
 
-func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
-	name := sc.key(m.Name)
+type lookupResult int
 
+const (
+	lookupMiss lookupResult = iota
+	lookupExpired
+	lookupHit
+)
+
+// lookUpInternal is the single source of truth for stat cache lookups and TTL expiration checks.
+// It resolves the bucket-scoped key, retrieves the entry from LRU cache, and evaluates TTL expiration.
+// If now is non-zero and the entry is expired, it erases the expired entry and returns (lookupExpired, &e).
+// It does NOT perform logging or record read metrics.
+func (sc *statCacheBucketView) lookUpInternal(key string, now time.Time) (lookupResult, *entry) {
+	value := sc.sharedCache.LookUp(sc.key(key))
+	if value == nil {
+		return lookupMiss, nil
+	}
+
+	e := value.(entry)
+
+	// Has this entry expired?
+	if !now.IsZero() && e.expiration.Before(now) {
+		sc.Erase(key)
+		return lookupExpired, &e
+	}
+
+	return lookupHit, &e
+}
+
+func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
 	// Is there already a better entry?
-	if existing := sc.sharedCache.LookUp(name); existing != nil {
-		if !shouldReplace(m, existing.(entry)) {
+	if res, existing := sc.lookUpInternal(m.Name, time.Time{}); res == lookupHit {
+		if !shouldReplace(m, *existing) {
 			return
 		}
 	}
+
+	name := sc.key(m.Name)
 
 	// Insert an entry.
 	e := entry{
@@ -216,11 +245,8 @@ func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
 }
 
 func (sc *statCacheBucketView) InsertImplicitDir(objectName string, expiration time.Time) {
-	name := sc.key(objectName)
-
 	// Is there already a better entry?
-	if existing := sc.sharedCache.LookUp(name); existing != nil {
-		e := existing.(entry)
+	if res, existing := sc.lookUpInternal(objectName, time.Time{}); res == lookupHit {
 		// The ListObjects response handles directories in two ways:
 		// 1. 'MinObject' returns explicit directory objects containing full metadata.
 		// 2. 'CollapseRun' generates placeholders for these same directories; if no
@@ -235,10 +261,12 @@ func (sc *statCacheBucketView) InsertImplicitDir(objectName string, expiration t
 		// with non-nil metadata. If metadata is present, we skip the implicit
 		// creation to avoid overwriting a real, explicit object with an inferred
 		// placeholder (which would lack metadata and have 'Generation 0').
-		if e.m != nil {
+		if existing.m != nil {
 			return
 		}
 	}
+
+	name := sc.key(objectName)
 
 	// Insert an entry.
 	e := entry{
@@ -313,14 +341,13 @@ func (sc *statCacheBucketView) LookUpFolder(
 }
 
 func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (bool, *entry) {
-	value := sc.sharedCache.LookUp(sc.key(key))
-	if value == nil {
+	result, e := sc.lookUpInternal(key, now)
+
+	if result == lookupMiss {
 		logger.Infof("MetadataCache: sharedCacheLookup miss for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr, getBriefStack())
 		sc.metricHandle.MetadataCacheReadCount(1, false, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr)
 		return false, nil
 	}
-
-	e := value.(entry)
 
 	// An entry in statCache is positive if it holds either a GCS MinObject (e.m),
 	// a GCS Folder (e.f), or is an implicit directory (e.implicitDir).
@@ -333,17 +360,15 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 		entryStatus = metrics.EntryStatusNegativeAttr
 	}
 
-	// Has this entry expired?
-	if e.expiration.Before(now) {
+	if result == lookupExpired {
 		logger.Infof("MetadataCache: sharedCacheLookup expired for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailTtlExpiredAttr, getBriefStack())
-		sc.Erase(key)
 		sc.metricHandle.MetadataCacheReadCount(1, false, entryStatus, metrics.LookupDetailTtlExpiredAttr)
 		return false, nil
 	}
 
 	logger.Infof("MetadataCache: sharedCacheLookup hit for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailFoundAttr, getBriefStack())
 	sc.metricHandle.MetadataCacheReadCount(1, true, entryStatus, metrics.LookupDetailFoundAttr)
-	return true, &e
+	return true, e
 }
 
 func getBriefStack() string {

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 // A cache mapping from name to most recent known record for the object of that
@@ -86,10 +87,11 @@ type StatCache interface {
 // Create a new bucket-view to the passed shared-cache object.
 // For dynamic-mount (mount for multiple buckets), pass bn as bucket-name.
 // For static-mout (mount for single bucket), pass bn as "".
-func NewStatCacheBucketView(sc *lru.Cache, bn string) StatCache {
+func NewStatCacheBucketView(sc *lru.Cache, bn string, metricHandle metrics.MetricHandle) StatCache {
 	return &statCacheBucketView{
-		sharedCache: sc,
-		bucketName:  bn,
+		sharedCache:  sc,
+		bucketName:   bn,
+		metricHandle: metricHandle,
 	}
 }
 
@@ -105,7 +107,8 @@ type statCacheBucketView struct {
 	// statCache object among all statCache objects
 	// using the same shared lru.Cache object.
 	// It can be empty ("").
-	bucketName string
+	bucketName   string
+	metricHandle metrics.MetricHandle
 }
 
 // An entry in the cache, pairing an object with the expiration time for the
@@ -309,17 +312,31 @@ func (sc *statCacheBucketView) LookUpFolder(
 func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (bool, *entry) {
 	value := sc.sharedCache.LookUp(sc.key(key))
 	if value == nil {
+		sc.metricHandle.MetadataCacheReadCount(1, false, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr)
 		return false, nil
 	}
 
 	e := value.(entry)
 
+	// An entry in statCache is positive if it holds either a GCS MinObject (e.m),
+	// a GCS Folder (e.f), or is an implicit directory (e.implicitDir).
+	// If all are nil/false, the entry represents a negative cache entry (i.e. we
+	// explicitly cached that the object/folder does not exist).
+	var entryStatus metrics.EntryStatus
+	if e.m != nil || e.f != nil || e.implicitDir {
+		entryStatus = metrics.EntryStatusPositiveAttr
+	} else {
+		entryStatus = metrics.EntryStatusNegativeAttr
+	}
+
 	// Has this entry expired?
 	if e.expiration.Before(now) {
 		sc.Erase(key)
+		sc.metricHandle.MetadataCacheReadCount(1, false, entryStatus, metrics.LookupDetailTtlExpiredAttr)
 		return false, nil
 	}
 
+	sc.metricHandle.MetadataCacheReadCount(1, true, entryStatus, metrics.LookupDetailFoundAttr)
 	return true, &e
 }
 

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -15,10 +15,7 @@
 package metadata
 
 import (
-	"fmt"
 	"math"
-	"runtime"
-	"strings"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
@@ -344,7 +341,6 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 	result, e := sc.lookUpInternal(key, now)
 
 	if result == lookupMiss {
-		logger.Infof("MetadataCache: sharedCacheLookup miss for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr, getBriefStack())
 		sc.metricHandle.MetadataCacheReadCount(1, false, metrics.EntryStatusAttr, metrics.LookupDetailNotFoundAttr)
 		return false, nil
 	}
@@ -361,43 +357,12 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 	}
 
 	if result == lookupExpired {
-		logger.Infof("MetadataCache: sharedCacheLookup expired for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailTtlExpiredAttr, getBriefStack())
 		sc.metricHandle.MetadataCacheReadCount(1, false, entryStatus, metrics.LookupDetailTtlExpiredAttr)
 		return false, nil
 	}
 
-	logger.Infof("MetadataCache: sharedCacheLookup hit for key %q, entryStatus: %s, lookupDetail: %s, caller: %s", key, entryStatus, metrics.LookupDetailFoundAttr, getBriefStack())
 	sc.metricHandle.MetadataCacheReadCount(1, true, entryStatus, metrics.LookupDetailFoundAttr)
 	return true, e
-}
-
-func getBriefStack() string {
-	var pcs [16]uintptr
-	n := runtime.Callers(3, pcs[:])
-	frames := runtime.CallersFrames(pcs[:n])
-	var sb strings.Builder
-	for {
-		frame, more := frames.Next()
-		if sb.Len() > 0 {
-			sb.WriteString(" -> ")
-		}
-
-		file := frame.File
-		if idx := strings.LastIndex(file, "/"); idx != -1 {
-			file = file[idx+1:]
-		}
-
-		funcName := frame.Function
-		if idx := strings.LastIndex(funcName, "/"); idx != -1 {
-			funcName = funcName[idx+1:]
-		}
-
-		sb.WriteString(fmt.Sprintf("%s (%s:%d)", funcName, file, frame.Line))
-		if !more {
-			break
-		}
-	}
-	return sb.String()
 }
 
 func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time) {

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -810,3 +810,28 @@ func (t *StatCacheTest) Test_Metrics_LookupMiss_NegativeExpired() {
 		lookupDetail: metrics.LookupDetailTtlExpiredAttr,
 	}, mockMetrics.readCounts[0])
 }
+
+func (t *StatCacheTest) Test_Metrics_InsertDoesNotIncrementReadCount() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+	m := &gcs.MinObject{Name: "file.txt", Generation: 1}
+	f := &gcs.Folder{Name: "dir/"}
+
+	// Act: Perform insertion operations
+	statCache.Insert(m, expiration)
+	statCache.InsertImplicitDir("implicit_dir/", expiration)
+	statCache.InsertFolder(f, expiration)
+	statCache.AddNegativeEntry("nonexistent", expiration)
+	statCache.AddNegativeEntryForFolder("nonexistent_folder/", expiration)
+
+	// Re-inserting existing items (which triggers lookUpInternal check inside Insert/InsertImplicitDir)
+	mUpdated := &gcs.MinObject{Name: "file.txt", Generation: 2}
+	statCache.Insert(mUpdated, expiration)
+	statCache.InsertImplicitDir("implicit_dir/", expiration)
+
+	// Assert: Insertion operations must not record read count metrics
+	assert.Equal(t.T(), 0, len(mockMetrics.readCounts))
+}
+

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 )
@@ -124,16 +125,16 @@ type MultiBucketStatCacheTest struct {
 
 func (t *StatCacheTest) SetupTest() {
 	cache := lru.NewCache(uint64((cfg.AverageSizeOfPositiveStatCacheEntry + cfg.AverageSizeOfNegativeStatCacheEntry) * capacity))
-	t.cache.wrapped = metadata.NewStatCacheBucketView(cache, "") // this demonstrates
-	t.statCache = metadata.NewStatCacheBucketView(cache, "")     // this demonstrates
+	t.cache.wrapped = metadata.NewStatCacheBucketView(cache, "", metrics.NewNoopMetrics()) // this demonstrates
+	t.statCache = metadata.NewStatCacheBucketView(cache, "", metrics.NewNoopMetrics())     // this demonstrates
 	// that if you are using a cache for a single bucket, then
 	// its prepending bucketName can be left empty("") without any problem.
 }
 
 func (t *MultiBucketStatCacheTest) SetupTest() {
 	sharedCache := lru.NewCache(uint64((cfg.AverageSizeOfPositiveStatCacheEntry + cfg.AverageSizeOfNegativeStatCacheEntry) * capacity))
-	t.multiBucketCache.fruits = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "fruits")}
-	t.multiBucketCache.spices = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "spices")}
+	t.multiBucketCache.fruits = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "fruits", metrics.NewNoopMetrics())}
+	t.multiBucketCache.spices = testHelperCache{wrapped: metadata.NewStatCacheBucketView(sharedCache, "spices", metrics.NewNoopMetrics())}
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -543,8 +544,8 @@ func (t *StatCacheTest) Test_ShouldReturnHitTrueWhenOnlyObjectAlreadyHasEntry() 
 }
 
 func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize() {
-	localCache := lru.NewCache(uint64(2700))
-	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
+	localCache := lru.NewCache(uint64(2800))
+	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket", metrics.NewNoopMetrics())
 	objectEntry1 := &gcs.MinObject{Name: "1"}
 	objectEntry2 := &gcs.MinObject{Name: "2"}
 	folderEntry := &gcs.Folder{
@@ -577,7 +578,7 @@ func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize()
 
 func (t *StatCacheTest) Test_ShouldEvictAllEntriesWithPrefixFolder() {
 	localCache := lru.NewCache(uint64(10000))
-	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
+	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket", metrics.NewNoopMetrics())
 	folderEntry1 := &gcs.Folder{
 		Name: "a",
 	}
@@ -671,4 +672,141 @@ func (t *StatCacheTest) Test_Insert_OverwritesImplicitDir() {
 	hit, result := t.statCache.LookUp(name, someTime)
 	assert.True(t.T(), hit)
 	assert.Equal(t.T(), m, result)
+}
+
+type recordedReadCount struct {
+	inc          int64
+	cacheHit     bool
+	entryStatus  metrics.EntryStatus
+	lookupDetail metrics.LookupDetail
+}
+
+type mockMetricHandle struct {
+	metrics.MetricHandle
+	readCounts []recordedReadCount
+}
+
+func (m *mockMetricHandle) MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus metrics.EntryStatus, lookupDetail metrics.LookupDetail) {
+	m.readCounts = append(m.readCounts, recordedReadCount{
+		inc:          inc,
+		cacheHit:     cacheHit,
+		entryStatus:  entryStatus,
+		lookupDetail: lookupDetail,
+	})
+}
+
+func (t *StatCacheTest) Test_Metrics_LookupMiss_NotFound() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+
+	// Act
+	hit, entry := statCache.LookUp("nonexistent", someTime)
+
+	// Assert
+	assert.False(t.T(), hit)
+	assert.Nil(t.T(), entry)
+	assert.Equal(t.T(), 1, len(mockMetrics.readCounts))
+	assert.Equal(t.T(), recordedReadCount{
+		inc:          1,
+		cacheHit:     false,
+		entryStatus:  metrics.EntryStatusAttr,
+		lookupDetail: metrics.LookupDetailNotFoundAttr,
+	}, mockMetrics.readCounts[0])
+}
+
+func (t *StatCacheTest) Test_Metrics_LookupHit_PositiveFound() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+	m := &gcs.MinObject{Name: "file.txt", Generation: 1}
+	statCache.Insert(m, expiration)
+	mockMetrics.readCounts = nil // clear insert metrics if any (insert doesn't trigger read_count anyway)
+
+	// Act
+	hit, entry := statCache.LookUp("file.txt", someTime)
+
+	// Assert
+	assert.True(t.T(), hit)
+	assert.Equal(t.T(), m.Name, entry.Name)
+	assert.Equal(t.T(), 1, len(mockMetrics.readCounts))
+	assert.Equal(t.T(), recordedReadCount{
+		inc:          1,
+		cacheHit:     true,
+		entryStatus:  metrics.EntryStatusPositiveAttr,
+		lookupDetail: metrics.LookupDetailFoundAttr,
+	}, mockMetrics.readCounts[0])
+}
+
+func (t *StatCacheTest) Test_Metrics_LookupHit_NegativeFound() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+	statCache.AddNegativeEntry("nonexistent", expiration)
+	mockMetrics.readCounts = nil
+
+	// Act
+	hit, entry := statCache.LookUp("nonexistent", someTime)
+
+	// Assert
+	assert.True(t.T(), hit)
+	assert.Nil(t.T(), entry)
+	assert.Equal(t.T(), 1, len(mockMetrics.readCounts))
+	assert.Equal(t.T(), recordedReadCount{
+		inc:          1,
+		cacheHit:     true,
+		entryStatus:  metrics.EntryStatusNegativeAttr,
+		lookupDetail: metrics.LookupDetailFoundAttr,
+	}, mockMetrics.readCounts[0])
+}
+
+func (t *StatCacheTest) Test_Metrics_LookupMiss_PositiveExpired() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+	m := &gcs.MinObject{Name: "file.txt", Generation: 1}
+	statCache.Insert(m, expiration)
+	mockMetrics.readCounts = nil
+
+	// Act
+	// expiration is 1 minute from someTime, so someTime + 2 minutes is expired
+	hit, entry := statCache.LookUp("file.txt", expiration.Add(time.Second))
+
+	// Assert
+	assert.False(t.T(), hit)
+	assert.Nil(t.T(), entry)
+	assert.Equal(t.T(), 1, len(mockMetrics.readCounts))
+	assert.Equal(t.T(), recordedReadCount{
+		inc:          1,
+		cacheHit:     false,
+		entryStatus:  metrics.EntryStatusPositiveAttr,
+		lookupDetail: metrics.LookupDetailTtlExpiredAttr,
+	}, mockMetrics.readCounts[0])
+}
+
+func (t *StatCacheTest) Test_Metrics_LookupMiss_NegativeExpired() {
+	// Arrange
+	mockMetrics := &mockMetricHandle{MetricHandle: metrics.NewNoopMetrics()}
+	localCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(localCache, "bucket", mockMetrics)
+	statCache.AddNegativeEntry("nonexistent", expiration)
+	mockMetrics.readCounts = nil
+
+	// Act
+	hit, entry := statCache.LookUp("nonexistent", expiration.Add(time.Second))
+
+	// Assert
+	assert.False(t.T(), hit)
+	assert.Nil(t.T(), entry)
+	assert.Equal(t.T(), 1, len(mockMetrics.readCounts))
+	assert.Equal(t.T(), recordedReadCount{
+		inc:          1,
+		cacheHit:     false,
+		entryStatus:  metrics.EntryStatusNegativeAttr,
+		lookupDetail: metrics.LookupDetailTtlExpiredAttr,
+	}, mockMetrics.readCounts[0])
 }

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -544,7 +544,7 @@ func (t *StatCacheTest) Test_ShouldReturnHitTrueWhenOnlyObjectAlreadyHasEntry() 
 }
 
 func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize() {
-	localCache := lru.NewCache(uint64(2800))
+	localCache := lru.NewCache(uint64(2700))
 	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket", metrics.NewNoopMetrics())
 	objectEntry1 := &gcs.MinObject{Name: "1"}
 	objectEntry2 := &gcs.MinObject{Name: "2"}
@@ -834,4 +834,3 @@ func (t *StatCacheTest) Test_Metrics_InsertDoesNotIncrementReadCount() {
 	// Assert: Insertion operations must not record read count metrics
 	assert.Equal(t.T(), 0, len(mockMetrics.readCounts))
 }
-

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 )
 
 func getMemStats() uint64 {
@@ -84,7 +85,7 @@ func TestStatCacheMemoryWorkloads(t *testing.T) {
 		baseMem := getMemStats()
 
 		sharedCache := lru.NewCache(capacity)
-		statCache := metadata.NewStatCacheBucketView(sharedCache, "")
+		statCache := metadata.NewStatCacheBucketView(sharedCache, "", metrics.NewNoopMetrics())
 
 		for _, p := range paths {
 			statCache.Insert(&gcs.MinObject{Name: p}, expiration)

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -60,7 +60,7 @@ func (t *cachingTestCommon) SetUpTestSuite() {
 	// system.
 	uncachedBucket = fake.NewFakeBucket(timeutil.RealClock(), "some_bucket", gcs.BucketType{})
 	lruCache := newLruCache(uint64(1000 * cfg.AverageSizeOfPositiveStatCacheEntry))
-	statCache := metadata.NewStatCacheBucketView(lruCache, "")
+	statCache := metadata.NewStatCacheBucketView(lruCache, "", metrics.NewNoopMetrics())
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,
@@ -477,7 +477,7 @@ func (t *MultiBucketMountCachingTest) SetUpTestSuite() {
 	// for the purposes of the file system.
 	for _, bucketName := range []string{bucket1Name, bucket2Name} {
 		uncachedBuckets[bucketName] = fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{})
-		statCache := metadata.NewStatCacheBucketView(sharedCache, bucketName)
+		statCache := metadata.NewStatCacheBucketView(sharedCache, bucketName, metrics.NewNoopMetrics())
 		buckets[bucketName] = caching.NewFastStatBucket(
 			ttl,
 			statCache,

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -497,7 +497,7 @@ func TestGCSMetrics_RequestCount_NegativeCachingShortCircuit(t *testing.T) {
 	rawBucket := fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{Hierarchical: false})
 	monitoringInnerBucket := monitor.NewMonitoringBucket(rawBucket, mh)
 	lruCache := lru.NewCache(1024 * 1024)
-	statCacheView := metadata.NewStatCacheBucketView(lruCache, "")
+	statCacheView := metadata.NewStatCacheBucketView(lruCache, "", metrics.NewNoopMetrics())
 	cachedOuterBucket := caching.NewFastStatBucket(
 		time.Minute,
 		statCacheView,

--- a/internal/fs/hns_bucket_test.go
+++ b/internal/fs/hns_bucket_test.go
@@ -164,7 +164,7 @@ func (t *HNSCachedBucketMountTest) SetupSuite() {
 	bucketType = gcs.BucketType{Hierarchical: true}
 	uncachedHNSBucket = fake.NewFakeBucket(timeutil.RealClock(), cachedHnsBucketName, bucketType)
 	lruCache := newLruCache(uint64(1000 * cfg.AverageSizeOfPositiveStatCacheEntry))
-	statCache := metadata.NewStatCacheBucketView(lruCache, "")
+	statCache := metadata.NewStatCacheBucketView(lruCache, "", metrics.NewNoopMetrics())
 	bucket = caching.NewFastStatBucket(
 		ttl,
 		statCache,

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -391,19 +391,19 @@ func (d *dirInode) checkInvariants() {
 }
 
 func (d *dirInode) lookUpChildFile(ctx context.Context, name string) (*Core, error) {
-	return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+	return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false, d.IsTypeCacheDeprecated())
 }
 
 func (d *dirInode) lookUpChildDir(ctx context.Context, name string) (*Core, error) {
 	childName := NewDirName(d.Name(), name)
 	if d.isBucketHierarchical() {
-		return findExplicitFolder(ctx, d.Bucket(), childName, false)
+		return findExplicitFolder(ctx, d.Bucket(), childName, false, d.IsTypeCacheDeprecated())
 	}
 
 	if d.implicitDirs {
 		return findDirInode(ctx, d.Bucket(), childName)
 	}
-	return findExplicitInode(ctx, d.Bucket(), childName, false)
+	return findExplicitInode(ctx, d.Bucket(), childName, false, d.IsTypeCacheDeprecated())
 }
 
 // Look up the file for a (file, dir) pair with conflicting names, overriding
@@ -437,11 +437,12 @@ func (d *dirInode) lookUpConflicting(ctx context.Context, name string) (*Core, e
 
 // findExplicitInode finds the file or dir inode core backed by an explicit
 // object in GCS with the given name. Return nil if such object does not exist.
-func findExplicitInode(ctx context.Context, bucket *gcsx.SyncerBucket, name Name, fetchOnlyFromCache bool) (*Core, error) {
+func findExplicitInode(ctx context.Context, bucket *gcsx.SyncerBucket, name Name, fetchOnlyFromCache bool, forceFetchFromGcs bool) (*Core, error) {
 	// Call the bucket.
 	req := &gcs.StatObjectRequest{
 		Name:               name.GcsObjectName(),
 		FetchOnlyFromCache: fetchOnlyFromCache,
+		ForceFetchFromGcs:  forceFetchFromGcs,
 	}
 
 	m, _, err := bucket.StatObject(ctx, req)
@@ -471,11 +472,12 @@ func findExplicitInode(ctx context.Context, bucket *gcsx.SyncerBucket, name Name
 	}, nil
 }
 
-func findExplicitFolder(ctx context.Context, bucket *gcsx.SyncerBucket, name Name, fetchOnlyFromCache bool) (*Core, error) {
+func findExplicitFolder(ctx context.Context, bucket *gcsx.SyncerBucket, name Name, fetchOnlyFromCache bool, forceFetchFromGcs bool) (*Core, error) {
 	// Call the bucket.
 	req := &gcs.GetFolderRequest{
 		Name:               name.GcsObjectName(),
 		FetchOnlyFromCache: fetchOnlyFromCache,
+		ForceFetchFromGcs:  forceFetchFromGcs,
 	}
 	folder, err := bucket.GetFolder(ctx, req)
 
@@ -682,9 +684,9 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 		var dirResult *Core
 		var dirErr error
 		if d.Bucket().BucketType().Hierarchical {
-			dirResult, dirErr = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), true)
+			dirResult, dirErr = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), true, false)
 		} else {
-			dirResult, dirErr = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), true)
+			dirResult, dirErr = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), true, false)
 		}
 
 		// If we hit a real error (not a cache miss), exit early.
@@ -698,7 +700,7 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 		}
 
 		// 2. Try File ONLY if directory wasn't found
-		fileResult, fileErr := findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), true)
+		fileResult, fileErr := findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), true, false)
 		if fileErr != nil && !errors.As(fileErr, &cacheMissErr) {
 			return nil, fileErr
 		}
@@ -753,12 +755,12 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 
 	case metadata.ExplicitDirType:
 		if d.isBucketHierarchical() {
-			return findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+			return findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false, false)
 		}
-		return findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+		return findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false, false)
 
 	case metadata.RegularFileType, metadata.SymlinkType:
-		return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+		return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false, false)
 
 	case metadata.UnknownType:
 		return d.lookUpUnknownType(ctx, name)
@@ -785,7 +787,7 @@ func (d *dirInode) lookUpUnknownType(ctx context.Context, name string) (*Core, e
 	var dirResult *Core
 
 	group.Go(func() (err error) {
-		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false, d.IsTypeCacheDeprecated())
 		return err
 	})
 
@@ -796,7 +798,7 @@ func (d *dirInode) lookUpUnknownType(ctx context.Context, name string) (*Core, e
 		})
 	} else {
 		group.Go(func() (err error) {
-			dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+			dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false, d.IsTypeCacheDeprecated())
 			return err
 		})
 	}
@@ -823,12 +825,12 @@ func (d *dirInode) lookUpHNSRace(ctx context.Context, name string) (*Core, error
 	ch := make(chan raceResult, 2)
 
 	go func() {
-		res, err := findExplicitInode(raceCtx, d.Bucket(), NewFileName(d.Name(), name), false)
+		res, err := findExplicitInode(raceCtx, d.Bucket(), NewFileName(d.Name(), name), false, d.IsTypeCacheDeprecated())
 		ch <- raceResult{core: res, err: err}
 	}()
 
 	go func() {
-		res, err := findExplicitFolder(raceCtx, d.Bucket(), NewDirName(d.Name(), name), false)
+		res, err := findExplicitFolder(raceCtx, d.Bucket(), NewDirName(d.Name(), name), false, d.IsTypeCacheDeprecated())
 		ch <- raceResult{core: res, err: err}
 	}()
 

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -193,7 +193,7 @@ func (t *HNSDirTest) TestShouldFindExplicitHNSFolder() {
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(folder, nil)
 
 	// Look up with the name.
-	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), name), false)
+	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), name), false, false)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Nil(t.T(), err)
@@ -207,7 +207,7 @@ func (t *HNSDirTest) TestShouldReturnNilWhenGCSFolderNotFoundForInHNS() {
 	t.mockBucket.On("GetFolder", mock.Anything, mock.Anything).Return(nil, notFoundErr)
 
 	// Look up with the name.
-	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), "not-present"), false)
+	result, err := findExplicitFolder(t.ctx, t.bucket, NewDirName(t.in.Name(), "not-present"), false, false)
 
 	t.mockBucket.AssertExpectations(t.T())
 	assert.Nil(t.T(), err)

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -22,8 +22,12 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/wrappers"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
@@ -1697,4 +1701,146 @@ func TestStreamingWrites_Fallback_ConcurrencyLimitBreached(t *testing.T) {
 	waitForMetricsProcessing()
 	attrs := attribute.NewSet(attribute.String("write_fallback_reason", "concurrency_limit_breached"))
 	metrics.VerifyCounterMetric(t, ctx, reader, "fs/streaming_write_fallback_count", attrs, 1, metrics.Subset())
+}
+
+type fakeBucketManagerForStatCache struct {
+	bucket    gcs.Bucket
+	statCache metadata.StatCache
+}
+
+func (bm *fakeBucketManagerForStatCache) SetUpBucket(
+	ctx context.Context,
+	name string,
+	isMultibucketMount bool,
+	mh metrics.MetricHandle) (sb gcsx.SyncerBucket, err error) {
+
+	fastBucket := caching.NewFastStatBucket(
+		10*time.Minute,
+		bm.statCache,
+		timeutil.RealClock(),
+		bm.bucket,
+		1*time.Minute,
+		true,  // IsTypeCacheDeprecated
+		false, // isImplicitDir
+	)
+
+	sb = gcsx.NewSyncerBucket(
+		0,
+		10,
+		10,
+		".gcsfuse_tmp/",
+		gcsx.NewContentTypeBucket(fastBucket),
+	)
+	return sb, nil
+}
+
+func (bm *fakeBucketManagerForStatCache) ShutDown() {}
+
+func TestMetadataCache_ReadCount_Integration(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	origProvider := otel.GetMeterProvider()
+	t.Cleanup(func() { otel.SetMeterProvider(origProvider) })
+	reader := metric.NewManualReader()
+	provider := metric.NewMeterProvider(metric.WithReader(reader))
+	otel.SetMeterProvider(provider)
+
+	mh, err := metrics.NewOTelMetrics(ctx, 1, 100)
+	require.NoError(t, err)
+
+	bucketName := "test-bucket"
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{})
+
+	lruCache := lru.NewCache(100000)
+	statCache := metadata.NewStatCacheBucketView(lruCache, bucketName, mh)
+
+	serverCfg := &fs.ServerConfig{
+		NewConfig: &cfg.Config{
+			Write:           cfg.WriteConfig{GlobalMaxBlocks: 1},
+			Read:            cfg.ReadConfig{GlobalMaxBlocks: 1},
+			EnableNewReader: true,
+			MetadataCache: cfg.MetadataCacheConfig{
+				TtlSecs: 60,
+			},
+		},
+		MetricHandle: mh,
+		TraceHandle:  tracing.NewNoopTracer(),
+		CacheClock:   &timeutil.SimulatedClock{},
+		BucketName:   bucketName,
+		BucketManager: &fakeBucketManagerForStatCache{
+			bucket:    bucket,
+			statCache: statCache,
+		},
+	}
+
+	server, err := fs.NewFileSystem(ctx, serverCfg)
+	require.NoError(t, err)
+	server = wrappers.WithMonitoring(server, mh)
+
+	// --- Step 1: Lookup nonexistent file (Miss: NotFound) ---
+	lookupOp1 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "nonexistent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp1)
+	assert.Equal(t, fuse.ENOENT, err)
+	waitForMetricsProcessing()
+
+	attrsMissNotFound := attribute.NewSet(
+		attribute.Bool("cache_hit", false),
+		attribute.String("lookup_detail", "not_found"),
+	)
+	// Expect 2 lookups: one for "nonexistent.txt/", one for "nonexistent.txt"
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsMissNotFound, 2)
+
+	// --- Step 2: Lookup nonexistent file again (Hit: Negative Found) ---
+	lookupOp2 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "nonexistent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp2)
+	assert.Equal(t, fuse.ENOENT, err)
+	waitForMetricsProcessing()
+
+	attrsHitNegative := attribute.NewSet(
+		attribute.Bool("cache_hit", true),
+		attribute.String("entry_status", "negative"),
+		attribute.String("lookup_detail", "found"),
+	)
+	// Expect 2 lookups: one for "nonexistent.txt/", one for "nonexistent.txt"
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitNegative, 2)
+
+	// --- Step 3: Lookup existent file first time (Miss: NotFound) ---
+	createWithContents(ctx, t, bucket, "existent.txt", "hello")
+	lookupOp3 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "existent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp3)
+	require.NoError(t, err)
+	waitForMetricsProcessing()
+
+	// Expect 4 lookups total: 2 from nonexistent lookup, 2 from existent lookup
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsMissNotFound, 4)
+
+	// --- Step 4: Lookup existent file again (Hit: Positive Found) ---
+	lookupOp4 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "existent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp4)
+	require.NoError(t, err)
+	waitForMetricsProcessing()
+
+	attrsHitPositive := attribute.NewSet(
+		attribute.Bool("cache_hit", true),
+		attribute.String("entry_status", "positive"),
+		attribute.String("lookup_detail", "found"),
+	)
+	// Expect 3 lookups total: LookUpInode checks both the directory form and file form,
+	// and may refresh attributes.
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitPositive, 3)
+
+	// Verifying that negative hit also got incremented by 1 (due to checking "existent.txt/")
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitNegative, 3)
 }

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -1722,6 +1722,7 @@ func (bm *fakeBucketManagerForStatCache) SetUpBucket(
 		1*time.Minute,
 		true,  // IsTypeCacheDeprecated
 		false, // isImplicitDir
+		true,  // enableEmptyManagedFolders
 	)
 
 	sb = gcsx.NewSyncerBucket(

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -1706,6 +1706,7 @@ func TestStreamingWrites_Fallback_ConcurrencyLimitBreached(t *testing.T) {
 type fakeBucketManagerForStatCache struct {
 	bucket    gcs.Bucket
 	statCache metadata.StatCache
+	clock     timeutil.Clock
 }
 
 func (bm *fakeBucketManagerForStatCache) SetUpBucket(
@@ -1715,9 +1716,9 @@ func (bm *fakeBucketManagerForStatCache) SetUpBucket(
 	mh metrics.MetricHandle) (sb gcsx.SyncerBucket, err error) {
 
 	fastBucket := caching.NewFastStatBucket(
-		10*time.Minute,
+		1*time.Minute,
 		bm.statCache,
-		timeutil.RealClock(),
+		bm.clock,
 		bm.bucket,
 		1*time.Minute,
 		true,  // IsTypeCacheDeprecated
@@ -1749,8 +1750,11 @@ func TestMetadataCache_ReadCount_Integration(t *testing.T) {
 	mh, err := metrics.NewOTelMetrics(ctx, 1, 100)
 	require.NoError(t, err)
 
+	clock := &timeutil.SimulatedClock{}
+	clock.SetTime(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
 	bucketName := "test-bucket"
-	bucket := fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{})
+	bucket := fake.NewFakeBucket(clock, bucketName, gcs.BucketType{})
 
 	lruCache := lru.NewCache(100000)
 	statCache := metadata.NewStatCacheBucketView(lruCache, bucketName, mh)
@@ -1761,16 +1765,18 @@ func TestMetadataCache_ReadCount_Integration(t *testing.T) {
 			Read:            cfg.ReadConfig{GlobalMaxBlocks: 1},
 			EnableNewReader: true,
 			MetadataCache: cfg.MetadataCacheConfig{
-				TtlSecs: 60,
+				TtlSecs:         60,
+				NegativeTtlSecs: 60,
 			},
 		},
 		MetricHandle: mh,
 		TraceHandle:  tracing.NewNoopTracer(),
-		CacheClock:   &timeutil.SimulatedClock{},
+		CacheClock:   clock,
 		BucketName:   bucketName,
 		BucketManager: &fakeBucketManagerForStatCache{
 			bucket:    bucket,
 			statCache: statCache,
+			clock:     clock,
 		},
 	}
 
@@ -1811,7 +1817,7 @@ func TestMetadataCache_ReadCount_Integration(t *testing.T) {
 	// Expect 2 lookups: one for "nonexistent.txt/", one for "nonexistent.txt"
 	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitNegative, 2)
 
-	// --- Step 3: Lookup existent file first time (Miss: NotFound) ---
+	// --- Step 3: Lookup existent file first time (Miss: NotFound + Hit: Positive on attribute refresh) ---
 	createWithContents(ctx, t, bucket, "existent.txt", "hello")
 	lookupOp3 := &fuseops.LookUpInodeOp{
 		Parent: fuseops.RootInodeID,
@@ -1824,6 +1830,13 @@ func TestMetadataCache_ReadCount_Integration(t *testing.T) {
 	// Expect 4 lookups total: 2 from nonexistent lookup, 2 from existent lookup
 	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsMissNotFound, 4)
 
+	attrsHitPositive := attribute.NewSet(
+		attribute.Bool("cache_hit", true),
+		attribute.String("entry_status", "positive"),
+		attribute.String("lookup_detail", "found"),
+	)
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitPositive, 1)
+
 	// --- Step 4: Lookup existent file again (Hit: Positive Found) ---
 	lookupOp4 := &fuseops.LookUpInodeOp{
 		Parent: fuseops.RootInodeID,
@@ -1833,15 +1846,68 @@ func TestMetadataCache_ReadCount_Integration(t *testing.T) {
 	require.NoError(t, err)
 	waitForMetricsProcessing()
 
-	attrsHitPositive := attribute.NewSet(
-		attribute.Bool("cache_hit", true),
-		attribute.String("entry_status", "positive"),
-		attribute.String("lookup_detail", "found"),
-	)
-	// Expect 3 lookups total: LookUpInode checks both the directory form and file form,
-	// and may refresh attributes.
+	// Expect 3 positive lookups total: 1 from step 3 attribute refresh, 2 from step 4 lookup + attribute refresh
 	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitPositive, 3)
-
 	// Verifying that negative hit also got incremented by 1 (due to checking "existent.txt/")
 	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitNegative, 3)
+
+	// --- Step 5: ReadDir does not increment metadata_cache/read_count ---
+	openDirOp := &fuseops.OpenDirOp{
+		Inode: fuseops.RootInodeID,
+	}
+	err = server.OpenDir(ctx, openDirOp)
+	require.NoError(t, err)
+	readDirOp := &fuseops.ReadDirOp{
+		Inode:  fuseops.RootInodeID,
+		Handle: openDirOp.Handle,
+		Dst:    make([]byte, 4096),
+	}
+	err = server.ReadDir(ctx, readDirOp)
+	require.NoError(t, err)
+	waitForMetricsProcessing()
+
+	// Verify metrics unchanged after ReadDir
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsMissNotFound, 4)
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitPositive, 3)
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitNegative, 3)
+
+	// --- Step 6: Advance clock past TTL and lookup nonexistent file (Miss: Negative TTL Expired) ---
+	clock.AdvanceTime(2 * time.Minute)
+
+	lookupOp5 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "nonexistent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp5)
+	assert.Equal(t, fuse.ENOENT, err)
+	waitForMetricsProcessing()
+
+	attrsExpiredNegative := attribute.NewSet(
+		attribute.Bool("cache_hit", false),
+		attribute.String("entry_status", "negative"),
+		attribute.String("lookup_detail", "ttl_expired"),
+	)
+	// Expect 2 lookups expired: "nonexistent.txt/" and "nonexistent.txt"
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsExpiredNegative, 2)
+
+	// --- Step 7: Lookup existent file after TTL expired (Miss: Positive and Negative TTL Expired) ---
+	lookupOp6 := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "existent.txt",
+	}
+	err = server.LookUpInode(ctx, lookupOp6)
+	require.NoError(t, err)
+	waitForMetricsProcessing()
+
+	attrsExpiredPositive := attribute.NewSet(
+		attribute.Bool("cache_hit", false),
+		attribute.String("entry_status", "positive"),
+		attribute.String("lookup_detail", "ttl_expired"),
+	)
+	// Expect 1 positive TTL expired (for "existent.txt")
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsExpiredPositive, 1)
+	// Expect negative TTL expired to increment by 1 (for "existent.txt/") -> total 3
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsExpiredNegative, 3)
+	// Post-fetch attribute check hits positive cache -> total 4
+	metrics.VerifyCounterMetric(t, ctx, reader, "metadata_cache/read_count", attrsHitPositive, 4)
 }

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -231,9 +231,9 @@ func (bm *bucketManager) SetUpBucket(
 	if bm.config.StatCacheTTL != 0 && bm.sharedStatCache != nil {
 		var statCache metadata.StatCache
 		if isMultibucketMount {
-			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, name)
+			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, name, metricHandle)
 		} else {
-			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, "")
+			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, "", metricHandle)
 		}
 
 		b = caching.NewFastStatBucket(

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -230,9 +230,9 @@ func (bm *bucketManager) SetUpBucket(
 	if bm.config.StatCacheTTL != 0 && bm.sharedStatCache != nil {
 		var statCache metadata.StatCache
 		if isMultibucketMount {
-			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, name)
+			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, name, metricHandle)
 		} else {
-			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, "")
+			statCache = metadata.NewStatCacheBucketView(bm.sharedStatCache, "", metricHandle)
 		}
 
 		b = caching.NewFastStatBucket(

--- a/internal/monitor/otelexporters.go
+++ b/internal/monitor/otelexporters.go
@@ -42,7 +42,7 @@ import (
 const serviceName = "gcsfuse"
 const cloudMonitoringMetricPrefix = "custom.googleapis.com/gcsfuse/"
 
-var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "buffered_read/", "grpc.", "read/"}
+var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "buffered_read/", "grpc.", "read/", "metadata_cache/"}
 
 // SetupOTelMetricExporters sets up the metrics exporters
 func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config, mountID string) (shutdownFn common.ShutdownFn) {

--- a/internal/monitor/otelexporters.go
+++ b/internal/monitor/otelexporters.go
@@ -55,7 +55,7 @@ import (
 const serviceName = "gcsfuse"
 const cloudMonitoringMetricPrefix = "custom.googleapis.com/gcsfuse/"
 
-var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "buffered_read/", "grpc.", "read/"}
+var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "buffered_read/", "grpc.", "read/", "metadata_cache/"}
 
 // SetupOTelMetricExporters sets up the metrics exporters
 func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config, mountID string) (shutdownFn common.ShutdownFn) {

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -572,6 +572,10 @@ func (b *fastStatBucket) StatObjectFromGcs(ctx context.Context,
 }
 
 func (b *fastStatBucket) GetFolder(ctx context.Context, req *gcs.GetFolderRequest) (*gcs.Folder, error) {
+	if req.ForceFetchFromGcs {
+		return b.getFolderFromGCS(ctx, req)
+	}
+
 	// Cache Lookup
 	if hit, entry := b.lookUpFolder(req.Name); hit {
 		// Negative entries result in NotFoundError.

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
-	. "github.com/jacobsa/oglematchers"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -26,6 +26,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+	. "github.com/jacobsa/oglematchers"
+	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -47,7 +50,7 @@ func setupIntegrationTest(t *testing.T) *integrationTestDeps {
 
 	const cacheCapacity = 100
 	lruCache := lru.NewCache(cfg.AverageSizeOfPositiveStatCacheEntry * cacheCapacity)
-	cache := metadata.NewStatCacheBucketView(lruCache, "")
+	cache := metadata.NewStatCacheBucketView(lruCache, "", metrics.NewNoopMetrics())
 	wrapped := fake.NewFakeBucket(clock, bucketName, gcs.BucketType{})
 
 	bucket := caching.NewFastStatBucket(

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -268,6 +268,10 @@ type StatObjectRequest struct {
 type GetFolderRequest struct {
 	Name string
 
+	// Relevant only when fast_stat_bucket is used. This field controls whether
+	// to fetch from gcs or from cache.
+	ForceFetchFromGcs bool
+
 	// FetchOnlyFromCache determines if the request should be served exclusively from the stat cache.
 	//
 	// If true, the request performs a cache lookup. On a cache miss, it returns a CacheMissError

--- a/metrics/metrics_test_utils.go
+++ b/metrics/metrics_test_utils.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,7 +102,7 @@ func VerifyCounterMetric(t *testing.T, ctx context.Context, reader *metric.Manua
 	}
 
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
+	require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric", attrs, metricName))
 }
 
 // VerifyHistogramMetric finds a histogram metric across all scopes and verifies its count.
@@ -146,7 +147,7 @@ func VerifyHistogramMetric(t *testing.T, ctx context.Context, reader *metric.Man
 		}
 	}
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
+	require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric", attrs, metricName))
 }
 
 // VerifyHistogramFull finds a histogram metric and fully verifies its state including total count, sum, and bucket distribution.
@@ -200,5 +201,5 @@ func VerifyHistogramFull[T int64 | float64](t *testing.T, ctx context.Context, r
 		}
 	}
 	require.True(t, foundMetric, "metric %s not found", metricName)
-	require.Fail(t, "Data point for attributes %v not found in %s metric", attrs, metricName)
+	require.Fail(t, fmt.Sprintf("Data point for attributes %v not found in %s metric", attrs, metricName))
 }

--- a/tools/integration_tests/monitoring/prom_test.go
+++ b/tools/integration_tests/monitoring/prom_test.go
@@ -50,6 +50,36 @@ func (p *PromTest) TestFsOpsErrorMetrics() {
 	assertNonZeroHistogramMetric(p.T(), "fs_ops_latency", "fs_op", "LookUpInode", prometheusPort)
 }
 
+func (p *PromTest) TestMetadataCacheReadCountMetrics() {
+	prometheusPort := p.prometheusPort
+	// Stat non-existent file -> miss not_found
+	nonExistentFile := path.Join(testEnv.testDirPath, "non_existent_meta_cache_file.txt")
+	_, err := os.Stat(nonExistentFile)
+	require.Error(p.T(), err)
+	assertNonZeroCountMetricWithLabels(p.T(), "metadata_cache_read_count", map[string]string{
+		"cache_hit":     "false",
+		"lookup_detail": "not_found",
+	}, prometheusPort)
+
+	// Stat non-existent file second time -> hit negative found
+	_, err = os.Stat(nonExistentFile)
+	require.Error(p.T(), err)
+	assertNonZeroCountMetricWithLabels(p.T(), "metadata_cache_read_count", map[string]string{
+		"cache_hit":     "true",
+		"entry_status":  "negative",
+		"lookup_detail": "found",
+	}, prometheusPort)
+
+	// Stat existent file -> hit positive found
+	_, err = os.Stat(path.Join(testEnv.testDirPath, "hello.txt"))
+	require.NoError(p.T(), err)
+	assertNonZeroCountMetricWithLabels(p.T(), "metadata_cache_read_count", map[string]string{
+		"cache_hit":     "true",
+		"entry_status":  "positive",
+		"lookup_detail": "found",
+	}, prometheusPort)
+}
+
 func (p *PromTest) TestListMetrics() {
 	prometheusPort := p.prometheusPort
 	_, err := os.ReadDir(testEnv.testDirPath)

--- a/tools/integration_tests/monitoring/setup_test.go
+++ b/tools/integration_tests/monitoring/setup_test.go
@@ -141,6 +141,34 @@ func assertNonZeroCountMetric(t *testing.T, metricName, labelName, labelValue st
 	require.Fail(t, fmt.Sprintf("Metric %s with label %s=%s not found or zero", metricName, labelName, labelValue))
 }
 
+func assertNonZeroCountMetricWithLabels(t *testing.T, metricName string, expectedLabels map[string]string, prometheusPort int) {
+	t.Helper()
+	mf, err := parsePromFormat(t, prometheusPort)
+	require.NoError(t, err)
+	for k, v := range mf {
+		if k != metricName || *v.Type != promclient.MetricType_COUNTER {
+			continue
+		}
+		for _, m := range v.Metric {
+			matched := true
+			labelMap := make(map[string]string)
+			for _, l := range m.Label {
+				labelMap[*l.Name] = *l.Value
+			}
+			for expK, expV := range expectedLabels {
+				if labelMap[expK] != expV {
+					matched = false
+					break
+				}
+			}
+			if matched && *m.Counter.Value > 0 {
+				return
+			}
+		}
+	}
+	require.Fail(t, fmt.Sprintf("Metric %s with labels %v not found or zero", metricName, expectedLabels))
+}
+
 func assertNonZeroHistogramMetric(t *testing.T, metricName, labelName, labelValue string, prometheusPort int) {
 	t.Helper()
 	mf, err := parsePromFormat(t, prometheusPort)


### PR DESCRIPTION
### Description
Adding a metric to capture the metadata cache reads.
Hits & misses, more detail on the cache lookup and if cached entry is positive or negative.

### Link to the issue in case of a bug fix.
b/512002923

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A