### PR TITLE
feat(storage): introduce IsDirectory flag to bypass appendable API

### DIFF
--- a/internal/canned/canned.go
+++ b/internal/canned/canned.go
@@ -71,8 +71,9 @@ func MakeFakeBucket(ctx context.Context) (b gcs.Bucket) {
 		_, err := b.CreateObject(
 			ctx,
 			&gcs.CreateObjectRequest{
-				Name:     k,
-				Contents: strings.NewReader(v),
+				Name:        k,
+				Contents:    strings.NewReader(v),
+				IsDirectory: strings.HasSuffix(k, "/"),
 			})
 
 		if err != nil {

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -533,7 +533,8 @@ func (d *dirInode) createNewObject(
 	ctx context.Context,
 	name Name,
 	metadata map[string]string,
-	content string) (o *gcs.Object, err error) {
+	content string,
+	isDirectory bool) (o *gcs.Object, err error) {
 	// Create a backing object for the child, failing if it already
 	// exists.
 	var precond int64
@@ -542,6 +543,7 @@ func (d *dirInode) createNewObject(
 		Contents:               strings.NewReader(content),
 		GenerationPrecondition: &precond,
 		Metadata:               metadata,
+		IsDirectory:            isDirectory,
 	}
 
 	o, err = d.bucket.CreateObject(ctx, createReq)
@@ -1117,7 +1119,7 @@ func (d *dirInode) CreateChildFile(ctx context.Context, name string) (*Core, err
 	}
 	fullName := NewFileName(d.Name(), name)
 
-	o, err := d.createNewObject(ctx, fullName, childMetadata, "")
+	o, err := d.createNewObject(ctx, fullName, childMetadata, "", false)
 	if err != nil {
 		return nil, err
 	}
@@ -1215,7 +1217,7 @@ func (d *dirInode) CreateChildSymlink(ctx context.Context, name string, target s
 		}
 	}
 
-	o, err := d.createNewObject(ctx, fullName, childMetadata, content)
+	o, err := d.createNewObject(ctx, fullName, childMetadata, content, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1251,7 +1253,7 @@ func (d *dirInode) CreateChildDir(ctx context.Context, name string) (*Core, erro
 	} else {
 		var o *gcs.Object
 		// For non-hierarchical buckets, create a new object.
-		o, err = d.createNewObject(ctx, fullName, nil, "")
+		o, err = d.createNewObject(ctx, fullName, nil, "", true)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/fs/inode/hns_dir_test.go
+++ b/internal/fs/inode/hns_dir_test.go
@@ -656,7 +656,7 @@ func (t *NonHNSDirTest) TestCreateChildDirWhenBucketTypeIsNonHNSWithFailure() {
 	const name = "folder"
 	var preCond int64
 	dirName := path.Join(dirInodeName, name) + "/"
-	createObjectReq := gcs.CreateObjectRequest{Name: dirName, Contents: strings.NewReader(""), GenerationPrecondition: &preCond}
+	createObjectReq := gcs.CreateObjectRequest{Name: dirName, Contents: strings.NewReader(""), GenerationPrecondition: &preCond, IsDirectory: true}
 	t.mockBucket.On("CreateObject", t.ctx, &createObjectReq).Return(nil, fmt.Errorf("mock error"))
 
 	result, err := t.in.CreateChildDir(t.ctx, name)
@@ -673,7 +673,7 @@ func (t *NonHNSDirTest) TestCreateChildDirWhenBucketTypeIsNonHNSWithSuccess() {
 	const name = "folder"
 	dirName := path.Join(dirInodeName, name) + "/"
 	var preCond int64
-	createObjectReq := gcs.CreateObjectRequest{Name: dirName, Contents: strings.NewReader(""), GenerationPrecondition: &preCond}
+	createObjectReq := gcs.CreateObjectRequest{Name: dirName, Contents: strings.NewReader(""), GenerationPrecondition: &preCond, IsDirectory: true}
 	object := gcs.Object{Name: dirName}
 	t.mockBucket.On("CreateObject", t.ctx, &createObjectReq).Return(&object, nil)
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -207,7 +207,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// choose to keep objects unfinalized by setting the FinalizeFileForRapid flag
 	// to false, which allows further appends, but if they keep it unfinalized
 	// it never becomes regionally durable.
-	wc.Append = bh.BucketType().RapidWritesEnabled()
+	wc.Append = bh.BucketType().RapidWritesEnabled() && !req.IsDirectory
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileForRapid flag.
 	// When writer.Append is false, then this parameter is anyways ignored.
@@ -248,7 +248,7 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	// choose to keep objects unfinalized by setting the FinalizeFileForRapid flag
 	// to false, which allows further appends, but if they keep it unfinalized
 	// it never becomes regionally durable.
-	wc.Append = bh.BucketType().RapidWritesEnabled()
+	wc.Append = bh.BucketType().RapidWritesEnabled() && !req.IsDirectory
 	// By default, objects in zonal buckets are not finalized on close, whereas objects in
 	// pirlo buckets are. This behavior is controlled by the finalizeFileForRapid flag.
 	// When writer.Append is false, then this parameter is anyways ignored.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -599,6 +599,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 		name                 string
 		bucketType           gcs.BucketType
 		finalizeFileForRapid bool
+		isDirectory          bool
 		expectedAppend       bool
 	}{
 		{
@@ -625,6 +626,13 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 			finalizeFileForRapid: false,
 			expectedAppend:       false,
 		},
+		{
+			name:                 "PirloBucket_RapidEnabled_Directory",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			finalizeFileForRapid: true,
+			isDirectory:          true,
+			expectedAppend:       false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -633,13 +641,14 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 			testSuite.bucketHandle.bucketType = &tt.bucketType
 			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{FinalizeFileForRapid: tt.finalizeFileForRapid}
 
-			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), &gcs.CreateObjectRequest{Name: "test_object"}, 1024, nil)
+			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), &gcs.CreateObjectRequest{Name: "test_object", IsDirectory: tt.isDirectory}, 1024, nil)
 
 			require.NoError(t, err)
 			objWr, ok := w.(*ObjectWriter)
 			require.True(t, ok)
 			assert.Equal(t, tt.expectedAppend, objWr.Append)
 			assert.Equal(t, tt.finalizeFileForRapid, objWr.FinalizeOnClose)
+			assert.Equal(t, 1024, objWr.ChunkSize)
 		})
 	}
 }

