### PR TITLE
feat(native-retries): add hidden flag for GKE mount-retry error file

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -666,6 +666,8 @@ type LoggingConfig struct {
 
 	Format string `yaml:"format"`
 
+	GkeGcsFuseErrorFile ResolvedPath `yaml:"gke-gcsfuse-error-file"`
+
 	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
 
 	Severity LogSeverity `yaml:"severity"`
@@ -1164,6 +1166,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	}
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
+
+	flagSet.StringP("gke-gcsfuse-error-file", "", "", "File path to write GCSFuse error logs during mount retries in GKE environment.")
+
+	if err := flagSet.MarkHidden("gke-gcsfuse-error-file"); err != nil {
+		return err
+	}
 
 	flagSet.StringP("grpc-path-strategy", "", "direct-path-with-fallback", "Strategy for DirectPath connectivity when client-protocol=grpc. Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available).")
 
@@ -1761,6 +1769,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("file-system.gid", flagSet.Lookup("gid")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("logging.gke-gcsfuse-error-file", flagSet.Lookup("gke-gcsfuse-error-file")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -640,6 +640,8 @@ type GcsRetriesConfig struct {
 
 	ExperimentalNonrapidFolderApiStallRetry bool `yaml:"experimental-nonrapid-folder-api-stall-retry"`
 
+	GkeMountRetriesErrorFile ResolvedPath `yaml:"gke-mount-retries-error-file"`
+
 	MaxRetryAttempts int64 `yaml:"max-retry-attempts"`
 
 	MaxRetrySleep time.Duration `yaml:"max-retry-sleep"`
@@ -665,8 +667,6 @@ type LoggingConfig struct {
 	FilePath ResolvedPath `yaml:"file-path"`
 
 	Format string `yaml:"format"`
-
-	GkeGcsFuseErrorFile ResolvedPath `yaml:"gke-gcsfuse-error-file"`
 
 	LogRotate LogRotateLoggingConfig `yaml:"log-rotate"`
 
@@ -1167,9 +1167,9 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
-	flagSet.StringP("gke-gcsfuse-error-file", "", "", "File path to write GCSFuse error logs during mount retries in GKE environment.")
+	flagSet.StringP("gke-mount-retries-error-file", "", "", "File path to write GCSFuse mounting errors during mount retries in GKE environment when enable-mount-retries is set.")
 
-	if err := flagSet.MarkHidden("gke-gcsfuse-error-file"); err != nil {
+	if err := flagSet.MarkHidden("gke-mount-retries-error-file"); err != nil {
 		return err
 	}
 
@@ -1772,7 +1772,7 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	if err := v.BindPFlag("logging.gke-gcsfuse-error-file", flagSet.Lookup("gke-gcsfuse-error-file")); err != nil {
+	if err := v.BindPFlag("gcs-retries.gke-mount-retries-error-file", flagSet.Lookup("gke-mount-retries-error-file")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -743,6 +743,13 @@ params:
     default: false
     hide-flag: true
 
+  - config-path: "gcs-retries.gke-mount-retries-error-file"
+    flag-name: "gke-mount-retries-error-file"
+    type: "resolvedPath"
+    usage: "File path to write GCSFuse mounting errors during mount retries in GKE environment when enable-mount-retries is set."
+    default: ""
+    hide-flag: true
+
   - config-path: "gcs-retries.max-retry-attempts"
     flag-name: "max-retry-attempts"
     type: "int"
@@ -856,13 +863,6 @@ params:
     type: "string"
     usage: "The format of the log file: 'text' or 'json'."
     default: "json"
-
-  - config-path: "logging.gke-gcsfuse-error-file"
-    flag-name: "gke-gcsfuse-error-file"
-    type: "resolvedPath"
-    usage: "File path to write GCSFuse error logs during mount retries in GKE environment."
-    default: ""
-    hide-flag: true
 
   - config-path: "logging.log-rotate.backup-file-count"
     flag-name: "log-rotate-backup-file-count"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -857,6 +857,13 @@ params:
     usage: "The format of the log file: 'text' or 'json'."
     default: "json"
 
+  - config-path: "logging.gke-gcsfuse-error-file"
+    flag-name: "gke-gcsfuse-error-file"
+    type: "resolvedPath"
+    usage: "File path to write GCSFuse error logs during mount retries in GKE environment."
+    default: ""
+    hide-flag: true
+
   - config-path: "logging.log-rotate.backup-file-count"
     flag-name: "log-rotate-backup-file-count"
     type: "int"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2166,6 +2166,29 @@ func TestArgParsing_GCSRetries(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test with gke-mount-retries-error-file",
+			args: []string{"gcsfuse", "--gke-mount-retries-error-file=/path/to/error.json", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsRetries: cfg.GcsRetriesConfig{
+					ChunkRetryDeadlineSecs:   120,
+					ChunkTransferTimeoutSecs: 10,
+					EnableMountRetries:       false,
+					GkeMountRetriesErrorFile: "/path/to/error.json",
+					MaxRetryAttempts:         math.MaxInt,
+					MaxRetrySleep:            30 * time.Second,
+					Multiplier:               2,
+					ReadStall: cfg.ReadStallGcsRetriesConfig{
+						Enable:              true,
+						InitialReqTimeout:   20 * time.Second,
+						MinReqTimeout:       1500 * time.Millisecond,
+						MaxReqTimeout:       1200 * time.Second,
+						ReqIncreaseRate:     15,
+						ReqTargetPercentile: 0.99,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -2891,78 +2914,13 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 	}
 }
 
-func TestArgsParsing_LoggingFlags(t *testing.T) {
-	tests := []struct {
-		name           string
-		args           []string
-		expectedConfig *cfg.Config
-	}{
-		{
-			name: "default",
-			args: []string{"gcsfuse", "abc", "pqr"},
-			expectedConfig: &cfg.Config{
-				Logging: cfg.LoggingConfig{
-					FilePath:            "",
-					Format:              "json",
-					GkeGcsFuseErrorFile: "",
-					Severity:            "INFO",
-					WireLog:             "",
-				},
-			},
-		},
-		{
-			name: "normal",
-			args: []string{
-				"gcsfuse",
-				"--log-file=/path/to/log.txt",
-				"--log-format=text",
-				"--log-severity=debug",
-				"--gke-gcsfuse-error-file=/path/to/error.json",
-				"pqr",
-			},
-			expectedConfig: &cfg.Config{
-				Logging: cfg.LoggingConfig{
-					FilePath:            "/path/to/log.txt",
-					Format:              "text",
-					GkeGcsFuseErrorFile: "/path/to/error.json",
-					Severity:            "DEBUG",
-					WireLog:             "",
-				},
-			},
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var gotConfig *cfg.Config
-			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
-				gotConfig = mountInfo.config
-				return nil
-			})
-			require.Nil(t, err)
-			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
-
-			err = cmd.Execute()
-
-			require.NoError(t, err)
-			assert.Equal(t, tc.expectedConfig.Logging.FilePath, gotConfig.Logging.FilePath)
-			assert.Equal(t, tc.expectedConfig.Logging.Format, gotConfig.Logging.Format)
-			assert.Equal(t, tc.expectedConfig.Logging.GkeGcsFuseErrorFile, gotConfig.Logging.GkeGcsFuseErrorFile)
-			assert.Equal(t, tc.expectedConfig.Logging.Severity, gotConfig.Logging.Severity)
-		})
-	}
-}
-
-func TestArgsParsing_LoggingConfigFile(t *testing.T) {
+func TestArgsParsing_GcsRetriesConfigFile(t *testing.T) {
 	content := `
-logging:
-  file-path: /path/to/log.txt
-  format: text
-  severity: debug
-  gke-gcsfuse-error-file: /path/to/error.json
+gcs-retries:
+  gke-mount-retries-error-file: /path/to/error.json
 `
 	tempFile := createTempConfigFile(t, content)
 	defer func() { _ = os.Remove(tempFile) }()
-
 	var gotConfig *cfg.Config
 	cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
 		gotConfig = mountInfo.config
@@ -2974,8 +2932,5 @@ logging:
 	err = cmd.Execute()
 
 	require.NoError(t, err)
-	assert.Equal(t, "/path/to/log.txt", string(gotConfig.Logging.FilePath))
-	assert.Equal(t, "text", gotConfig.Logging.Format)
-	assert.Equal(t, "/path/to/error.json", string(gotConfig.Logging.GkeGcsFuseErrorFile))
-	assert.Equal(t, "DEBUG", string(gotConfig.Logging.Severity))
+	assert.Equal(t, "/path/to/error.json", string(gotConfig.GcsRetries.GkeMountRetriesErrorFile))
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2961,7 +2961,7 @@ logging:
   gke-gcsfuse-error-file: /path/to/error.json
 `
 	tempFile := createTempConfigFile(t, content)
-	defer os.Remove(tempFile)
+	defer func() { _ = os.Remove(tempFile) }()
 
 	var gotConfig *cfg.Config
 	cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -2890,3 +2890,92 @@ func TestArgParsing_CliFlagsOverridesFlagOptimizations(t *testing.T) {
 		})
 	}
 }
+
+func TestArgsParsing_LoggingFlags(t *testing.T) {
+	tests := []struct {
+		name           string
+		args           []string
+		expectedConfig *cfg.Config
+	}{
+		{
+			name: "default",
+			args: []string{"gcsfuse", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				Logging: cfg.LoggingConfig{
+					FilePath:            "",
+					Format:              "json",
+					GkeGcsFuseErrorFile: "",
+					Severity:            "INFO",
+					WireLog:             "",
+				},
+			},
+		},
+		{
+			name: "normal",
+			args: []string{
+				"gcsfuse",
+				"--log-file=/path/to/log.txt",
+				"--log-format=text",
+				"--log-severity=debug",
+				"--gke-gcsfuse-error-file=/path/to/error.json",
+				"pqr",
+			},
+			expectedConfig: &cfg.Config{
+				Logging: cfg.LoggingConfig{
+					FilePath:            "/path/to/log.txt",
+					Format:              "text",
+					GkeGcsFuseErrorFile: "/path/to/error.json",
+					Severity:            "DEBUG",
+					WireLog:             "",
+				},
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotConfig *cfg.Config
+			cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
+				gotConfig = mountInfo.config
+				return nil
+			})
+			require.Nil(t, err)
+			cmd.SetArgs(convertToPosixArgs(tc.args, cmd))
+
+			err = cmd.Execute()
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedConfig.Logging.FilePath, gotConfig.Logging.FilePath)
+			assert.Equal(t, tc.expectedConfig.Logging.Format, gotConfig.Logging.Format)
+			assert.Equal(t, tc.expectedConfig.Logging.GkeGcsFuseErrorFile, gotConfig.Logging.GkeGcsFuseErrorFile)
+			assert.Equal(t, tc.expectedConfig.Logging.Severity, gotConfig.Logging.Severity)
+		})
+	}
+}
+
+func TestArgsParsing_LoggingConfigFile(t *testing.T) {
+	content := `
+logging:
+  file-path: /path/to/log.txt
+  format: text
+  severity: debug
+  gke-gcsfuse-error-file: /path/to/error.json
+`
+	tempFile := createTempConfigFile(t, content)
+	defer os.Remove(tempFile)
+
+	var gotConfig *cfg.Config
+	cmd, err := newRootCmd(func(mountInfo *mountInfo, _, _ string) error {
+		gotConfig = mountInfo.config
+		return nil
+	})
+	require.Nil(t, err)
+	cmd.SetArgs(convertToPosixArgs([]string{"gcsfuse", fmt.Sprintf("--config-file=%s", tempFile), "abc", "pqr"}, cmd))
+
+	err = cmd.Execute()
+
+	require.NoError(t, err)
+	assert.Equal(t, "/path/to/log.txt", string(gotConfig.Logging.FilePath))
+	assert.Equal(t, "text", gotConfig.Logging.Format)
+	assert.Equal(t, "/path/to/error.json", string(gotConfig.Logging.GkeGcsFuseErrorFile))
+	assert.Equal(t, "DEBUG", string(gotConfig.Logging.Severity))
+}


### PR DESCRIPTION
### Description
- Added a new hidden CLI flag `--gke-mount-retries-error-file` and bound it to configuration `gcs-retries.gke-mount-retries-error-file`.
- This specifies a file path to write GCSFuse error logs during GKE mount retries.

### Link to the issue in case of a bug fix.
b/526940808

### Testing details
1. Manual - Verified configuration mapping via unit tests.
2. Unit tests - Added `TestArgsParsing_LoggingFlags` and `TestArgsParsing_LoggingConfigFile` in `cmd/root_test.go` to test parser and binder logic.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No