### PR TITLE
test(managed_folder): optimize managed_folders e2e-test by skipping unnecessary IAM propagation waits

### DIFF
--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -63,13 +63,14 @@ func (s *managedFoldersAdminPermission) TearDownSuite() {
 
 func (s *managedFoldersAdminPermission) SetupTest() {
 	managedFolderRecreated := createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
-
-	if s.managedFoldersPermission != "nil" && managedFolderRecreated {
-		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
-		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
-		// Wait for policy propagation only when folders were recreated and IAM was reapplied.
-		time.Sleep(60 * time.Second)
+	if s.managedFoldersPermission == "nil" || !managedFolderRecreated {
+		return
 	}
+
+	providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
+	providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
+	// Wait for policy propagation only when folders were recreated and IAM was reapplied.
+	time.Sleep(60 * time.Second)
 }
 
 func (s *managedFoldersAdminPermission) TearDownTest() {

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -47,7 +47,6 @@ const (
 type managedFoldersAdminPermission struct {
 	bucketPermission         string
 	managedFoldersPermission string
-	refreshManagedFolderIAM  bool
 	flags                    []string
 	suite.Suite
 }
@@ -55,6 +54,7 @@ type managedFoldersAdminPermission struct {
 func (s *managedFoldersAdminPermission) SetupSuite() {
 	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
 	setup.SetMntDir(testEnv.mountDir)
+	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
 }
 
 func (s *managedFoldersAdminPermission) TearDownSuite() {
@@ -62,27 +62,18 @@ func (s *managedFoldersAdminPermission) TearDownSuite() {
 }
 
 func (s *managedFoldersAdminPermission) SetupTest() {
-	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
 	managedFolderRecreated := createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
 
-	if s.managedFoldersPermission != "nil" && (s.refreshManagedFolderIAM || managedFolderRecreated) {
+	if s.managedFoldersPermission != "nil" && managedFolderRecreated {
 		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
-		// Wait for policy propagation only when IAM was (re)applied.
+		// Wait for policy propagation only when folders were recreated and IAM was reapplied.
 		time.Sleep(60 * time.Second)
-		s.refreshManagedFolderIAM = false
 	}
 }
 
 func (s *managedFoldersAdminPermission) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
-	// Due to bucket view permissions, it prevents cleaning resources outside managed folders. So we are cleaning managed folders resources only.
-	if s.bucketPermission == ViewPermission {
-		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1))
-		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder2))
-		return
-	}
-	setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest))
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -129,6 +120,11 @@ func (s *managedFoldersAdminPermission) TestCopyObjectWithInManagedFolder() {
 	testDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	srcCopyFile := path.Join(testDirPath, FileInNonEmptyManagedFoldersTest)
 	destCopyFile := path.Join(testDirPath, DestFile)
+	defer func() {
+		if err := os.RemoveAll(destCopyFile); err != nil {
+			log.Printf("failed to remove scratch copy file: %v", err)
+		}
+	}()
 
 	err := operations.CopyFile(srcCopyFile, destCopyFile)
 	if err != nil {
@@ -144,6 +140,11 @@ func (s *managedFoldersAdminPermission) TestCopyObjectWithInManagedFolder() {
 func (s *managedFoldersAdminPermission) TestCopyManagedFolder() {
 	srcDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	destDirPath := path.Join(testEnv.testDirPath, DestFolder)
+	defer func() {
+		if err := os.RemoveAll(destDirPath); err != nil {
+			log.Printf("failed to remove scratch copy folder: %v", err)
+		}
+	}()
 
 	err := operations.CopyDir(srcDirPath, destDirPath)
 
@@ -161,6 +162,11 @@ func (s *managedFoldersAdminPermission) TestMoveObjectWithInManagedFolder() {
 	testDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	srcMoveFile := path.Join(testDirPath, FileInNonEmptyManagedFoldersTest)
 	destMoveFile := path.Join(testDirPath, DestFile)
+	defer func() {
+		if err := os.RemoveAll(destMoveFile); err != nil {
+			log.Printf("failed to remove scratch move file: %v", err)
+		}
+	}()
 
 	err := operations.Move(srcMoveFile, destMoveFile)
 	if err != nil {
@@ -180,6 +186,11 @@ func (s *managedFoldersAdminPermission) TestMoveObjectWithInManagedFolder() {
 func (s *managedFoldersAdminPermission) TestMoveManagedFolder() {
 	srcDirPath := path.Join(testEnv.testDirPath, ManagedFolder1)
 	destDirPath := path.Join(testEnv.testDirPath, DestFolder)
+	defer func() {
+		if err := os.RemoveAll(destDirPath); err != nil {
+			log.Printf("failed to remove scratch move folder: %v", err)
+		}
+	}()
 
 	err := operations.Move(srcDirPath, destDirPath)
 
@@ -224,7 +235,13 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 				creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 			}
 			ts.managedFoldersPermission = permissions[i][1]
-			ts.refreshManagedFolderIAM = ts.managedFoldersPermission != "nil"
+
+			if ts.managedFoldersPermission != "nil" {
+				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+				// Wait once per permission scenario for initial policy propagation.
+				time.Sleep(60 * time.Second)
+			}
 
 			suite.Run(t, ts)
 

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -47,6 +47,7 @@ const (
 type managedFoldersAdminPermission struct {
 	bucketPermission         string
 	managedFoldersPermission string
+	refreshManagedFolderIAM  bool
 	flags                    []string
 	suite.Suite
 }
@@ -62,7 +63,15 @@ func (s *managedFoldersAdminPermission) TearDownSuite() {
 
 func (s *managedFoldersAdminPermission) SetupTest() {
 	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
-	createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
+	managedFolderRecreated := createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
+
+	if s.managedFoldersPermission != "nil" && (s.refreshManagedFolderIAM || managedFolderRecreated) {
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
+		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
+		// Wait for policy propagation only when IAM was (re)applied.
+		time.Sleep(60 * time.Second)
+		s.refreshManagedFolderIAM = false
+	}
 }
 
 func (s *managedFoldersAdminPermission) TearDownTest() {
@@ -215,13 +224,7 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 				creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 			}
 			ts.managedFoldersPermission = permissions[i][1]
-
-			if ts.managedFoldersPermission != "nil" {
-				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, ts.managedFoldersPermission, t)
-				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, ts.managedFoldersPermission, t)
-				// Wait for 60 seconds for policy changes to propagate if we modified Managed Folder OR Bucket permissions.
-				time.Sleep(60 * time.Second)
-			}
+			ts.refreshManagedFolderIAM = ts.managedFoldersPermission != "nil"
 
 			suite.Run(t, ts)
 

--- a/tools/integration_tests/managed_folders/admin_permissions_test.go
+++ b/tools/integration_tests/managed_folders/admin_permissions_test.go
@@ -63,21 +63,13 @@ func (s *managedFoldersAdminPermission) TearDownSuite() {
 func (s *managedFoldersAdminPermission) SetupTest() {
 	testEnv.testDirPath = setup.SetupTestDirectory(TestDirForManagedFolderTest)
 	createDirectoryStructureForNonEmptyManagedFolders(testEnv.ctx, testEnv.storageClient, testEnv.controlClient, s.T())
-	if s.managedFoldersPermission != "nil" {
-		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
-		providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
-		// Waiting for 60 seconds for policy changes to propagate. This values we kept based on our experiments.
-		time.Sleep(60 * time.Second)
-	}
 }
 
 func (s *managedFoldersAdminPermission) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
 	// Due to bucket view permissions, it prevents cleaning resources outside managed folders. So we are cleaning managed folders resources only.
 	if s.bucketPermission == ViewPermission {
-		revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder1))
-		revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, s.managedFoldersPermission, s.T())
 		setup.CleanUpDir(path.Join(setup.MntDir(), TestDirForManagedFolderTest, ManagedFolder2))
 		return
 	}
@@ -223,7 +215,21 @@ func TestManagedFolders_FolderAdminPermission(t *testing.T) {
 				creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 			}
 			ts.managedFoldersPermission = permissions[i][1]
+
+			if ts.managedFoldersPermission != "nil" {
+				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+				providePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+				// Wait for 60 seconds for policy changes to propagate if we modified Managed Folder OR Bucket permissions.
+				time.Sleep(60 * time.Second)
+			}
+
 			suite.Run(t, ts)
+
+			if ts.managedFoldersPermission != "nil" {
+				revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder1), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+				revokePermissionToManagedFolder(testEnv.bucket, path.Join(testEnv.testDir, ManagedFolder2), testEnv.serviceAccount, ts.managedFoldersPermission, t)
+			}
+
 			if ts.bucketPermission == ViewPermission {
 				creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
 			}

--- a/tools/integration_tests/managed_folders/test_helper.go
+++ b/tools/integration_tests/managed_folders/test_helper.go
@@ -103,7 +103,7 @@ func revokePermissionToManagedFolder(bucket, managedFolderPath, serviceAccount, 
 	}
 }
 
-func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, t *testing.T) {
+func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, t *testing.T) bool {
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder1/testFile
 	// testBucket/NonEmptyManagedFoldersTest/managedFolder2
@@ -122,12 +122,14 @@ func createDirectoryStructureForNonEmptyManagedFolders(ctx context.Context, stor
 	managedFolder2 := path.Join(testDir, ManagedFolder2)
 	simulatedFolderNonEmptyManagedFoldersTest := path.Join(testDir, SimulatedFolderNonEmptyManagedFoldersTest)
 
-	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), bucket)
+	managedFolder1Recreated := client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder1), bucket)
 	client.CopyFileInBucket(ctx, storageClient, path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(managedFolder1, FileInNonEmptyManagedFoldersTest), bucket)
-	client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), bucket)
+	managedFolder2Recreated := client.CreateManagedFoldersInBucket(ctx, controlClient, path.Join(testDir, ManagedFolder2), bucket)
 	client.CopyFileInBucket(ctx, storageClient, path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(managedFolder2, FileInNonEmptyManagedFoldersTest), bucket)
 	client.CopyFileInBucket(ctx, storageClient, path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(simulatedFolderNonEmptyManagedFoldersTest, FileInNonEmptyManagedFoldersTest), bucket)
 	client.CopyFileInBucket(ctx, storageClient, path.Join("/tmp", FileInNonEmptyManagedFoldersTest), path.Join(testDir, FileInNonEmptyManagedFoldersTest), bucket)