--- a/internal/storage/gcs/request.go
+++ b/internal/storage/gcs/request.go
@@ -77,6 +77,10 @@ type CreateObjectRequest struct {
 	// NOTE: This is not supported in gRPC (e.g. CreateAppendableObjectWriter).
 	ChunkTransferTimeoutSecs int64
 
+	// IsDirectory indicates whether this object represents a directory.
+	// When true, it bypasses the appendable upload API.
+	IsDirectory bool
+
 	// A reader from which to obtain the contents of the object. Must be non-nil.
 	Contents io.Reader
 

--- a/internal/storage/storageutil/create_object.go
+++ b/internal/storage/storageutil/create_object.go
@@ -16,6 +16,7 @@ package storageutil
 
 import (
 	"bytes"
+	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"golang.org/x/net/context"
@@ -29,8 +30,9 @@ func CreateObject(
 	name string,
 	contents []byte) (*gcs.Object, error) {
 	req := &gcs.CreateObjectRequest{
-		Name:     name,
-		Contents: bytes.NewReader(contents),
+		Name:        name,
+		Contents:    bytes.NewReader(contents),
+		IsDirectory: strings.HasSuffix(name, "/"),
 	}
 
 	return bucket.CreateObject(ctx, req)


### PR DESCRIPTION
### Description
This PR introduces a new `IsDirectory` flag in `gcs.CreateObjectRequest` to explicitly distinguish 0-byte directory placeholders from regular files at the storage layer. 

Previously, `CreateObject` and `CreateObjectChunkWriter` would default to using the appendable upload API for *all* objects when rapid writes were enabled. While Hierarchical Namespace (HNS) and Zonal buckets bypass this path entirely by using the `CreateFolder` API, **Flat Pirlo buckets** still rely on `CreateObject` to create 0-byte directory placeholders. 

Because we do not want to use the appendable API to write these simple 0-byte directory markers to the rapid storage class, setting `IsDirectory: true` explicitly bypasses the appendable API (`wc.Append = false`). 

### Link to the issue in case of a bug fix.
b/527767043

### Testing details
1. **Manual** - NA
2. **Unit tests** - Done
3. **Integration tests** - Automated

### Any backward incompatible change? If so, please explain.
N/A
