### PR TITLE
Add hidden flag in GCSFuse for GKE mount-retry error file

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -666,6 +666,8 @@ type LoggingConfig struct {
 
 	Format string `yaml:"format"`
 
+	GkeGcsFuseErrorFile ResolvedPath `yaml:"gke-gcsfuse-error-file"`
+
 	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
 
 	Severity LogSeverity `yaml:"severity"`
@@ -1164,6 +1166,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
+
+	flagSet.StringP("gke-gcsfuse-error-file", "", "", "File path to write GCSFuse error logs during mount retries in GKE environment.")
+
+	if err := flagSet.MarkHidden("gke-gcsfuse-error-file"); err != nil {
+		return err
+	}
 
 	flagSet.StringP("grpc-path-strategy", "", "direct-path-with-fallback", "Strategy for DirectPath connectivity when client-protocol=grpc. Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available).")
 
@@ -1761,6 +1769,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.gid", flagSet.Lookup("gid")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.gke-gcsfuse-error-file", flagSet.Lookup("gke-gcsfuse-error-file")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -857,6 +857,13 @@ params:
     usage: "The format of the log file: 'text' or 'json'."
     default: "json"
 
+  - config-path: "logging.gke-gcsfuse-error-file"
+    flag-name: "gke-gcsfuse-error-file"
+    type: "resolvedPath"
+    usage: "File path to write GCSFuse error logs during mount retries in GKE environment."
+    default: ""
+    hide-flag: true
+
   - config-path: "logging.log-rotate.backup-file-count"
     flag-name: "log-rotate-backup-file-count"
     type: "int"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2890,3 +2890,92 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 		})
 	}
 }
+
+func TestArgsParsing_LoggingFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name: "default",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				Logging: cfg.LoggingConfig{
+					FilePath:            "",
+					Format:              "json",
+					GkeGcsFuseErrorFile: "",
+					Severity:            "INFO",
+					WireLog:             "",
+				},
+			},
+		},
+		{
+			name: "normal",
+			args: []string{
+				"gcsfuse",
+				"--log-file=/path/to/log.txt",
+				"--log-format=text",
+				"--log-severity=debug",
+				"--gke-gcsfuse-error-file=/path/to/error.json",
+				"pqr",
+			},
+			expectedConfig: &cfg.Config{
+				Logging: cfg.LoggingConfig{
+					FilePath:            "/path/to/log.txt",
+					Format:              "text",
+					GkeGcsFuseErrorFile: "/path/to/error.json",
+					Severity:            "DEBUG",
+					WireLog:             "",
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
+				gotConfig = mountInfo.config
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedConfig.Logging.FilePath, gotConfig.Logging.FilePath)
+			assert.Equal(t, tc.expectedConfig.Logging.Format, gotConfig.Logging.Format)
+			assert.Equal(t, tc.expectedConfig.Logging.GkeGcsFuseErrorFile, gotConfig.Logging.GkeGcsFuseErrorFile)
+			assert.Equal(t, tc.expectedConfig.Logging.Severity, gotConfig.Logging.Severity)
+		})
+	}
+}
+
+func TestArgsParsing_LoggingConfigFile(t *testing.T) {
+	content := `
+logging:
+  file-path: /path/to/log.txt
+  format: text
+  severity: debug
+  gke-gcsfuse-error-file: /path/to/error.json
+`
+	tempFile := createTempConfigFile(t, content)
+	defer os.Remove(tempFile)
+
+	var gotConfig *cfg.Config
+	cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
+		gotConfig = mountInfo.config
+		return nil
+	})
+	require.Nil(t, err)
+	cmd.SetArgs(convertToPosixArgs([]string{"gcsfuse", fmt.Sprintf("--config-file=%s", tempFile), "abc", "pqr"}, cmd))
+
+	err = cmd.Execute()
+
+	assert.NoError(t, err)
+	assert.Equal(t, "/path/to/log.txt", string(gotConfig.Logging.FilePath))
+	assert.Equal(t, "text", gotConfig.Logging.Format)
+	assert.Equal(t, "/path/to/error.json", string(gotConfig.Logging.GkeGcsFuseErrorFile))
+	assert.Equal(t, "DEBUG", string(gotConfig.Logging.Severity))
+}


### PR DESCRIPTION
Refactor struct field casing from GkeGcsfuseErrorFile to GkeGcsFuseErrorFile to capitalize 'Fuse'.