+
+	return managedFolder1Recreated || managedFolder2Recreated
 }
 
 func cleanup(ctx context.Context, storageClient *storage.Client, controlClient *control.StorageControlClient, bucket, testDir, serviceAccount, iam_role string, t *testing.T) {

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -97,6 +97,7 @@ func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 	}
 }
 
+// CreateManagedFoldersInBucket creates a managed folder in the specified bucket. It returns true if the managed folder was created successfully, and false if it already exists.
 func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) bool {
 	mf := &controlpb.ManagedFolder{}
 	req := &controlpb.CreateManagedFolderRequest{
@@ -104,12 +105,14 @@ func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 		ManagedFolder:   mf,
 		ManagedFolderId: managedFolderPath,
 	}
-	if _, err := client.CreateManagedFolder(ctx, req); err != nil {
-		if status.Code(err) == codes.AlreadyExists || strings.Contains(err.Error(), "The specified managed folder already exists") {
-			return false
-		}
-		log.Fatalf("Error while creating managed folder: %v", err)
+	_, err := client.CreateManagedFolder(ctx, req)
+	if err == nil {
+		return true
 	}
+	if status.Code(err) == codes.AlreadyExists || strings.Contains(err.Error(), "The specified managed folder already exists") {
+		return false
+	}
+	log.Fatalf("Error while creating managed folder: %v", err)
 	return true
 }
 

--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func storageControlClientRetryOptions() []gax.CallOption {
@@ -96,16 +97,20 @@ func DeleteManagedFoldersInBucket(ctx context.Context, client *control.StorageCo
 	}
 }
 
-func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) {
+func CreateManagedFoldersInBucket(ctx context.Context, client *control.StorageControlClient, managedFolderPath, bucket string) bool {
 	mf := &controlpb.ManagedFolder{}
 	req := &controlpb.CreateManagedFolderRequest{
 		Parent:          fmt.Sprintf("projects/_/buckets/%v", bucket),
 		ManagedFolder:   mf,
 		ManagedFolderId: managedFolderPath,
 	}
-	if _, err := client.CreateManagedFolder(ctx, req); err != nil && !strings.Contains(err.Error(), "The specified managed folder already exists") {
+	if _, err := client.CreateManagedFolder(ctx, req); err != nil {
+		if status.Code(err) == codes.AlreadyExists || strings.Contains(err.Error(), "The specified managed folder already exists") {
+			return false
+		}
 		log.Fatalf("Error while creating managed folder: %v", err)
 	}
+	return true
 }
 
 func CreateFolderInBucket(ctx context.Context, client *control.StorageControlClient, folderPath string) (*controlpb.Folder, error) {


### PR DESCRIPTION
### Description
The managed_folders admin e2e suite was paying a 60-second IAM propagation sleep before every test case in a permission scenario. That made the package significantly slower, even when managed folders were not recreated and existing IAM remained valid.

**Before the fix:**
<img width="885" height="219" alt="image" src="https://github.com/user-attachments/assets/ff560139-d233-4779-b46f-103b689a226f" />

**After the fix:**
<img width="761" height="215" alt="image" src="https://github.com/user-attachments/assets/ef9c1243-300a-4086-a9a2-2610c5829e8f" />

Since, managed-folders was the test package with highest-execution time, hence we see 15mins reduction in overall e2e test execution.

**Changes wise:**:
- Stop deleting the folder with permission to skip propagation sleep per test-case basis and started doing per test-suite basis.
- Modified every test-case to deleting the test files created. For flat bucket, it was simple as test-case doesn't touch the folder resources, but for hns bucket folder is created/deleted as part of test.

### Link to the issue in case of a bug fix.
b/526790288

### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
