### PR TITLE
perf: Optimize `fetchCoreEntity` to avoid heap allocations

### DIFF
--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -736,29 +736,6 @@ func (d *dirInode) LookUpChild(ctx context.Context, name string) (*Core, error) 
 // fetchCoreEntity contains all the existing logic for looking up children
 // without worrying about the isTypeCacheDeprecated flag.
 func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType metadata.Type) (*Core, error) {
-	group, ctx := errgroup.WithContext(ctx)
-
-	var fileResult *Core
-	var dirResult *Core
-	var err error
-
-	lookUpFile := func() (err error) {
-		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
-		return
-	}
-	lookUpExplicitDir := func() (err error) {
-		dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
-		return
-	}
-	lookUpImplicitOrExplicitDir := func() (err error) {
-		dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
-		return
-	}
-	lookUpHNSDir := func() (err error) {
-		dirResult, err = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
-		return
-	}
-
 	switch cachedType {
 	case metadata.ImplicitDirType:
 		return &Core{
@@ -766,17 +743,19 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 			FullName:  NewDirName(d.Name(), name),
 			MinObject: nil,
 		}, nil
-	case metadata.ExplicitDirType:
-		if d.isBucketHierarchical() {
-			group.Go(lookUpHNSDir)
-		} else {
-			group.Go(lookUpExplicitDir)
-		}
-	case metadata.RegularFileType, metadata.SymlinkType:
-		group.Go(lookUpFile)
 
 	case metadata.NonexistentType:
 		return nil, nil
+
+	case metadata.ExplicitDirType:
+		if d.isBucketHierarchical() {
+			return findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+		}
+		return findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+
+	case metadata.RegularFileType, metadata.SymlinkType:
+		return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+
 	case metadata.UnknownType:
 		// Entry not present in cache.
 		// Trigger prefetcher
@@ -788,22 +767,39 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 			return d.lookUpHNSRace(ctx, name)
 		}
 
-		group.Go(lookUpFile)
+		group, ctx := errgroup.WithContext(ctx)
+
+		var fileResult *Core
+		var dirResult *Core
+
+		group.Go(func() (err error) {
+			fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+			return
+		})
+
 		if d.implicitDirs {
-			group.Go(lookUpImplicitOrExplicitDir)
+			group.Go(func() (err error) {
+				dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
+				return
+			})
 		} else {
-			group.Go(lookUpExplicitDir)
+			group.Go(func() (err error) {
+				dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+				return
+			})
 		}
+
+		if err := group.Wait(); err != nil {
+			return nil, err
+		}
+
+		if dirResult != nil {
+			return dirResult, nil
+		}
+		return fileResult, nil
 	}
 
