### PR TITLE
test(dentry_cache): accept both ESTALE and EIO errors in notifier tests

### DIFF
--- a/tools/integration_tests/dentry_cache/notifier_test.go
+++ b/tools/integration_tests/dentry_cache/notifier_test.go
@@ -72,7 +72,7 @@ func (s *notifierTest) TestWriteFileWithDentryCacheEnabled() {
 	err = operations.WriteFile(filePath, "ShouldNotWrite")
 
 	// First Write File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 	// Second Write File attempt.
 	err = operations.WriteFile(filePath, "ShouldWrite")
 	// The notifier is triggered after the first write failure, invalidating the kernel cache entry.
@@ -97,7 +97,7 @@ func (s *notifierTest) TestReadFileWithDentryCacheEnabled() {
 	// First Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// First Read File attempt should fail because file has been clobbered.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 	// Second Read File attempt.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
@@ -119,7 +119,7 @@ func (s *notifierTest) TestDeleteFileWithDentryCacheEnabled() {
 	// Read File to call the notifier to invalidate entry.
 	_, err = operations.ReadFile(filePath)
 	// The notifier is triggered after the first read failure, invalidating the kernel cache entry.
-	operations.ValidateESTALEError(s.T(), err)
+	operations.ValidateESTALEOrEIOError(s.T(), err)
 
 	// Stat again, it should give error as entry does not exist.
 	_, err = os.Stat(filePath)

--- a/tools/integration_tests/util/operations/validation_helper.go
+++ b/tools/integration_tests/util/operations/validation_helper.go
@@ -52,14 +52,25 @@ func ValidateESTALEError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
-	assert.Regexp(t, syscall.ESTALE.Error(), err.Error())
+	require.Contains(t, err.Error(), syscall.ESTALE.Error())
+}
+
+func ValidateESTALEOrEIOError(t *testing.T, err error) {
+	t.Helper()
+
+	require.Error(t, err)
+	// FUSE kernel driver can translate ESTALE to EIO (input/output error) on some operations/kernels.
+	// So we accept both "stale file handle" (ESTALE) and "input/output error" (EIO).
+	errStr := err.Error()
+	require.True(t, strings.Contains(errStr, syscall.ESTALE.Error()) || strings.Contains(errStr, syscall.EIO.Error()),
+		"Expected error to contain %q (ESTALE) or %q (EIO). Got: %v", syscall.ESTALE.Error(), syscall.EIO.Error(), err)
 }
 
 func ValidateEIOError(t *testing.T, err error) {
 	t.Helper()
 
 	require.Error(t, err)
-	assert.Regexp(t, syscall.EIO.Error(), err.Error())
+	require.Contains(t, err.Error(), syscall.EIO.Error())
 }
 
 func CheckErrorForReadOnlyFileSystem(t *testing.T, err error) {


### PR DESCRIPTION
### Description
This PR resolves potential test failures and flakes in the FUSE dentry cache notifier integration tests.

On certain kernels or FUSE configurations, the FUSE kernel driver translates the `ESTALE` (Stale File Handle) error returned by gcsfuse into `EIO` (Input/Output Error) for some filesystem operations. To ensure these tests are robust and pass reliably across different kernel environments, this change accepts both EIO as well as ESTALE as valid errors.

### Link to the issue in case of a bug fix.
b/518338525

### Testing details
1. Manual - N/A
2. Unit tests - N/A
3. Integration tests - Ran the test on Ubuntu 2604 where the test fails without this fix.

### Any backward incompatible change? If so, please explain.
None