### PR TITLE
test(fix flaky test): fixing flaky TestZonalFileCacheReaderTestSuite

### DIFF
--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -110,9 +110,15 @@ func (t *fileCacheReaderTest) SetupTest() {
 }
 
 func (t *fileCacheReaderTest) TearDownTest() {
-	t.reader.Destroy()
-	t.reader_unfinalized_object.Destroy()
-	t.jobManager.Destroy()
+	if t.reader != nil {
+		t.reader.Destroy()
+	}
+	if t.reader_unfinalized_object != nil {
+		t.reader_unfinalized_object.Destroy()
+	}
+	if t.jobManager != nil {
+		t.jobManager.Destroy()
+	}
 	err := os.RemoveAll(t.cacheDir)
 	if err != nil {
 		t.T().Logf("Failed to clean up test cache directory '%s': %v", t.cacheDir, err)

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -110,11 +110,13 @@ func (t *fileCacheReaderTest) SetupTest() {
 }
 
 func (t *fileCacheReaderTest) TearDownTest() {
+	t.reader.Destroy()
+	t.reader_unfinalized_object.Destroy()
+	t.jobManager.Destroy()
 	err := os.RemoveAll(t.cacheDir)
 	if err != nil {
 		t.T().Logf("Failed to clean up test cache directory '%s': %v", t.cacheDir, err)
 	}
-	t.reader.Destroy()
 }
 
 func (t *fileCacheReaderTest) mockNewReaderWithHandleCallForTestBucket(limit uint64, rd gcs.StorageReader) {


### PR DESCRIPTION
### Description
- **Problem:** The TestZonalFileCacheReaderTestSuite/Test_ReadAt_SequentialRangeRead test was flaky because the asynchronous background downloader goroutines (downloader.Job) were being leaked after each test completed. When TearDownTest() executed os.RemoveAll(t.cacheDir), it raced against those active background jobs trying to write to that same directory, causing device or resource busy or mock assertion failures.
- **Solution:** Updated TearDownTest in file_cache_reader_test.go
 to call t.jobManager.Destroy() before removing the directory. This guarantees that all background downloader jobs are instantly cancelled and stopped, releasing their file descriptors and terminating their goroutines, making the directory cleanup completely safe and race-free.

### Link to the issue in case of a bug fix.
b/524993281

### Testing details
1. Manual - yes, by running 30 times.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