-	if err = group.Wait(); err != nil {
-		return nil, err
-	}
-
-	if dirResult != nil {
-		return dirResult, nil
-	}
-	return fileResult, nil
+	return nil, nil
 }
 
 func (d *dirInode) lookUpHNSRace(ctx context.Context, name string) (*Core, error) {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -757,49 +757,54 @@ func (d *dirInode) fetchCoreEntity(ctx context.Context, name string, cachedType 
 		return findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
 
 	case metadata.UnknownType:
-		// Entry not present in cache.
-		// Trigger prefetcher
-		if d.prefetcher != nil {
-			d.prefetcher.Run(NewFileName(d.Name(), name).GcsObjectName())
-		}
-
-		if d.isBucketHierarchical() {
-			return d.lookUpHNSRace(ctx, name)
-		}
-
-		group, ctx := errgroup.WithContext(ctx)
-
-		var fileResult *Core
-		var dirResult *Core
-
-		group.Go(func() (err error) {
-			fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
-			return
-		})
-
-		if d.implicitDirs {
-			group.Go(func() (err error) {
-				dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
-				return
-			})
-		} else {
-			group.Go(func() (err error) {
-				dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
-				return
-			})
-		}
-
-		if err := group.Wait(); err != nil {
-			return nil, err
-		}
-
-		if dirResult != nil {
-			return dirResult, nil
-		}
-		return fileResult, nil
+		return d.lookUpUnknownType(ctx, name)
 	}
 
 	return nil, nil
+}
+
+// lookUpUnknownType handles the lookup of a child entity when its type is unknown.
+func (d *dirInode) lookUpUnknownType(ctx context.Context, name string) (*Core, error) {
+	// Entry not present in cache.
+	// Trigger prefetcher
+	if d.prefetcher != nil {
+		d.prefetcher.Run(NewFileName(d.Name(), name).GcsObjectName())
+	}
+
+	if d.isBucketHierarchical() {
+		return d.lookUpHNSRace(ctx, name)
+	}
+
+	group, ctx := errgroup.WithContext(ctx)
+
+	var fileResult *Core
+	var dirResult *Core
+
+	group.Go(func() (err error) {
+		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+		return err
+	})
+
+	if d.implicitDirs {
+		group.Go(func() (err error) {
+			dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
+			return err
+		})
+	} else {
+		group.Go(func() (err error) {
+			dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+			return err
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	if dirResult != nil {
+		return dirResult, nil
+	}
+	return fileResult, nil
 }
 
 func (d *dirInode) lookUpHNSRace(ctx context.Context, name string) (*Core, error) {

--- a/internal/fs/inode/dir_benchmark_test.go
+++ b/internal/fs/inode/dir_benchmark_test.go
@@ -48,7 +48,7 @@ func newBenchmarkDirInode(b *testing.B, implicitDirs bool) *dirInode {
 		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
 		EnableHns:                    true,
 		EnableUnsupportedPathSupport: true,
-		EnableTypeCacheDeprecation:   false,
+		EnableTypeCacheDeprecation:   true,
 	}
 
 	in := NewDirInode(

--- a/internal/fs/inode/dir_benchmark_test.go
+++ b/internal/fs/inode/dir_benchmark_test.go
@@ -35,7 +35,7 @@ func newBenchmarkDirInode(b *testing.B, implicitDirs bool) *dirInode {
 	ctx := context.Background()
 	var clock timeutil.SimulatedClock
 	clock.SetTime(time.Date(2026, 6, 18, 12, 0, 0, 0, time.Local))
-	bucket := fake.NewFakeBucket(&clock, "some_bucket", gcs.BucketType{})
+	bucket := fake.NewFakeBucket(&clock, "some_bucket", gcs.BucketType{Hierarchical: true})
 	syncerBucket := gcsx.NewSyncerBucket(
 		/*appendThreshold=*/ 1,
 		chunkRetryDeadlineSecs,
@@ -46,7 +46,7 @@ func newBenchmarkDirInode(b *testing.B, implicitDirs bool) *dirInode {
 	config := &cfg.Config{
 		List:                         cfg.ListConfig{EnableEmptyManagedFolders: true},
 		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
-		EnableHns:                    false,
+		EnableHns:                    true,
 		EnableUnsupportedPathSupport: true,
 		EnableTypeCacheDeprecation:   false,
 	}

--- a/internal/fs/inode/dir_benchmark_test.go
+++ b/internal/fs/inode/dir_benchmark_test.go
@@ -1,0 +1,223 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/timeutil"
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/semaphore"
+)
+
+// fetchCoreEntityOld contains the old, unoptimized implementation of fetchCoreEntity.
+func (d *dirInode) fetchCoreEntityOld(ctx context.Context, name string, cachedType metadata.Type) (*Core, error) {
+	group, ctx := errgroup.WithContext(ctx)
+
+	var fileResult *Core
+	var dirResult *Core
+	var err error
+
+	lookUpFile := func() (err error) {
+		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
+		return
+	}
+	lookUpExplicitDir := func() (err error) {
+		dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+		return
+	}
+	lookUpImplicitOrExplicitDir := func() (err error) {
+		dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
+		return
+	}
+	lookUpHNSDir := func() (err error) {
+		dirResult, err = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
+		return
+	}
+
+	switch cachedType {
+	case metadata.ImplicitDirType:
+		return &Core{
+			Bucket:    d.Bucket(),
+			FullName:  NewDirName(d.Name(), name),
+			MinObject: nil,
+		}, nil
+	case metadata.ExplicitDirType:
+		if d.isBucketHierarchical() {
+			group.Go(lookUpHNSDir)
+		} else {
+			group.Go(lookUpExplicitDir)
+		}
+	case metadata.RegularFileType, metadata.SymlinkType:
+		group.Go(lookUpFile)
+
+	case metadata.NonexistentType:
+		return nil, nil
+	case metadata.UnknownType:
+		// Entry not present in cache.
+		// Trigger prefetcher
+		if d.prefetcher != nil {
+			d.prefetcher.Run(NewFileName(d.Name(), name).GcsObjectName())
+		}
+
+		if d.isBucketHierarchical() {
+			return d.lookUpHNSRace(ctx, name)
+		}
+
+		group.Go(lookUpFile)
+		if d.implicitDirs {
+			group.Go(lookUpImplicitOrExplicitDir)
+		} else {
+			group.Go(lookUpExplicitDir)
+		}
+	}
+
+	if err = group.Wait(); err != nil {
+		return nil, err
+	}
+
+	if dirResult != nil {
+		return dirResult, nil
+	}
+	return fileResult, nil
+}
+
+func newBenchmarkDirInode(tb testing.TB, implicitDirs bool) *dirInode {
+	ctx := context.Background()
+	var clock timeutil.SimulatedClock
+	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+	bucket := fake.NewFakeBucket(&clock, "some_bucket", gcs.BucketType{})
+	syncerBucket := gcsx.NewSyncerBucket(
+		/*appendThreshold=*/ 1,
+		chunkRetryDeadlineSecs,
+		chunkTransferTimeoutSecs,
+		".gcsfuse_tmp/",
+		bucket)
+
+	config := &cfg.Config{
+		List:                         cfg.ListConfig{EnableEmptyManagedFolders: true},
+		MetadataCache:                cfg.MetadataCacheConfig{TypeCacheMaxSizeMb: 4},
+		EnableHns:                    false,
+		EnableUnsupportedPathSupport: true,
+		EnableTypeCacheDeprecation:   false,
+	}
+
+	in := NewDirInode(
+		dirInodeID,
+		NewDirName(NewRootName(""), dirInodeName),
+		ctx,
+		fuseops.InodeAttributes{
+			Uid:  uid,
+			Gid:  gid,
+			Mode: dirMode,
+		},
+		implicitDirs,
+		true, // enableNonexistentTypeCache
+		typeCacheTTL,
+		&syncerBucket,
+		&clock,
+		&clock,
+		semaphore.NewWeighted(10),
+		config,
+	)
+
+	return in.(*dirInode)
+}
+
+func runBenchmark(b *testing.B, cachedType metadata.Type, name string, useOld bool, setupBucket func(d *dirInode)) {
+	d := newBenchmarkDirInode(b, true)
+	if setupBucket != nil {
+		setupBucket(d)
+	}
+	ctx := context.Background()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if useOld {
+			_, _ = d.fetchCoreEntityOld(ctx, name, cachedType)
+		} else {
+			_, _ = d.fetchCoreEntity(ctx, name, cachedType)
+		}
+	}
+}
+
+func Benchmark_ImplicitDirType_Old(b *testing.B) {
+	runBenchmark(b, metadata.ImplicitDirType, "subdir", true, nil)
+}
+
+func Benchmark_ImplicitDirType_New(b *testing.B) {
+	runBenchmark(b, metadata.ImplicitDirType, "subdir", false, nil)
+}
+
+func Benchmark_NonexistentType_Old(b *testing.B) {
+	runBenchmark(b, metadata.NonexistentType, "absent", true, nil)
+}
+
+func Benchmark_NonexistentType_New(b *testing.B) {
+	runBenchmark(b, metadata.NonexistentType, "absent", false, nil)
+}
+
+func Benchmark_ExplicitDirType_Old(b *testing.B) {
+	runBenchmark(b, metadata.ExplicitDirType, "subdir", true, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewDirName(d.Name(), "subdir").GcsObjectName(), []byte(""))
+	})
+}
+
+func Benchmark_ExplicitDirType_New(b *testing.B) {
+	runBenchmark(b, metadata.ExplicitDirType, "subdir", false, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewDirName(d.Name(), "subdir").GcsObjectName(), []byte(""))
+	})
+}
+
+func Benchmark_RegularFileType_Old(b *testing.B) {
+	runBenchmark(b, metadata.RegularFileType, "file", true, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
+	})
+}
+
+func Benchmark_RegularFileType_New(b *testing.B) {
+	runBenchmark(b, metadata.RegularFileType, "file", false, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
+	})
+}
+
+func Benchmark_UnknownType_Nonexistent_Old(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "absent", true, nil)
+}
+
+func Benchmark_UnknownType_Nonexistent_New(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "absent", false, nil)
+}
+
+func Benchmark_UnknownType_ExistingFile_Old(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "file", true, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
+	})
+}
+
+func Benchmark_UnknownType_ExistingFile_New(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "file", false, func(d *dirInode) {
+		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
+	})
+}

