### PR TITLE
test(internal/bufferedread): fix flaky TestReadAtBackwardSeekIsRandomRead

### DIFF
--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -1083,6 +1083,13 @@ func (t *BufferedReaderTest) TestReadAtBackwardSeekIsRandomRead() {
 	assert.Equal(t.T(), int64(2), reader.randomSeekCount, "Second read should be counted as random.")
 	assert.Equal(t.T(), 2, reader.blockQueue.Len(), "Queue should contain newly prefetched blocks.")
 	assertReadResponseContent(t.T(), resp, 0)
+	// Wait for the async prefetch tasks to complete to verify the mock calls.
+	bqe1 := reader.blockQueue.Pop()
+	bqe2 := reader.blockQueue.Pop()
+	_, err = bqe1.block.AwaitReady(t.ctx)
+	require.NoError(t.T(), err, "AwaitReady for block 1 failed")
+	_, err = bqe2.block.AwaitReady(t.ctx)
+	require.NoError(t.T(), err, "AwaitReady for block 2 failed")
 	t.bucket.AssertExpectations(t.T())
 }
 


### PR DESCRIPTION
### Description
This PR resolves a flaky test failure in `TestReadAtBackwardSeekIsRandomRead` under the `internal/bufferedread` package.

**Problem:**
During a backward seek, `ReadAt` triggers a "fresh start" of prefetching, scheduling the first block urgently and subsequent prefetch blocks (blocks 1 and 2) asynchronously on the worker pool. Since the read request (1024 bytes) was satisfied entirely by block 0, `ReadAt` returned immediately. The test then immediately asserted the mock expectations. Because the prefetch tasks for blocks 1 and 2 were running asynchronously in the background, they did not always execute before `AssertExpectations` was called, causing flaky mock expectation failures.

**Solution:**
Synchronized the test by waiting for the asynchronous prefetch tasks to complete before asserting mock expectations. We pop the block queue entries for the two prefetched blocks (block 1 and block 2) and call `AwaitReady(t.ctx)` to block until their download tasks finish. This is an established pattern used in other tests in the same file (e.g., `TestReadAtForwardSeekDiscardsPreviousBlocks`).

### Link to the issue in case of a bug fix.
b/525677881

### Testing details
1. Manual - Ran `go test -v ./internal/bufferedread -run TestBufferedReaderTestSuite/TestReadAtBackwardSeekIsRandomRead` multiple times to ensure it compiles and passes consistently.
2. Unit tests - Executed the entire `internal/bufferedread` test suite successfully: `go test -v ./internal/bufferedread`.
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
No
