### PR TITLE
feat(retry): enhance retry logging for operations via storage-client

### DIFF
--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -441,7 +441,7 @@ func TestGCSMetrics_RetryCount(t *testing.T) {
 
 	// Simulate a retryable error (e.g. 429)
 	var err error = &googleapi.Error{Code: 429}
-	shouldRetry := storageutil.ShouldRetryWithMonitoring(ctx, err, mh)
+	shouldRetry := storageutil.ShouldRetryWithMonitoringAndRetryContext(ctx, err, nil, mh)
 	require.True(t, shouldRetry)
 
 	waitForMetricsProcessing()
@@ -453,7 +453,7 @@ func TestGCSMetrics_RetryCount(t *testing.T) {
 
 	// Simulate a DeadlineExceeded error (Stalled Read)
 	err = context.DeadlineExceeded
-	shouldRetry = storageutil.ShouldRetryWithMonitoring(ctx, err, mh)
+	shouldRetry = storageutil.ShouldRetryWithMonitoringAndRetryContext(ctx, err, nil, mh)
 	require.True(t, shouldRetry)
 
 	waitForMetricsProcessing()

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -175,8 +175,8 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 		storage.WithPolicy(storage.RetryAlways),
 		storage.WithMaxAttempts(clientConfig.MaxRetryAttempts),
 		storage.WithMaxRetryDuration(0),
-		storage.WithErrorFunc(func(err error) bool {
-			return storageutil.ShouldRetryWithMonitoring(ctx, err, clientConfig.MetricHandle)
+		storage.WithErrorFuncWithContext(func(err error, retryCtx *storage.RetryContext) bool {
+			return storageutil.ShouldRetryWithMonitoringAndContext(ctx, err, retryCtx, clientConfig.MetricHandle)
 		})}
 
 	sc.SetRetry(retryOpts...)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -176,7 +176,7 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 		storage.WithMaxAttempts(clientConfig.MaxRetryAttempts),
 		storage.WithMaxRetryDuration(0),
 		storage.WithErrorFuncWithContext(func(err error, retryCtx *storage.RetryContext) bool {
-			return storageutil.ShouldRetryWithMonitoringAndContext(ctx, err, retryCtx, clientConfig.MetricHandle)
+			return storageutil.ShouldRetryWithMonitoringAndRetryContext(ctx, err, retryCtx, clientConfig.MetricHandle)
 		})}
 
 	sc.SetRetry(retryOpts...)

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -17,6 +17,7 @@ package storageutil
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
@@ -76,18 +77,25 @@ func ShouldRetryWithoutLogging(err error) bool {
 }
 
 // ShouldRetry checks if the given error is transient and should be retried.
-// It logs a warning message with the error details for any retryable error.
+// It logs a warning message with the error details and execution context (TraceID, remaining budget) for any retryable error.
 // Returns true if the error is retryable, false otherwise.
-func ShouldRetry(err error) bool {
+func ShouldRetry(ctx context.Context, err error) bool {
+	return ShouldRetryWithContext(ctx, err, nil)
+}
+
+// ShouldRetryWithContext checks if the given error is transient and should be retried,
+// logging the retry warning with rich context from both the execution context (TraceID, remaining budget)
+// and the Go Storage SDK's experimental RetryContext (operation, bucket, object, attempt, invocation ID).
+func ShouldRetryWithContext(ctx context.Context, err error, retryCtx *storage.RetryContext) bool {
 	switch determineRetryAction(err) {
 	case retryTransient:
-		logger.Warnf("Retrying for the error: %v", err)
+		logRetryWithContext("Retrying for transient error", err, retryCtx)
 		return true
 	case retry401:
-		logger.Warnf("Retrying for error-code 401: %v", err)
+		logRetryWithContext("Retrying for error-code 401", err, retryCtx)
 		return true
 	case retryUnauthenticated:
-		logger.Warnf("Retrying for UNAUTHENTICATED error: %v", err)
+		logRetryWithContext("Retrying for UNAUTHENTICATED error", err, retryCtx)
 		return true
 	default:
 		return false
@@ -95,11 +103,20 @@ func ShouldRetry(err error) bool {
 }
 
 func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metrics.MetricHandle) bool {
+	return ShouldRetryWithMonitoringAndContext(ctx, err, nil, metricHandle)
+}
+
+func ShouldRetryWithMonitoringAndContext(
+	ctx context.Context,
+	err error,
+	retryCtx *storage.RetryContext,
+	metricHandle metrics.MetricHandle,
+) bool {
 	if err == nil {
 		return false
 	}
 
-	retry := ShouldRetry(err)
+	retry := ShouldRetryWithContext(ctx, err, retryCtx)
 	if !retry {
 		return false
 	}
@@ -111,4 +128,21 @@ func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metr
 
 	metricHandle.GcsRetryCount(1, val)
 	return retry
+}
+
+func logRetryWithContext(prefix string, err error, retryCtx *storage.RetryContext) {
+	var errorDetails string
+	if typed, ok := err.(*googleapi.Error); ok {
+		errorDetails = fmt.Sprintf(" [HTTP Code: %d, Message: %q]", typed.Code, typed.Message)
+	} else if st, ok := status.FromError(err); ok {
+		errorDetails = fmt.Sprintf(" [gRPC Code: %s, Message: %q]", st.Code().String(), st.Message())
+	}
+
+	var sdkRetryInfo string
+	if retryCtx != nil {
+		sdkRetryInfo = fmt.Sprintf(" [Op: %s, Bucket: %q, Object: %q, Attempt: %d, InvocationID: %s]",
+			retryCtx.Operation, retryCtx.Bucket, retryCtx.Object, retryCtx.Attempt, retryCtx.InvocationID)
+	}
+
+	logger.Warnf("%s: %v%s%s", prefix, err, errorDetails, sdkRetryInfo)
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -17,7 +17,6 @@ package storageutil
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
@@ -80,19 +79,25 @@ func ShouldRetryWithoutLogging(err error) bool {
 // logging the retry warning with RetryContext (operation, bucket, object, attempt, invocation ID).
 // Returns true if the error is retryable, false otherwise.
 func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
+	var prefix string
 	switch determineRetryAction(err) {
 	case retryTransient:
-		logWithRetryContext("Retrying for transient error", err, retryCtx)
-		return true
+		prefix = "Retrying for transient error"
 	case retry401:
-		logWithRetryContext("Retrying for error-code 401", err, retryCtx)
-		return true
+		prefix = "Retrying for error-code 401"
 	case retryUnauthenticated:
-		logWithRetryContext("Retrying for UNAUTHENTICATED error", err, retryCtx)
-		return true
+		prefix = "Retrying for UNAUTHENTICATED error"
 	default:
 		return false
 	}
+
+	if retryCtx != nil {
+		logger.Warnf("%s: %v, InvocationID: %s, Attempt: %d, Op: %s, Object: %q",
+			prefix, err, retryCtx.InvocationID, retryCtx.Attempt, retryCtx.Operation, retryCtx.Object)
+	} else {
+		logger.Warnf("%s: %v", prefix, err)
+	}
+	return true
 }
 
 func ShouldRetryWithMonitoringAndRetryContext(
@@ -117,14 +122,4 @@ func ShouldRetryWithMonitoringAndRetryContext(
 
 	metricHandle.GcsRetryCount(1, val)
 	return retry
-}
-
-func logWithRetryContext(prefix string, err error, retryCtx *storage.RetryContext) {
-	var retryInfo string
-	if retryCtx != nil {
-		retryInfo = fmt.Sprintf(" [Op: %s, Object: %q, Attempt: %d, InvocationID: %s]",
-			retryCtx.Operation, retryCtx.Object, retryCtx.Attempt, retryCtx.InvocationID)
-	}
-
-	logger.Warnf("%s: %v%s", prefix, err, retryInfo)
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -77,26 +77,22 @@ func ShouldRetryWithoutLogging(err error) bool {
 }
 
 // ShouldRetryWithRetryContext checks if the given error is transient and should be retried,
-// logging the retry warning with rich context from both the execution context (TraceID, remaining budget)
-// and the Go Storage SDK's experimental RetryContext (operation, bucket, object, attempt, invocation ID).
+// logging the retry warning with RetryContext (operation, bucket, object, attempt, invocation ID).
+// Returns true if the error is retryable, false otherwise.
 func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
 	switch determineRetryAction(err) {
 	case retryTransient:
-		logRetryWithContext("Retrying for transient error", err, retryCtx)
+		logWithRetryContext("Retrying for transient error", err, retryCtx)
 		return true
 	case retry401:
-		logRetryWithContext("Retrying for error-code 401", err, retryCtx)
+		logWithRetryContext("Retrying for error-code 401", err, retryCtx)
 		return true
 	case retryUnauthenticated:
-		logRetryWithContext("Retrying for UNAUTHENTICATED error", err, retryCtx)
+		logWithRetryContext("Retrying for UNAUTHENTICATED error", err, retryCtx)
 		return true
 	default:
 		return false
 	}
-}
-
-func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metrics.MetricHandle) bool {
-	return ShouldRetryWithMonitoringAndRetryContext(ctx, err, nil, metricHandle)
 }
 
 func ShouldRetryWithMonitoringAndRetryContext(
@@ -123,12 +119,12 @@ func ShouldRetryWithMonitoringAndRetryContext(
 	return retry
 }
 
-func logRetryWithContext(prefix string, err error, retryCtx *storage.RetryContext) {
-	var sdkRetryInfo string
+func logWithRetryContext(prefix string, err error, retryCtx *storage.RetryContext) {
+	var retryInfo string
 	if retryCtx != nil {
-		sdkRetryInfo = fmt.Sprintf(" [Op: %s, Object: %q, Attempt: %d, InvocationID: %s]",
+		retryInfo = fmt.Sprintf(" [Op: %s, Object: %q, Attempt: %d, InvocationID: %s]",
 			retryCtx.Operation, retryCtx.Object, retryCtx.Attempt, retryCtx.InvocationID)
 	}
 
-	logger.Warnf("%s: %v%s", prefix, err, sdkRetryInfo)
+	logger.Warnf("%s: %v%s", prefix, err, retryInfo)
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -76,17 +76,10 @@ func ShouldRetryWithoutLogging(err error) bool {
 	return determineRetryAction(err) != noRetry
 }
 
-// ShouldRetry checks if the given error is transient and should be retried.
-// It logs a warning message with the error details and execution context (TraceID, remaining budget) for any retryable error.
-// Returns true if the error is retryable, false otherwise.
-func ShouldRetry(ctx context.Context, err error) bool {
-	return ShouldRetryWithContext(ctx, err, nil)
-}
-
-// ShouldRetryWithContext checks if the given error is transient and should be retried,
+// ShouldRetryWithRetryContext checks if the given error is transient and should be retried,
 // logging the retry warning with rich context from both the execution context (TraceID, remaining budget)
 // and the Go Storage SDK's experimental RetryContext (operation, bucket, object, attempt, invocation ID).
-func ShouldRetryWithContext(ctx context.Context, err error, retryCtx *storage.RetryContext) bool {
+func ShouldRetryWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
 	switch determineRetryAction(err) {
 	case retryTransient:
 		logRetryWithContext("Retrying for transient error", err, retryCtx)
@@ -103,10 +96,10 @@ func ShouldRetryWithContext(ctx context.Context, err error, retryCtx *storage.Re
 }
 
 func ShouldRetryWithMonitoring(ctx context.Context, err error, metricHandle metrics.MetricHandle) bool {
-	return ShouldRetryWithMonitoringAndContext(ctx, err, nil, metricHandle)
+	return ShouldRetryWithMonitoringAndRetryContext(ctx, err, nil, metricHandle)
 }
 
-func ShouldRetryWithMonitoringAndContext(
+func ShouldRetryWithMonitoringAndRetryContext(
 	ctx context.Context,
 	err error,
 	retryCtx *storage.RetryContext,
@@ -116,7 +109,7 @@ func ShouldRetryWithMonitoringAndContext(
 		return false
 	}
 
-	retry := ShouldRetryWithContext(ctx, err, retryCtx)
+	retry := ShouldRetryWithRetryContext(err, retryCtx)
 	if !retry {
 		return false
 	}
@@ -131,18 +124,11 @@ func ShouldRetryWithMonitoringAndContext(
 }
 
 func logRetryWithContext(prefix string, err error, retryCtx *storage.RetryContext) {
-	var errorDetails string
-	if typed, ok := err.(*googleapi.Error); ok {
-		errorDetails = fmt.Sprintf(" [HTTP Code: %d, Message: %q]", typed.Code, typed.Message)
-	} else if st, ok := status.FromError(err); ok {
-		errorDetails = fmt.Sprintf(" [gRPC Code: %s, Message: %q]", st.Code().String(), st.Message())
-	}
-
 	var sdkRetryInfo string
 	if retryCtx != nil {
-		sdkRetryInfo = fmt.Sprintf(" [Op: %s, Bucket: %q, Object: %q, Attempt: %d, InvocationID: %s]",
-			retryCtx.Operation, retryCtx.Bucket, retryCtx.Object, retryCtx.Attempt, retryCtx.InvocationID)
+		sdkRetryInfo = fmt.Sprintf(" [Op: %s, Object: %q, Attempt: %d, InvocationID: %s]",
+			retryCtx.Operation, retryCtx.Object, retryCtx.Attempt, retryCtx.InvocationID)
 	}
 
-	logger.Warnf("%s: %v%s%s", prefix, err, errorDetails, sdkRetryInfo)
+	logger.Warnf("%s: %v%s", prefix, err, sdkRetryInfo)
 }

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -313,7 +313,6 @@ func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
 	// Assert
 	assert.True(t, retry)
 	logMsg := buf.String()
-	t.Logf("Captured Log Message:\n%s", logMsg)
 	assert.Contains(t, logMsg, "WARNING")
 	assert.Contains(t, logMsg, "Retrying for error-code 401")
 	assert.Contains(t, logMsg, "Invalid Credential")
@@ -322,6 +321,31 @@ func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
 	assert.Contains(t, logMsg, "Attempt: 3")
 	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")
 }
+
+func TestShouldRetryLogsWarningWithNilRetryContext(t *testing.T) {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	var err401 = &googleapi.Error{
+		Code:    401,
+		Message: "Invalid Credential",
+	}
+
+	// Act
+	retry := ShouldRetryWithRetryContext(err401, nil)
+
+	// Assert
+	assert.True(t, retry)
+	logMsg := buf.String()
+	assert.Contains(t, logMsg, "WARNING")
+	assert.Contains(t, logMsg, "Retrying for error-code 401: googleapi: Error 401: Invalid Credential")
+	assert.NotContains(t, logMsg, "Op:")
+	assert.NotContains(t, logMsg, "Object:")
+	assert.NotContains(t, logMsg, "Attempt:")
+	assert.NotContains(t, logMsg, "InvocationID:")
+}
+
 
 type fakeMetricHandle struct {
 	metrics.MetricHandle

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"testing"
 
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/stretchr/testify/assert"
@@ -49,9 +50,9 @@ func TestShouldRetryReturnsTrueWithGoogleApiError(t *testing.T) {
 		Body: "API rate limit exceeded",
 	}
 
-	assert.Equal(t, true, ShouldRetry(&err401))
-	assert.Equal(t, true, ShouldRetry(&err502))
-	assert.Equal(t, true, ShouldRetry(&err429))
+	assert.Equal(t, true, ShouldRetry(context.Background(), &err401))
+	assert.Equal(t, true, ShouldRetry(context.Background(), &err502))
+	assert.Equal(t, true, ShouldRetry(context.Background(), &err429))
 }
 
 func TestShouldRetryReturnsFalseWithGoogleApiError400(t *testing.T) {
@@ -60,15 +61,15 @@ func TestShouldRetryReturnsFalseWithGoogleApiError400(t *testing.T) {
 		Code: 400,
 	}
 
-	assert.Equal(t, false, ShouldRetry(&err400))
+	assert.Equal(t, false, ShouldRetry(context.Background(), &err400))
 }
 
 func TestShouldRetryReturnsTrueWithUnexpectedEOFError(t *testing.T) {
-	assert.Equal(t, true, ShouldRetry(io.ErrUnexpectedEOF))
+	assert.Equal(t, true, ShouldRetry(context.Background(), io.ErrUnexpectedEOF))
 }
 
 func TestShouldRetryReturnsTrueWithNetworkError(t *testing.T) {
-	assert.Equal(t, true, ShouldRetry(net.ErrClosed))
+	assert.Equal(t, true, ShouldRetry(context.Background(), net.ErrClosed))
 }
 
 func TestShouldRetryReturnsTrueForConnectionRefusedAndResetErrors(t *testing.T) {
@@ -121,7 +122,7 @@ func TestShouldRetryReturnsTrueForConnectionRefusedAndResetErrors(t *testing.T) 
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualResult := ShouldRetry(tc.err)
+			actualResult := ShouldRetry(context.Background(), tc.err)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}
@@ -147,7 +148,7 @@ func TestShouldRetryReturnsTrueForUnauthenticatedGrpcErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualResult := ShouldRetry(tc.err)
+			actualResult := ShouldRetry(context.Background(), tc.err)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}
@@ -281,12 +282,49 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	}
 
 	// Act
-	retry := ShouldRetry(err401)
+	retry := ShouldRetry(context.Background(), err401)
 
 	// Assert
 	assert.True(t, retry)
 	assert.Contains(t, buf.String(), "WARNING")
 	assert.Contains(t, buf.String(), "Retrying for error-code 401")
+}
+
+func TestShouldRetryLogsWarningWithSDKRetryContext(t *testing.T) {
+	// Arrange
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	var err401 = &googleapi.Error{
+		Code:    401,
+		Message: "Invalid Credential",
+	}
+
+	// Create SDK RetryContext
+	retryCtx := &storage.RetryContext{
+		Attempt:      3,
+		InvocationID: "mock-invocation-id-123",
+		Operation:    "GetObject",
+		Bucket:       "my-test-bucket",
+		Object:       "some/file.txt",
+	}
+
+	// Act
+	retry := ShouldRetryWithContext(context.Background(), err401, retryCtx)
+
+	// Assert
+	assert.True(t, retry)
+	logMsg := buf.String()
+	t.Logf("Captured Log Message:\n%s", logMsg)
+	assert.Contains(t, logMsg, "WARNING")
+	assert.Contains(t, logMsg, "Retrying for error-code 401")
+	assert.Contains(t, logMsg, "[HTTP Code: 401, Message: ")
+	assert.Contains(t, logMsg, "Invalid Credential")
+	assert.Contains(t, logMsg, "[Op: GetObject, Bucket: ")
+	assert.Contains(t, logMsg, "my-test-bucket")
+	assert.Contains(t, logMsg, "some/file.txt")
+	assert.Contains(t, logMsg, "Attempt: 3")
+	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")
 }
 
 type fakeMetricHandle struct {

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -50,9 +50,9 @@ func TestShouldRetryReturnsTrueWithGoogleApiError(t *testing.T) {
 		Body: "API rate limit exceeded",
 	}
 
-	assert.Equal(t, true, ShouldRetry(context.Background(), &err401))
-	assert.Equal(t, true, ShouldRetry(context.Background(), &err502))
-	assert.Equal(t, true, ShouldRetry(context.Background(), &err429))
+	assert.Equal(t, true, ShouldRetryWithRetryContext(&err401, nil))
+	assert.Equal(t, true, ShouldRetryWithRetryContext(&err502, nil))
+	assert.Equal(t, true, ShouldRetryWithRetryContext(&err429, nil))
 }
 
 func TestShouldRetryReturnsFalseWithGoogleApiError400(t *testing.T) {
@@ -61,15 +61,15 @@ func TestShouldRetryReturnsFalseWithGoogleApiError400(t *testing.T) {
 		Code: 400,
 	}
 
-	assert.Equal(t, false, ShouldRetry(context.Background(), &err400))
+	assert.Equal(t, false, ShouldRetryWithRetryContext(&err400, nil))
 }
 
 func TestShouldRetryReturnsTrueWithUnexpectedEOFError(t *testing.T) {
-	assert.Equal(t, true, ShouldRetry(context.Background(), io.ErrUnexpectedEOF))
+	assert.Equal(t, true, ShouldRetryWithRetryContext(io.ErrUnexpectedEOF, nil))
 }
 
 func TestShouldRetryReturnsTrueWithNetworkError(t *testing.T) {
-	assert.Equal(t, true, ShouldRetry(context.Background(), net.ErrClosed))
+	assert.Equal(t, true, ShouldRetryWithRetryContext(net.ErrClosed, nil))
 }
 
 func TestShouldRetryReturnsTrueForConnectionRefusedAndResetErrors(t *testing.T) {
@@ -122,7 +122,7 @@ func TestShouldRetryReturnsTrueForConnectionRefusedAndResetErrors(t *testing.T) 
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualResult := ShouldRetry(context.Background(), tc.err)
+			actualResult := ShouldRetryWithRetryContext(tc.err, nil)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}
@@ -148,7 +148,7 @@ func TestShouldRetryReturnsTrueForUnauthenticatedGrpcErrors(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			actualResult := ShouldRetry(context.Background(), tc.err)
+			actualResult := ShouldRetryWithRetryContext(tc.err, nil)
 			assert.Equal(t, tc.expectedResult, actualResult)
 		})
 	}
@@ -282,7 +282,7 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	}
 
 	// Act
-	retry := ShouldRetry(context.Background(), err401)
+	retry := ShouldRetryWithRetryContext(err401, nil)
 
 	// Assert
 	assert.True(t, retry)
@@ -310,7 +310,7 @@ func TestShouldRetryLogsWarningWithSDKRetryContext(t *testing.T) {
 	}
 
 	// Act
-	retry := ShouldRetryWithContext(context.Background(), err401, retryCtx)
+	retry := ShouldRetryWithRetryContext(err401, retryCtx)
 
 	// Assert
 	assert.True(t, retry)
@@ -318,10 +318,8 @@ func TestShouldRetryLogsWarningWithSDKRetryContext(t *testing.T) {
 	t.Logf("Captured Log Message:\n%s", logMsg)
 	assert.Contains(t, logMsg, "WARNING")
 	assert.Contains(t, logMsg, "Retrying for error-code 401")
-	assert.Contains(t, logMsg, "[HTTP Code: 401, Message: ")
 	assert.Contains(t, logMsg, "Invalid Credential")
-	assert.Contains(t, logMsg, "[Op: GetObject, Bucket: ")
-	assert.Contains(t, logMsg, "my-test-bucket")
+	assert.Contains(t, logMsg, "[Op: GetObject, Object: ")
 	assert.Contains(t, logMsg, "some/file.txt")
 	assert.Contains(t, logMsg, "Attempt: 3")
 	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -317,7 +317,7 @@ func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
 	assert.Contains(t, logMsg, "WARNING")
 	assert.Contains(t, logMsg, "Retrying for error-code 401")
 	assert.Contains(t, logMsg, "Invalid Credential")
-	assert.Contains(t, logMsg, "[Op: GetObject, Object: ")
+	assert.Contains(t, logMsg, "Op: GetObject, Object: ")
 	assert.Contains(t, logMsg, "some/file.txt")
 	assert.Contains(t, logMsg, "Attempt: 3")
 	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -346,7 +346,6 @@ func TestShouldRetryLogsWarningWithNilRetryContext(t *testing.T) {
 	assert.NotContains(t, logMsg, "InvocationID:")
 }
 
-
 type fakeMetricHandle struct {
 	metrics.MetricHandle
 

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -290,7 +290,7 @@ func TestShouldRetryLogsWarning(t *testing.T) {
 	assert.Contains(t, buf.String(), "Retrying for error-code 401")
 }
 
-func TestShouldRetryLogsWarningWithSDKRetryContext(t *testing.T) {
+func TestShouldRetryLogsWarningWithRetryContext(t *testing.T) {
 	// Arrange
 	var buf logBuffer
 	logger.SetOutput(&buf)
@@ -299,8 +299,6 @@ func TestShouldRetryLogsWarningWithSDKRetryContext(t *testing.T) {
 		Code:    401,
 		Message: "Invalid Credential",
 	}
-
-	// Create SDK RetryContext
 	retryCtx := &storage.RetryContext{
 		Attempt:      3,
 		InvocationID: "mock-invocation-id-123",
@@ -360,7 +358,7 @@ func TestShouldRetryWithMonitoringForNonRetryableErrors(t *testing.T) {
 				MetricHandle: metrics.NewNoopMetrics(),
 			}
 
-			shouldRetry := ShouldRetryWithMonitoring(context.Background(), tc.err, fakeMetrics)
+			shouldRetry := ShouldRetryWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
 
 			assert.False(t, shouldRetry)
 			assert.False(t, fakeMetrics.gcsRetryCountCalled)
@@ -394,7 +392,7 @@ func TestShouldRetryWithMonitoringForRetryableErrors(t *testing.T) {
 				MetricHandle: metrics.NewNoopMetrics(),
 			}
 
-			shouldRetry := ShouldRetryWithMonitoring(context.Background(), tc.err, fakeMetrics)
+			shouldRetry := ShouldRetryWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
 
 			assert.True(t, shouldRetry)
 			assert.True(t, fakeMetrics.gcsRetryCountCalled)

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -561,7 +561,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_Composition
 	}
 	// Wrap default ShouldRetry and also allow customErr
 	customShouldRetry := func(err error) bool {
-		return ShouldRetry(err) || errors.Is(err, customErr)
+		return ShouldRetry(context.Background(), err) || errors.Is(err, customErr)
 	}
 
 	// Act

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -561,7 +561,7 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithCustomShouldRetry_Composition
 	}
 	// Wrap default ShouldRetry and also allow customErr
 	customShouldRetry := func(err error) bool {
-		return ShouldRetry(context.Background(), err) || errors.Is(err, customErr)
+		return ShouldRetryWithRetryContext(err, nil) || errors.Is(err, customErr)
 	}
 
 	// Act

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -51,7 +51,7 @@ const maxStorageClientRetryAttempts = 10
 const networkUnreachableError = "network is unreachable"
 
 func ShouldRetryForTest(err error) (b bool) {
-	b = storageutil.ShouldRetry(err)
+	b = storageutil.ShouldRetryWithRetryContext(err, nil)
 	if b {
 		log.Printf("Retrying for the error: %v", err)
 		return


### PR DESCRIPTION
### Description
- Using the the custom retrier function which provides more context about the retry, like, operation_name, attempt, retry_id (to trace all the retry for a given GCS api call). Integrate the changes for PR: https://github.com/googleapis/google-cloud-go/pull/13750
- Command used to trigger retry: `./gcsfuse --custom-endpoint="http://localhost:9999" --log-file=gcsfuse.log --log-format=text test-bucket mnt_test`
- Invocation-id can be used to collect all the retry logs for a particular invocation from GCSFuse.

**Before change:**
```
time="17/06/2026 01:04:41.376848" severity=WARNING message="Retrying for the error: Get \"http://localhost:9999/b/test-bucket/o?alt=json&delimiter=%2F&endOffset=&fields=nextPageToken%2Cprefixes%2Citems%28generation%2Cmetageneration%2Cupdated%2Cmetadata%2CcontentEncoding%2Ccrc32c%2Cname%2Csize%29&includeFoldersAsPrefixes=false&includeTrailingDelimiter=true&matchGlob=&maxResults=5000&pageToken=&prefix=&prettyPrint=false&projection=noAcl&startOffset=&versions=false\": dial tcp 127.0.0.1:9999: connect: connection refused" mount-id=test-bucket-668a92ca
```

**After change:**
```
time="17/06/2026 12:59:52.354686" severity=WARNING message="Retrying for transient error: Get \"http://localhost:9999/b/test-bucket/o?alt=json&delimiter=%2F&endOffset=&fields=nextPageToken%2Cprefixes%2Citems%28contentEncoding%2Ccrc32c%2Cname%2Csize%2Cgeneration%2Cmetageneration%2Cupdated%2Cmetadata%29&includeFoldersAsPrefixes=false&includeTrailingDelimiter=true&matchGlob=&maxResults=5000&pageToken=&prefix=&prettyPrint=false&projection=noAcl&startOffset=&versions=false\": dial tcp 127.0.0.1:9999: connect: connection refused, InvocationID: 1ef8ca0f-89a1-4b87-b4f5-183a4d38881d, Attempt: 6, Op: ListObjects, Object: \"\"" mount-id=test-bucket-236e2d01
```

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - tested with custom-endpoint.
2. Unit tests - added.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