--- a/internal/fs/inode/dir_benchmark_test.go
+++ b/internal/fs/inode/dir_benchmark_test.go
@@ -27,81 +27,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
-
-// fetchCoreEntityOld contains the old, unoptimized implementation of fetchCoreEntity.
-func (d *dirInode) fetchCoreEntityOld(ctx context.Context, name string, cachedType metadata.Type) (*Core, error) {
-	group, ctx := errgroup.WithContext(ctx)
-
-	var fileResult *Core
-	var dirResult *Core
-	var err error
-
-	lookUpFile := func() (err error) {
-		fileResult, err = findExplicitInode(ctx, d.Bucket(), NewFileName(d.Name(), name), false)
-		return
-	}
-	lookUpExplicitDir := func() (err error) {
-		dirResult, err = findExplicitInode(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
-		return
-	}
-	lookUpImplicitOrExplicitDir := func() (err error) {
-		dirResult, err = findDirInode(ctx, d.Bucket(), NewDirName(d.Name(), name))
-		return
-	}
-	lookUpHNSDir := func() (err error) {
-		dirResult, err = findExplicitFolder(ctx, d.Bucket(), NewDirName(d.Name(), name), false)
-		return
-	}
-
-	switch cachedType {
-	case metadata.ImplicitDirType:
-		return &Core{
-			Bucket:    d.Bucket(),
-			FullName:  NewDirName(d.Name(), name),
-			MinObject: nil,
-		}, nil
-	case metadata.ExplicitDirType:
-		if d.isBucketHierarchical() {
-			group.Go(lookUpHNSDir)
-		} else {
-			group.Go(lookUpExplicitDir)
-		}
-	case metadata.RegularFileType, metadata.SymlinkType:
-		group.Go(lookUpFile)
-
-	case metadata.NonexistentType:
-		return nil, nil
-	case metadata.UnknownType:
-		// Entry not present in cache.
-		// Trigger prefetcher
-		if d.prefetcher != nil {
-			d.prefetcher.Run(NewFileName(d.Name(), name).GcsObjectName())
-		}
-
-		if d.isBucketHierarchical() {
-			return d.lookUpHNSRace(ctx, name)
-		}
-
-		group.Go(lookUpFile)
-		if d.implicitDirs {
-			group.Go(lookUpImplicitOrExplicitDir)
-		} else {
-			group.Go(lookUpExplicitDir)
-		}
-	}
-
-	if err = group.Wait(); err != nil {
-		return nil, err
-	}
-
-	if dirResult != nil {
-		return dirResult, nil
-	}
-	return fileResult, nil
-}
 
 func newBenchmarkDirInode(tb testing.TB, implicitDirs bool) *dirInode {
 	ctx := context.Background()
@@ -145,7 +72,7 @@ func newBenchmarkDirInode(tb testing.TB, implicitDirs bool) *dirInode {
 	return in.(*dirInode)
 }
 
-func runBenchmark(b *testing.B, cachedType metadata.Type, name string, useOld bool, setupBucket func(d *dirInode)) {
+func runBenchmark(b *testing.B, cachedType metadata.Type, name string, setupBucket func(d *dirInode)) {
 	d := newBenchmarkDirInode(b, true)
 	if setupBucket != nil {
 		setupBucket(d)
@@ -154,70 +81,36 @@ func runBenchmark(b *testing.B, cachedType metadata.Type, name string, useOld bo
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if useOld {
-			_, _ = d.fetchCoreEntityOld(ctx, name, cachedType)
-		} else {
-			_, _ = d.fetchCoreEntity(ctx, name, cachedType)
-		}
+		_, _ = d.fetchCoreEntity(ctx, name, cachedType)
 	}
 }
 
-func Benchmark_ImplicitDirType_Old(b *testing.B) {
-	runBenchmark(b, metadata.ImplicitDirType, "subdir", true, nil)
+func Benchmark_ImplicitDirType(b *testing.B) {
+	runBenchmark(b, metadata.ImplicitDirType, "subdir", nil)
 }
 
-func Benchmark_ImplicitDirType_New(b *testing.B) {
-	runBenchmark(b, metadata.ImplicitDirType, "subdir", false, nil)
+func Benchmark_NonexistentType(b *testing.B) {
+	runBenchmark(b, metadata.NonexistentType, "absent", nil)
 }
 
-func Benchmark_NonexistentType_Old(b *testing.B) {
-	runBenchmark(b, metadata.NonexistentType, "absent", true, nil)
-}
-
-func Benchmark_NonexistentType_New(b *testing.B) {
-	runBenchmark(b, metadata.NonexistentType, "absent", false, nil)
-}
-
-func Benchmark_ExplicitDirType_Old(b *testing.B) {
-	runBenchmark(b, metadata.ExplicitDirType, "subdir", true, func(d *dirInode) {
+func Benchmark_ExplicitDirType(b *testing.B) {
+	runBenchmark(b, metadata.ExplicitDirType, "subdir", func(d *dirInode) {
 		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewDirName(d.Name(), "subdir").GcsObjectName(), []byte(""))
 	})
 }
 
-func Benchmark_ExplicitDirType_New(b *testing.B) {
-	runBenchmark(b, metadata.ExplicitDirType, "subdir", false, func(d *dirInode) {
-		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewDirName(d.Name(), "subdir").GcsObjectName(), []byte(""))
-	})
-}
-
-func Benchmark_RegularFileType_Old(b *testing.B) {
-	runBenchmark(b, metadata.RegularFileType, "file", true, func(d *dirInode) {
+func Benchmark_RegularFileType(b *testing.B) {
+	runBenchmark(b, metadata.RegularFileType, "file", func(d *dirInode) {
 		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
 	})
 }
 
-func Benchmark_RegularFileType_New(b *testing.B) {
-	runBenchmark(b, metadata.RegularFileType, "file", false, func(d *dirInode) {
-		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
-	})
+func Benchmark_UnknownType_Nonexistent(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "absent", nil)
 }
 
-func Benchmark_UnknownType_Nonexistent_Old(b *testing.B) {
-	runBenchmark(b, metadata.UnknownType, "absent", true, nil)
-}
-
-func Benchmark_UnknownType_Nonexistent_New(b *testing.B) {
-	runBenchmark(b, metadata.UnknownType, "absent", false, nil)
-}
-
-func Benchmark_UnknownType_ExistingFile_Old(b *testing.B) {
-	runBenchmark(b, metadata.UnknownType, "file", true, func(d *dirInode) {
-		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
-	})
-}
-
-func Benchmark_UnknownType_ExistingFile_New(b *testing.B) {
-	runBenchmark(b, metadata.UnknownType, "file", false, func(d *dirInode) {
+func Benchmark_UnknownType_ExistingFile(b *testing.B) {
+	runBenchmark(b, metadata.UnknownType, "file", func(d *dirInode) {
 		_, _ = storageutil.CreateObject(context.Background(), d.Bucket(), NewFileName(d.Name(), "file").GcsObjectName(), []byte("taco"))
 	})
 }

--- a/internal/fs/inode/dir_benchmark_test.go
+++ b/internal/fs/inode/dir_benchmark_test.go
@@ -30,10 +30,11 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
-func newBenchmarkDirInode(tb testing.TB, implicitDirs bool) *dirInode {
+func newBenchmarkDirInode(b *testing.B, implicitDirs bool) *dirInode {
+	b.Helper()
 	ctx := context.Background()
 	var clock timeutil.SimulatedClock
-	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+	clock.SetTime(time.Date(2026, 6, 18, 12, 0, 0, 0, time.Local))
 	bucket := fake.NewFakeBucket(&clock, "some_bucket", gcs.BucketType{})
 	syncerBucket := gcsx.NewSyncerBucket(
 		/*appendThreshold=*/ 1,
@@ -73,6 +74,7 @@ func newBenchmarkDirInode(tb testing.TB, implicitDirs bool) *dirInode {
 }
 
 func runBenchmark(b *testing.B, cachedType metadata.Type, name string, setupBucket func(d *dirInode)) {
+	b.Helper()
 	d := newBenchmarkDirInode(b, true)
 	if setupBucket != nil {
 		setupBucket(d)
@@ -80,7 +82,7 @@ func runBenchmark(b *testing.B, cachedType metadata.Type, name string, setupBuck
 	ctx := context.Background()
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for b.Loop() {
 		_, _ = d.fetchCoreEntity(ctx, name, cachedType)
 	}
 }


### PR DESCRIPTION
### Description
Every call to `fetchCoreEntity` previously incurred the allocation cost of 4 closures, 2 captured pointers (`fileResult`, `dirResult`), and 1 `errgroup.Group` on the heap, even on fast-paths (like `ImplicitDirType` or `NonexistentType`) where no goroutines are ever spawned and the function returns immediately.

Optimizes `fetchCoreEntity` by:
1. Moving the instant-return fast-paths (`ImplicitDirType`, `NonexistentType`) to the very top, bypassing all allocations.
2. Executing single-lookup paths (`ExplicitDirType`, `RegularFileType`, `SymlinkType`) synchronously avoiding `errgroup` and goroutines/closures.
3. Refactor the concurrent lookup path (`UnknownType` on non-hierarchical buckets) to only initialize `errgroup.WithContext` and closures when it is actually executed.

### Perf  
| Benchmark Case | Metric | Master Branch | Feature Branch | Improvement / Speedup |
| :--- | :--- | :---: | :---: | :---: |
| **`ImplicitDirType`** | Execution Time | `773.5 ns/op` | `216.6 ns/op` | **3.57x faster** |
| | Memory Bandwidth | `520 B/op` | `88 B/op` | **-83.1% memory** |
| | Heap Allocations | `12 allocs/op` | `3 allocs/op` | **-75.0% allocs** |
| **`NonexistentType`** | Execution Time | `556.2 ns/op` | `4.188 ns/op` | **132.8x faster** |
| | Memory Bandwidth | `432 B/op` | `0 B/op` | **-100% memory (0 B)** |
| | Heap Allocations | `9 allocs/op` | `0 allocs/op` | **-100% allocs (0 allocs)** |
| **`ExplicitDirType`** | Execution Time | `2,600.0 ns/op` | `450.2 ns/op` | **5.77x faster** |
| | Memory Bandwidth | `624 B/op` | `168 B/op` | **-73.1% memory** |
| | Heap Allocations | `16 allocs/op` | `6 allocs/op` | **-62.5% allocs** |
| **`RegularFileType`** | Execution Time | `3,304.0 ns/op` | `432.5 ns/op` | **7.64x faster** |
| | Memory Bandwidth | `696 B/op` | `240 B/op` | **-65.5% memory** |
| | Heap Allocations | `15 allocs/op` | `5 allocs/op` | **-66.7% allocs** |
| **`UnknownType_Nonexistent`** | Execution Time | `17,774.0 ns/op`| `13,246.0 ns/op`| **1.34x faster** (~34% speedup) |
| (Cache Miss - Nonexistent) | Memory Bandwidth | `1,450 B/op` | `649 B/op` | **-55.2% memory** |
| | Heap Allocations | `33 allocs/op` | `21 allocs/op` | **-36.4% allocs** |
| **`UnknownType_ExistingFile`** | Execution Time | `12,751.0 ns/op`| `8,923.0 ns/op` | **1.43x faster** (~43% speedup) |
| (Cache Miss - File Found) | Memory Bandwidth | `1,560 B/op` | `759 B/op` | **-51.3% memory** |
| | Heap Allocations | `31 allocs/op` | `19 allocs/op` | **-38.7% allocs** |

### Link to the issue in case of a bug fix.
b/525737897

### Testing details
1. Manual - Ran the new benchmark suite (`go test -v -run=^$ -bench=. -benchmem ./internal/fs/inode`) verifying substantial performance gains.
2. Unit tests - Ran the full suite
3. Integration tests - Tested via presubmits.

### Any backward incompatible change? If so, please explain.
N/A
