### PR TITLE
test(integration): support Pirlo test configuration in test_config.yaml

### DIFF
--- a/tools/integration_tests/rapid_appends/setup_test.go
+++ b/tools/integration_tests/rapid_appends/setup_test.go
@@ -127,8 +127,8 @@ func TestMain(m *testing.M) {
 	testEnv.ctx = context.Background()
 	testEnv.cfg = &cfg.RapidAppends[0]
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
-	if !setup.IsZonalBucketRun() {
-		log.Fatalf("This test package is only compatible for zonal bucket runs")
+	if !setup.IsZonalBucketRun() && !setup.IsPirloBucketRun() {
+		log.Fatalf("This test package is only compatible for zonal and pirlo bucket runs")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/rapid_appends/suites_test.go
+++ b/tools/integration_tests/rapid_appends/suites_test.go
@@ -197,6 +197,19 @@ func (t *BaseSuite) isMetadataCacheEnabled() bool {
 func RunTests(t *testing.T, runName string, factory func(primaryFlags, secondaryFlags []string) suite.TestingSuite) {
 	for _, cfg := range testEnv.cfg.Configs {
 		if cfg.Run == runName {
+			isCompatible := false
+			switch testEnv.bucketType {
+			case setup.FlatPirloBucket:
+				isCompatible = cfg.RunOnPirlo.Flat.SameZone || cfg.RunOnPirlo.Flat.DifferentZone
+			case setup.HNSPirloBucket:
+				isCompatible = cfg.RunOnPirlo.Hns.SameZone || cfg.RunOnPirlo.Hns.DifferentZone
+			default:
+				isCompatible = cfg.Compatible[testEnv.bucketType]
+			}
+			if !isCompatible {
+				continue
+			}
+
 			for i, flagStr := range cfg.Flags {
 				flagStr = strings.ReplaceAll(flagStr, ",", " ")
 				primaryFlags := strings.Fields(flagStr)

--- a/tools/integration_tests/symlink_handling/symlink_handling_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_handling_test.go
@@ -41,6 +41,7 @@ type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
 	cfg           *test_suite.TestConfig
+	bucketType    string
 }
 
 func TestMain(m *testing.M) {
@@ -70,7 +71,7 @@ func TestMain(m *testing.M) {
 
 	testEnv.ctx = context.Background()
 	testEnv.cfg = &cfg.SymlinkHandling[0]
-	setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
 	// 2. Create storage client before running tests.
 	var err error

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
@@ -174,12 +173,8 @@ func TestLegacySymlinks(t *testing.T) {
 }
 
 func RunTests(t *testing.T, runName string, factory func(flags []string) suite.TestingSuite) {
-	for _, cfg := range testEnv.cfg.Configs {
-		if cfg.Run == runName {
-			for _, flagStr := range cfg.Flags {
-				flags := strings.Fields(flagStr)
-				suite.Run(t, factory(flags))
-			}
-		}
+	flagsSets := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, runName)
+	for _, flags := range flagsSets {
+		suite.Run(t, factory(flags))
 	}
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -24,6 +24,16 @@ explicit_dir:
           hns: false
           zonal: false
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: false
+            different_zone: false
+        run_on_gke: true
 
 implicit_dir:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -35,6 +45,16 @@ implicit_dir:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
       - flags:
           - "--implicit-dirs,--client-protocol=grpc"
@@ -58,12 +78,34 @@ list_large_dir:
         run_on_gke: true
         run: TestListLargeDirWithKernelListCache
       - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--stat-cache-ttl=0,--kernel-list-cache-ttl-secs=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: TestListLargeDirWithKernelListCache
+      - flags:
           - "--enable-metadata-prefetch,--implicit-dirs"
           - "--client-protocol=grpc,--enable-metadata-prefetch,--implicit-dirs"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+        run: TestListLargeDirWithoutKernelListCache
+      - flags:
+          - "--experimental-enable-pirlo,--enable-metadata-prefetch,--implicit-dirs"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
         run: TestListLargeDirWithoutKernelListCache
 operations:
@@ -80,6 +122,17 @@ operations:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 write_large_files:
@@ -99,6 +152,28 @@ write_large_files:
           hns: true
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--write-max-blocks-per-file=2,--write-global-max-blocks=5"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: true
+          hns:
+            same_zone: true
+            different_zone: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--write-max-blocks-per-file=2,--write-global-max-blocks=5"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 gzip:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -111,6 +186,16 @@ gzip:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--sequential-read-size-mb=1,--implicit-dirs"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 read_large_files:
@@ -136,6 +221,19 @@ read_large_files:
           hns: false
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs"
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=700,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/read_large_files,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/read_large_files,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 readonly:
   - mounted_directory: "${MOUNTED_DIR}" # To be passed by GKE after mounting
@@ -150,6 +248,18 @@ readonly:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--o=ro,--implicit-dirs"
+          - "--experimental-enable-pirlo,--file-mode=544,--dir-mode=544,--implicit-dirs"
+          - "--experimental-enable-pirlo,--o=ro,--implicit-dirs,--cache-dir=/gcsfuse-tmp/readonly,--file-cache-max-size-mb=3,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 rename_dir_limit:
@@ -172,6 +282,27 @@ rename_dir_limit:
           flat: false
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--rename-dir-limit=3,--implicit-dirs"
+          - "--experimental-enable-pirlo,--rename-dir-limit=3"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: false
+            different_zone: false
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo"
+        run_on_pirlo:
+          flat:
+            same_zone: false
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 local_file:
@@ -196,6 +327,21 @@ local_file:
           hns: true
           zonal: false
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs,--rename-dir-limit=3,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs,--rename-dir-limit=3,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=0"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=0"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 streaming_writes:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -209,6 +355,17 @@ streaming_writes:
           hns: true
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 cloud_profiler:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -221,6 +378,16 @@ cloud_profiler:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-cloud-profiler,--cloud-profiler-cpu,--cloud-profiler-heap,--cloud-profiler-goroutines,--cloud-profiler-mutex,--cloud-profiler-allocated-heap,--cloud-profiler-label=${PROFILE_LABEL},--cloud-profiler-service-name=${PROFILE_SERVICE_NAME}"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 requester_pays_bucket:
@@ -256,6 +423,18 @@ read_cache:
         run: TestSmallCacheTTLTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestSmallCacheTTLTest
+        run_on_gke: true
+      - flags:
           - "--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--o=ro,--enable-kernel-reader=false"
@@ -271,12 +450,37 @@ read_cache:
         run: TestReadOnlyTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--o=ro,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--o=ro,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestReadOnlyTest
+        run_on_gke: true
+      - flags:
           - "--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestRangeReadTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestRangeReadTest
         run_on_gke: true
       - flags:
@@ -289,6 +493,17 @@ read_cache:
         run: TestRangeReadWithParallelDownloadsTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest,--log-file=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: TestRangeReadWithParallelDownloadsTest
+      - flags:
           - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -300,6 +515,18 @@ read_cache:
         run: TestLocalModificationTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: TestLocalModificationTest
+      - flags:
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -308,6 +535,18 @@ read_cache:
           flat: true
           hns: true
           zonal: true
+        run: TestDisabledCacheTTLTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestDisabledCacheTTLTest
         run_on_gke: true
       - flags:
@@ -321,6 +560,19 @@ read_cache:
           flat: true
           hns: true
           zonal: true
+        run: TestCacheFileForRangeReadTrueTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestCacheFileForRangeReadTrueTest
         run_on_gke: true
       #        TODO: Enable Ram cache tests after bug b/383682524 is fixed
@@ -346,6 +598,17 @@ read_cache:
           zonal: true
         run: TestCacheFileForRangeReadFalseTest
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: TestCacheFileForRangeReadFalseTest
       #      - flags:
       #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE"
       #          - "--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/dev/shm/TestCacheFileForRangeReadFalseWithRamCache,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithRamCache.log,--log-severity=TRACE,--client-protocol=grpc"
@@ -364,6 +627,18 @@ read_cache:
           flat: true
           hns: true
           zonal: true
+        run: TestCacheFileForRangeReadFalseWithParallelDownloads
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestCacheFileForRangeReadFalseWithParallelDownloads
         run_on_gke: true
       #      - flags:
@@ -387,6 +662,17 @@ read_cache:
         run: TestJobChunkTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestJobChunkTest,--log-file=/gcsfuse-tmp/TestJobChunkTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestJobChunkTest
+        run_on_gke: true
+      - flags:
           # with unlimited max parallel downloads.
           - "--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=-1,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=-1,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -401,6 +687,19 @@ read_cache:
           flat: true
           hns: true
           zonal: true
+        run: TestJobChunkTestWithParallelDownloads
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=-1,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=9,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=2,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestJobChunkTestWithParallelDownloads
         run_on_gke: true
       - flags:
@@ -420,6 +719,20 @@ read_cache:
         run: TestCacheFileForExcludeRegexTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-exclude-regex=.,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-exclude-regex=.,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-exclude-regex=^${BUCKET_NAME}/,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/,--file-cache-exclude-regex=^${BUCKET_NAME}/,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestCacheFileForExcludeRegexTest
+        run_on_gke: true
+      - flags:
           - "--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
@@ -428,6 +741,18 @@ read_cache:
           flat: true
           hns: true
           zonal: true
+        run: TestRemountTest
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestRemountTest
         run_on_gke: false
       - flags:
@@ -442,11 +767,34 @@ read_cache:
         run: TestCacheFileForIncludeRegexTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestCacheFileForIncludeRegexTest
+        run_on_gke: true
+      - flags:
           - "--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheTest,--log-file=/gcsfuse-tmp/TestChunkCacheTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestChunkCacheTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheTest,--log-file=/gcsfuse-tmp/TestChunkCacheTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestChunkCacheTest
         run_on_gke: true
       - flags:
@@ -458,11 +806,33 @@ read_cache:
         run: TestChunkCacheDisabledTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest,--log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestChunkCacheDisabledTest
+        run_on_gke: true
+      - flags:
           - "--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=15,--cache-dir=/gcsfuse-tmp/TestChunkCacheEviction,--log-file=/gcsfuse-tmp/TestChunkCacheEviction.log,--log-severity=TRACE,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestChunkCacheEviction
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=15,--cache-dir=/gcsfuse-tmp/TestChunkCacheEviction,--log-file=/gcsfuse-tmp/TestChunkCacheEviction.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestChunkCacheEviction
         run_on_gke: true
 
@@ -480,6 +850,18 @@ stale_handle:
         run: "TestStaleHandleStreamingWritesEnabled"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestStaleHandleStreamingWritesEnabled"
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
           - "--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=grpc"
         compatible:
@@ -488,6 +870,18 @@ stale_handle:
           zonal: true
         run: "TestStaleHandleStreamingWritesDisabled"
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: "TestStaleHandleStreamingWritesDisabled"
 
 readdirplus:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -503,6 +897,17 @@ readdirplus:
         run: TestReaddirplusWithDentryCacheTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-readdirplus,--experimental-enable-dentry-cache,--log-file=/gcsfuse-tmp/TestReaddirplusWithDentryCacheTest.log,--log-severity=TRACE"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestReaddirplusWithDentryCacheTest
+        run_on_gke: true
+      - flags:
           - "--implicit-dirs,--experimental-enable-readdirplus,--log-file=/gcsfuse-tmp/TestReaddirplusWithoutDentryCacheTest.log,--log-severity=TRACE"
           - "--implicit-dirs,--experimental-enable-readdirplus,--log-file=/gcsfuse-tmp/TestReaddirplusWithoutDentryCacheTest.log,--log-severity=TRACE,--client-protocol=grpc"
         compatible:
@@ -511,6 +916,17 @@ readdirplus:
           zonal: true
         run: TestReaddirplusWithoutDentryCacheTest
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-readdirplus,--log-file=/gcsfuse-tmp/TestReaddirplusWithoutDentryCacheTest.log,--log-severity=TRACE"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+        run: TestReaddirplusWithoutDentryCacheTest
 
 inactive_stream_timeout:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -526,11 +942,33 @@ inactive_stream_timeout:
         run: TestTimeoutEnabledSuite
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--read-inactive-stream-timeout=1s,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestTimeoutEnabledSuite
+        run_on_gke: true
+      - flags:
           - "--read-inactive-stream-timeout=0s,--client-protocol=http1,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestTimeoutDisabledSuite
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--read-inactive-stream-timeout=0s,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestTimeoutDisabledSuite
         run_on_gke: true
 
@@ -549,6 +987,17 @@ benchmarking:
         run: "Benchmark_Stat"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "Benchmark_Stat"
+        run_on_gke: true
+      - flags:
           - "--stat-cache-ttl=0,--enable-atomic-rename-object"
           - "--stat-cache-ttl=0,--enable-atomic-rename-object,--client-protocol=grpc"
         compatible:
@@ -558,12 +1007,34 @@ benchmarking:
         run: "Benchmark_Rename"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0,--enable-atomic-rename-object"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "Benchmark_Rename"
+        run_on_gke: true
+      - flags:
           - "--stat-cache-ttl=0"
           - "--client-protocol=grpc,--stat-cache-ttl=0"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: "Benchmark_Delete"
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "Benchmark_Delete"
         run_on_gke: true
 
@@ -581,6 +1052,17 @@ dentry_cache:
         run: TestStatWithDentryCacheEnabledTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=2"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestStatWithDentryCacheEnabledTest
+        run_on_gke: true
+      - flags:
           - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
           - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000,--client-protocol=grpc"
         compatible:
@@ -590,12 +1072,34 @@ dentry_cache:
         run: TestDeleteOperationTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestDeleteOperationTest
+        run_on_gke: true
+      - flags:
           - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
           - "--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestNotifierTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestNotifierTest
         run_on_gke: true
 
@@ -612,6 +1116,16 @@ read_gcs_algo:
           hns: true
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 unfinalized_object:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -627,6 +1141,18 @@ unfinalized_object:
         run: TestUnfinalizedObjectReadTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=-1"
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=-1,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestUnfinalizedObjectReadTest
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-ttl-secs=0"
           - "--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
         compatible:
@@ -636,12 +1162,36 @@ unfinalized_object:
         run: TestUnfinalizedObjectOperationTest
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0"
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestUnfinalizedObjectOperationTest
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-ttl-secs=2"
           - "--metadata-cache-ttl-secs=2,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: false
           zonal: true
+        run: TestUnfinalizedObjectTailingReadTest
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=2"
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=2,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestUnfinalizedObjectTailingReadTest
         run_on_gke: true
 
@@ -666,6 +1216,23 @@ interrupt:
           hns: true
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--enable-streaming-writes"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--enable-streaming-writes"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--ignore-interrupts,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--ignore-interrupts,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--ignore-interrupts=false,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--ignore-interrupts=false,--enable-streaming-writes=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 log_rotation:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -679,57 +1246,99 @@ log_rotation:
           hns: true
           zonal: true
         run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress=false,--log-severity=trace"
+          - "--experimental-enable-pirlo,--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress,--log-severity=trace"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 readonly_creds:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  configs:
-    - flags:
-      - "--implicit-dirs=true"
-      - "--implicit-dirs=true,--client-protocol=grpc"
-      - "--implicit-dirs=false"
-      - "--implicit-dirs=false,--client-protocol=grpc"
-      compatible:
-        flat: true
-        hns: true
-        zonal: true
-      run_on_gke: false
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--implicit-dirs=true"
+          - "--implicit-dirs=false"
+          - "--implicit-dirs=true,--client-protocol=grpc"
+          - "--implicit-dirs=false,--client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--implicit-dirs=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 mount_timeout:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  configs:
-    - flags:
-      - ""
-      compatible:
-        flat: true
-        hns: true
-        zonal: true
-      run_on_gke: false
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - ""
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 release_version:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  configs:
-    - flags:
-      - ""
-      compatible:
-        flat: true
-        hns: true
-        zonal: true
-      run_on_gke: false
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - ""
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
 
 mounting:
-- mounted_directory: "${MOUNTED_DIR}"
-  test_bucket: "${BUCKET_NAME}"
-  configs:
-    - flags:
-      - ""
-      compatible:
-        flat: true
-        hns: true
-        zonal: true
-      run_on_gke: false
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - ""
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 flag_optimizations:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -743,6 +1352,17 @@ flag_optimizations:
           hns: true
           zonal: true
         run_on_gke: false
+      - run: TestMountFails
+        flags:
+          - "--experimental-enable-pirlo,--profile=unknown-profile"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
       - run: TestImplicitDirsNotEnabled
         flags:
           - "--machine-type=low-end-machine"
@@ -750,6 +1370,14 @@ flag_optimizations:
           flat: true
           hns: false
           zonal: false
+        run_on_gke: true
+      - run: TestImplicitDirsNotEnabled
+        flags:
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
       - run: TestRenameDirLimitNotSet
         flags:
@@ -760,6 +1388,16 @@ flag_optimizations:
           flat: true
           hns: false
           zonal: false
+        run_on_gke: true
+      - run: TestRenameDirLimitNotSet
+        flags:
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine"
+          - "--experimental-enable-pirlo,--profile=aiml-training"
+          - "--experimental-enable-pirlo,--profile=aiml-serving"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
       - run: TestImplicitDirsEnabled
         flags:
@@ -775,6 +1413,20 @@ flag_optimizations:
           hns: false
           zonal: false
         run_on_gke: true
+      - run: TestImplicitDirsEnabled
+        flags:
+          - "--experimental-enable-pirlo,--machine-type=a3-highgpu-8g"
+          - "--experimental-enable-pirlo,--profile=aiml-training"
+          - "--experimental-enable-pirlo,--profile=aiml-serving"
+          - "--experimental-enable-pirlo,--profile=aiml-checkpointing"
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-training"
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-serving"
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-checkpointing"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
       - run: TestRenameDirLimitSet
         flags:
           - "--machine-type=a3-highgpu-8g"
@@ -785,6 +1437,16 @@ flag_optimizations:
           hns: false
           zonal: false
         run_on_gke: true
+      - run: TestRenameDirLimitSet
+        flags:
+          - "--experimental-enable-pirlo,--machine-type=a3-highgpu-8g"
+          - "--experimental-enable-pirlo,--profile=aiml-checkpointing"
+          - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-checkpointing"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
       - run: TestZonalBucketOptimizations
         flags:
           - "--log-severity=trace"
@@ -792,6 +1454,17 @@ flag_optimizations:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: false
+      - run: TestZonalBucketOptimizations
+        flags:
+          - "--experimental-enable-pirlo,--log-severity=trace"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: false
       - run: TestZonalBucketOptimizations_ExplicitOverrides
         flags:
@@ -801,6 +1474,17 @@ flag_optimizations:
           hns: false
           zonal: true
         run_on_gke: false
+      - run: TestZonalBucketOptimizations_ExplicitOverrides
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--max-read-ahead-kb=2048,--max-background=50,--congestion-threshold=30,--log-severity=trace"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
       - run: TestZonalBucketOptimizations_Dynamic
         flags:
           - "--log-severity=trace"
@@ -808,6 +1492,17 @@ flag_optimizations:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: false
+      - run: TestZonalBucketOptimizations_Dynamic
+        flags:
+          - "--experimental-enable-pirlo,--log-severity=trace"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: false
       - run: TestKernelReader_DefaultAndPrecedence
         # Tests that kernel reader is used by default and takes precedence over buffered reader and file cache.
@@ -821,6 +1516,20 @@ flag_optimizations:
           hns: false
           zonal: true
         run_on_gke: false
+      - run: TestKernelReader_DefaultAndPrecedence
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace"
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_FileCache"
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-buffered-read=true"
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-buffered-read=true,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
       - run: TestFileCache_KernelReaderDisabled
         # Tests that file cache is used when kernel reader is explicitly disabled.
         flags:
@@ -829,6 +1538,17 @@ flag_optimizations:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: false
+      - run: TestFileCache_KernelReaderDisabled
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: false
       - run: TestBufferedReader_KernelReaderDisabled
         # Tests that buffered reader is used when kernel reader is explicitly disabled.
@@ -839,6 +1559,17 @@ flag_optimizations:
           hns: false
           zonal: true
         run_on_gke: false
+      - run: TestBufferedReader_KernelReaderDisabled
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--enable-buffered-read"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
       - run: TestKernelReader_Dynamic
         flags:
           - "--implicit-dirs,--log-severity=trace"
@@ -846,6 +1577,17 @@ flag_optimizations:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: false
+      - run: TestKernelReader_Dynamic
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: false
 
 unsupported_path:
@@ -866,6 +1608,16 @@ unsupported_path:
           hns: true
           zonal: true
         run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 kernel_list_cache:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -882,6 +1634,17 @@ kernel_list_cache:
         run: "TestInfiniteKernelListCacheTest"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestInfiniteKernelListCacheTest"
+        run_on_gke: true
+      - flags:
           # Note: metadata cache is disabled to avoid cache consistency issue between gcsfuse cache and kernel cache. As
           # gcsfuse cache might hold the entry which already became stale due to delete operation.
           - "--kernel-list-cache-ttl-secs=-1,--metadata-cache-ttl-secs=0,--metadata-cache-negative-ttl-secs=0"
@@ -890,6 +1653,17 @@ kernel_list_cache:
           flat: true
           hns: true
           zonal: true
+        run: "TestInfiniteKernelListCacheDeleteDirTest"
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--metadata-cache-ttl-secs=0,--metadata-cache-negative-ttl-secs=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestInfiniteKernelListCacheDeleteDirTest"
         run_on_gke: true
       - flags:
@@ -902,12 +1676,34 @@ kernel_list_cache:
         run: "TestFiniteKernelListCacheTest"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=5,--rename-dir-limit=10"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestFiniteKernelListCacheTest"
+        run_on_gke: true
+      - flags:
           - "--kernel-list-cache-ttl-secs=0,--stat-cache-ttl=0,--rename-dir-limit=10"
           - "--kernel-list-cache-ttl-secs=0,--stat-cache-ttl=0,--rename-dir-limit=10,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: "TestDisabledKernelListCacheTest"
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=0,--stat-cache-ttl=0,--rename-dir-limit=10"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestDisabledKernelListCacheTest"
         run_on_gke: true
 
@@ -924,6 +1720,17 @@ rapid_appends:
           hns: false
           zonal: true
         run_on_gke: true
+      - run: TestSingleMountAppendsTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
       - run: TestDualMountAppendsTestSuite
         flags:
           - "--write-block-size-mb=1"
@@ -933,6 +1740,19 @@ rapid_appends:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: true
+      - run: TestDualMountAppendsTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+        secondary_flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
       - run: TestSingleMountReadsTestSuite
         flags:
@@ -948,6 +1768,24 @@ rapid_appends:
           flat: false
           hns: false
           zonal: true
+        run_on_gke: true
+      - run: TestSingleMountReadsTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0" # NoCache
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70" # MetadataCache
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache,--metadata-cache-ttl-secs=0" # FileCache
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache" # MetadataAndFileCache
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false" # NoCacheWithoutKernelReader
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--enable-kernel-reader=false" # MetadataCacheWithMRDWrapperWithoutKernelReader
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false" # FileCacheWithoutKernelReader
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache,--enable-kernel-reader=false" # MetadataAndFileCacheWithoutKernelReader
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
       - run: TestDualMountReadsTestSuiteWithMetadataCache
         flags:
@@ -965,6 +1803,25 @@ rapid_appends:
           hns: false
           zonal: true
         run_on_gke: true
+      - run: TestDualMountReadsTestSuiteWithMetadataCache
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache-primary"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache-primary,--enable-kernel-reader=false"
+        secondary_flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
       - run: TestDualMountReadsTestSuiteWithoutMetadataCache
         flags:
           - "--metadata-cache-ttl-secs=0"
@@ -981,6 +1838,25 @@ rapid_appends:
           hns: false
           zonal: true
         run_on_gke: true
+      - run: TestDualMountReadsTestSuiteWithoutMetadataCache
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache-primary,--metadata-cache-ttl-secs=0"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache-primary,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false"
+        secondary_flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
 
 monitoring:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -995,11 +1871,33 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: false
       - flags:
+          - "--experimental-enable-pirlo,--prometheus-port=11190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: false
+            different_zone: false
+        run: "TestPromOTELSuite"
+        run_on_gke: false
+      - flags:
           - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
           zonal: true
+        run: "TestPromOTELSuite"
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--prometheus-port=12190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: false
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestPromOTELSuite"
         run_on_gke: false
       - flags:
@@ -1011,11 +1909,33 @@ monitoring:
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
       - flags:
+          - "--experimental-enable-pirlo,--prometheus-port=11191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: false
+            different_zone: false
+        run: "TestPromBufferedReadSuite"
+        run_on_gke: false
+      - flags:
           - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
           hns: true
           zonal: true
+        run: "TestPromBufferedReadSuite"
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--prometheus-port=12191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: false
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
       - flags:
@@ -1027,6 +1947,17 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:
+          - "--experimental-enable-pirlo,--experimental-enable-grpc-metrics,--prometheus-port=11192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: false
+            different_zone: false
+        run: "TestPromGrpcMetricsSuite"
+        run_on_gke: false
+      - flags:
           - "--client-protocol=grpc,--experimental-enable-grpc-metrics,--prometheus-port=10192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
         compatible:
           flat: false
@@ -1035,11 +1966,33 @@ monitoring:
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:
-          - "--prometheus-port=9193 --log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
+          - "--experimental-enable-pirlo,--experimental-enable-grpc-metrics,--prometheus-port=12192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: false
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestPromGrpcMetricsSuite"
+        run_on_gke: false
+      - flags:
+          - "--prometheus-port=9193,--log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
         compatible:
           flat: false
           hns: false
           zonal: true
+        run: "TestPromKernelReaderSuite"
+        run_on_gke: false
+      - flags:
+          - "--experimental-enable-pirlo,--prometheus-port=12193,--log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestPromKernelReaderSuite"
         run_on_gke: false
 
@@ -1056,6 +2009,17 @@ symlink_handling:
           hns: true
           zonal: true
         run_on_gke: true
+      - run: TestStandardSymlinksTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-standard-symlinks=true"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
       - run: TestLegacySymlinksTestSuite
         flags:
           - "--enable-standard-symlinks=false"
@@ -1064,6 +2028,17 @@ symlink_handling:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: true
+      - run: TestLegacySymlinksTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-standard-symlinks=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: true
 
 buffered_read:
@@ -1080,6 +2055,17 @@ buffered_read:
         run: TestSequentialReadSuite
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestBufferedReadSuite.log,--log-severity=TRACE"
+        run: TestSequentialReadSuite
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+      - flags:
           - "--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE"
           - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE"
         compatible:
@@ -1089,12 +2075,34 @@ buffered_read:
         run: TestInsufficientPoolCreationSuite
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestInsufficientPoolCreationSuite
+        run_on_gke: true
+      - flags:
           - "--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE"
           - "--client-protocol=grpc,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: TestRandomReadFallbackSuite
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: TestRandomReadFallbackSuite
         run_on_gke: true
 
@@ -1113,6 +2121,17 @@ negative_stat_cache:
         run: "TestDisabledNegativeStatCacheTest"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestDisabledNegativeStatCacheTest"
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-negative-ttl-secs=5"
           - "--metadata-cache-negative-ttl-secs=5,--client-protocol=grpc"
         compatible:
@@ -1122,12 +2141,34 @@ negative_stat_cache:
         run: "TestFiniteNegativeStatCacheTest"
         run_on_gke: true
       - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=5"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: "TestFiniteNegativeStatCacheTest"
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-negative-ttl-secs=-1"
           - "--metadata-cache-negative-ttl-secs=-1,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
           zonal: true
+        run: "TestInfiniteNegativeStatCacheTest"
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run: "TestInfiniteNegativeStatCacheTest"
         run_on_gke: true
 
@@ -1144,6 +2185,17 @@ managed_folders:
           hns: true
           zonal: true
         run_on_gke: false
+      - run: TestManagedFolders_FolderViewPermission
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=3"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
       - run: TestEnableEmptyManagedFoldersTrue
         flags:
           - "--implicit-dirs,--enable-empty-managed-folders"
@@ -1151,6 +2203,17 @@ managed_folders:
           flat: true
           hns: true
           zonal: true
+        run_on_gke: false
+      - run: TestEnableEmptyManagedFoldersTrue
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-empty-managed-folders"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
         run_on_gke: false
       - run: TestManagedFolders_FolderAdminPermission
         flags:
@@ -1160,37 +2223,74 @@ managed_folders:
           hns: true
           zonal: true
         run_on_gke: false
+      - run: TestManagedFolders_FolderAdminPermission
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=5,--stat-cache-ttl=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 concurrent_operations:
- - mounted_directory: "${MOUNTED_DIR}"
-   test_bucket: "${BUCKET_NAME}"
-   configs:
-     - flags:
-       - ""
-       - "--file-cache-cache-file-for-range-read=true --file-cache-enable-parallel-downloads=true --enable-kernel-reader=false --cache-dir=/gcsfuse-tmp/read_large_files"
-       - "--enable-buffered-read --enable-kernel-reader=false --enable-metadata-prefetch"
-       compatible:
-         flat: true
-         hns: true
-         zonal: true
-       run: TestConcurrentRead
-       run_on_gke: true
-     - flags:
-       - "--enable-kernel-reader=false"
-       compatible:
-         flat: false
-         hns: false
-         zonal: true
-       run: TestConcurrentRead
-       run_on_gke: true
-     - flags:
-       - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch"
-       - "--kernel-list-cache-ttl-secs=0 --enable-metadata-prefetch --client-protocol=grpc"
-       - "--kernel-list-cache-ttl-secs=-1"
-       - "--kernel-list-cache-ttl-secs=-1 --client-protocol=grpc"
-       compatible:
-         flat: true
-         hns: true
-         zonal: true
-       run: TestConcurrentListing
-       run_on_gke: true
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - ""
+          - "--file-cache-cache-file-for-range-read=true,--file-cache-enable-parallel-downloads=true,--enable-kernel-reader=false,--cache-dir=/gcsfuse-tmp/read_large_files"
+          - "--enable-buffered-read,--enable-kernel-reader=false,--enable-metadata-prefetch"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestConcurrentRead
+        run_on_gke: true
+      - flags:
+          - "--enable-kernel-reader=false"
+        compatible:
+          flat: false
+          hns: false
+          zonal: true
+        run: TestConcurrentRead
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo"
+          - "--experimental-enable-pirlo,--file-cache-cache-file-for-range-read=true,--file-cache-enable-parallel-downloads=true,--enable-kernel-reader=false,--cache-dir=/gcsfuse-tmp/read_large_files"
+          - "--experimental-enable-pirlo,--enable-buffered-read,--enable-kernel-reader=false,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--enable-kernel-reader=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestConcurrentRead
+        run_on_gke: true
+      - flags:
+          - "--kernel-list-cache-ttl-secs=0,--enable-metadata-prefetch"
+          - "--kernel-list-cache-ttl-secs=0,--enable-metadata-prefetch,--client-protocol=grpc"
+          - "--kernel-list-cache-ttl-secs=-1"
+          - "--kernel-list-cache-ttl-secs=-1,--client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestConcurrentListing
+        run_on_gke: true
+      - flags:
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=0,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestConcurrentListing
+        run_on_gke: true

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,6 +43,7 @@ import (
 
 var isPresubmitRun = flag.Bool("presubmit", false, "Boolean flag to indicate if test-run is a presubmit run.")
 var isZonalBucketRun = flag.Bool("zonal", false, "Boolean flag to indicate if test-run should use a zonal bucket.")
+var isPirloBucketRun = flag.Bool("pirlo", false, "Boolean flag to indicate if test-run is for a Pirlo bucket.")
 var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
 var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
@@ -121,6 +122,14 @@ func IsZonalBucketRun() bool {
 
 func SetIsZonalBucketRun(val bool) {
 	*isZonalBucketRun = val
+}
+
+func IsPirloBucketRun() bool {
+	return *isPirloBucketRun
+}
+
+func SetIsPirloBucketRun(val bool) {
+	*isPirloBucketRun = val
 }
 
 func TestBucket() string {
@@ -588,6 +597,8 @@ func TestEnvironment(ctx context.Context, cfg *test_suite.TestConfig) string {
 const FlatBucket = "flat"
 const HNSBucket = "hns"
 const ZonalBucket = "zonal"
+const FlatPirloBucket = "flat_pirlo"
+const HNSPirloBucket = "hns_pirlo"
 
 func BucketType(ctx context.Context, testBucket string) (bucketType string, err error) {
 	// For only-dir mounts bucket name is passed as <test_bucket>/<only_dir> by GKE.
@@ -618,14 +629,22 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	if attrs.LocationType == "zone" {
 		return ZonalBucket, nil
 	}
+	// TODO(b/483608308): Once GetStorageLayout starts returning Pirlo bucket type,
+	// update this logic to use the response instead of inferring from IsPirloBucketRun().
 	if attrs.HierarchicalNamespace != nil && attrs.HierarchicalNamespace.Enabled {
+		if IsPirloBucketRun() {
+			return HNSPirloBucket, nil
+		}
 		return HNSBucket, nil
+	}
+	if IsPirloBucketRun() {
+		return FlatPirloBucket, nil
 	}
 	return FlatBucket, nil
 }
 
 // BuildFlagSets dynamically builds a list of flag sets based on bucket compatibility.
-// bucketType should be "flat", "hns", or "zonal".
+// bucketType should be "flat", "hns", "zonal", "flat_pirlo", or "hns_pirlo".
 // The run parameter filters flag sets based on the 'Run' field in the test
 // configuration, which typically corresponds to a specific test name. If run is
 // an empty string, all flag sets for the package are returned.
@@ -643,9 +662,22 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 	// 1. Iterate through each defined test configuration (e.g., HTTP, gRPC).
 	for _, testCase := range cfg.Configs {
 		// 2. Check if the current test case is compatible with the bucket type.
-		// This is a safe and concise way to check the map.
-		isCompatible, ok := testCase.Compatible[bucketType]
-		if ok && isCompatible && (run == "" || run == testCase.Run) {
+		// For Pirlo runs, evaluate the RunOnPirlo struct. Otherwise, check the standard Compatible map.
+		isCompatible := false
+		switch bucketType {
+		case FlatPirloBucket:
+			isCompatible = testCase.RunOnPirlo.Flat.SameZone || testCase.RunOnPirlo.Flat.DifferentZone
+		case HNSPirloBucket:
+			isCompatible = testCase.RunOnPirlo.Hns.SameZone || testCase.RunOnPirlo.Hns.DifferentZone
+		default:
+			var ok bool
+			isCompatible, ok = testCase.Compatible[bucketType]
+			if !ok {
+				isCompatible = false
+			}
+		}
+
+		if isCompatible && (run == "" || run == testCase.Run) {
 			// 3. If compatible, process its flags and add them to the result.
 			for _, flagString := range testCase.Flags {
 				flagString = strings.ReplaceAll(flagString, ",", " ")

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -40,13 +40,26 @@ type TestConfig struct {
 	OnlyDir                          string       `yaml:"only_dir,omitempty"`
 }
 
+// PirloZoneConfig defines whether to run in the same or different zone for Pirlo.
+type PirloZoneConfig struct {
+	SameZone      bool `yaml:"same_zone"`
+	DifferentZone bool `yaml:"different_zone"`
+}
+
+// RunOnPirloConfig defines the Pirlo execution configurations and specific flags.
+type RunOnPirloConfig struct {
+	Flat PirloZoneConfig `yaml:"flat"`
+	Hns  PirloZoneConfig `yaml:"hns"`
+}
+
 // ConfigItem defines the variable parts of each test run.
 type ConfigItem struct {
-	Flags          []string        `yaml:"flags"`
-	SecondaryFlags []string        `yaml:"secondary_flags"`
-	Compatible     map[string]bool `yaml:"compatible"`
-	Run            string          `yaml:"run,omitempty"`
-	RunOnGKE       bool            `yaml:"run_on_gke"`
+	Flags          []string         `yaml:"flags"`
+	SecondaryFlags []string         `yaml:"secondary_flags"`
+	Compatible     map[string]bool  `yaml:"compatible"`
+	Run            string           `yaml:"run,omitempty"`
+	RunOnGKE       bool             `yaml:"run_on_gke"`
+	RunOnPirlo     RunOnPirloConfig `yaml:"run_on_pirlo"`
 }
 
 // Config holds all test configurations parsed from the YAML file.


### PR DESCRIPTION
### **Description**
This PR enables integration testing support for Pirlo buckets by integrating this bucket type with the configuration-driven testing logic in standard GCSFuse testing framework. This aligns test configurations and execution scopes across both standard GCSFuse builds and GKE CSI driver deployments, supporting robust cross-environment validation.

#### **Key Changes**:
1. **`tools/integration_tests/test_config.yaml`**:
   * Appends the top-level `run_on_pirlo` structure to compatible test suites, defining whether a test runs on `same_zone` and/or `different_zone` across `flat` and `hns` bucket configurations.
2. **`tools/integration_tests/util/test_suite/config.go`**:
   * Added parsing structures `PirloZoneConfig` and `RunOnPirloConfig` to map YAML entries onto the standard `ConfigItem` structure.
3. **`tools/integration_tests/util/setup/setup.go`**:
   * Introduced the command-line flag `-pirlo` to specify that a given test execution is targeting an Pirlo run.
   * Defined bucket types `flat_pirlo` and `hns_pirlo` under environment detection.
   * Modified `BuildFlagSets` to resolve test compatibility against `RunOnPirlo` configurations instead of standard maps whenever a Pirlo bucket run is detected.

#### **Test Suite Adaptations & Flag Configurations**:
* **`write_large_files`**: Configured for cross-zone executions (`different_zone: true`) to validate GCSFuse's capability to read and write successfully across regions. Executes standard and rapid write path permutations (`--enable-rapid-writes=true|false`).
* **`local_file`, `streaming_writes`, `stale_handle`, `interrupt`**: Configured to test both permutations (`--enable-rapid-writes=true|false`) to validate behavioral variations over Standard Class and Rapid Class write paths.
* **`rapid_appends`**: Configured with `--enable-rapid-writes=true` and `--finalize-file-for-rapid=false` to validate takeover append behaviors without early backend finalization on file close.
* **Protocol Optimization**: Skipping all flagsets using `--client-protocol=grpc` for Pirlo runs, as Pirlo exclusively supports and defaults to the gRPC path.

### **Link to the Issue**
b/524077258


### **Testing Details**
1. **Manual**: NA
2. **Unit tests**: NA
3. **Integration tests**: NA


### **Any backward incompatible change? If so, please explain.**