### PR TITLE
test: add memory and performance benchmarks for MapLRU and StatCache

### DIFF
--- a/internal/cache/lru/lru_memory_test.go
+++ b/internal/cache/lru/lru_memory_test.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -81,9 +81,9 @@ func TestMapCacheWorkloads(t *testing.T) {
 		t.Logf("=== WORKLOAD: %s (%d files) ===", w, count)
 
 		// 1. Pure MapLRU
+		paths := generatePaths(w, count)
 		baseMem := getMemStats()
 
-		paths := generatePaths(w, count)
 		pureCache := lru.NewCache(capacity)
 		for _, p := range paths {
 			pureCache.Insert(p, dummyValue{})

--- a/internal/cache/lru/lru_memory_test.go
+++ b/internal/cache/lru/lru_memory_test.go
@@ -42,20 +42,20 @@ func generatePaths(workload string, count int) []string {
 			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
 		}
 	case "nested":
-		// e.g. 1000 dirs, 1000 files each
-		for d := 0; d < 1000; d++ {
-			for f := 0; f < 1000; f++ {
-				paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
-			}
+		filesPerDir := 1000
+		for i := 0; i < count; i++ {
+			d := i / filesPerDir
+			f := i % filesPerDir
+			paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
 		}
 	case "deeply_nested":
-		// e.g. 50 classes, 100 batches, 200 images = 1,000,000 keys
-		for c := 0; c < 50; c++ {
-			for b := 0; b < 100; b++ {
-				for i := 0; i < 200; i++ {
-					paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, i))
-				}
-			}
+		batches := 100
+		images := 200
+		for i := 0; i < count; i++ {
+			c := i / (batches * images)
+			b := (i / images) % batches
+			img := i % images
+			paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, img))
 		}
 	}
 
@@ -86,7 +86,7 @@ func TestMapCacheWorkloads(t *testing.T) {
 
 		pureCache := lru.NewCache(capacity)
 		for _, p := range paths {
-			pureCache.Insert(p, dummyValue{})
+			_, _ = pureCache.Insert(p, dummyValue{})
 		}
 		alloc := getMemStats()
 		pureMem := alloc - baseMem

--- a/internal/cache/lru/lru_memory_test.go
+++ b/internal/cache/lru/lru_memory_test.go
@@ -38,12 +38,12 @@ func generatePaths(workload string, count int) []string {
 
 	switch workload {
 	case "flat":
-		for i := 0; i < count; i++ {
+		for i := range count {
 			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
 		}
 	case "nested":
 		filesPerDir := 1000
-		for i := 0; i < count; i++ {
+		for i := range count {
 			d := i / filesPerDir
 			f := i % filesPerDir
 			paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
@@ -51,7 +51,7 @@ func generatePaths(workload string, count int) []string {
 	case "deeply_nested":
 		batches := 100
 		images := 200
-		for i := 0; i < count; i++ {
+		for i := range count {
 			c := i / (batches * images)
 			b := (i / images) % batches
 			img := i % images
@@ -59,6 +59,8 @@ func generatePaths(workload string, count int) []string {
 		}
 	}
 
+	//shuffle the paths to simulate a realistic, unpredictable workload
+	//inserting keys in perfectly sorted lexicographical order can benefit or penalize certain tree/map data structures
 	rand.Shuffle(len(paths), func(i, j int) {
 		paths[i], paths[j] = paths[j], paths[i]
 	})

--- a/internal/cache/lru/lru_memory_test.go
+++ b/internal/cache/lru/lru_memory_test.go
@@ -93,9 +93,8 @@ func TestMapCacheWorkloads(t *testing.T) {
 		alloc := getMemStats()
 		pureMem := alloc - baseMem
 		runtime.KeepAlive(pureCache)
-		pureCache = nil
+		runtime.KeepAlive(paths)
 
-		t.Logf("%-20s Heap Used: %10.2f MB", "Pure MapLRU", float64(pureMem)/(1024*1024))
-		t.Logf("")
+		t.Logf("%-20s Heap Used: %10.2f MB\n", "MapLRU", float64(pureMem)/(1024*1024))
 	}
 }

--- a/internal/cache/lru/lru_memory_test.go
+++ b/internal/cache/lru/lru_memory_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lru_test
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"runtime/debug"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+)
+
+func getMemStats() uint64 {
+	runtime.GC()
+	runtime.GC()
+	debug.FreeOSMemory()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.Alloc
+}
+
+func generatePaths(workload string, count int) []string {
+	var paths []string
+
+	switch workload {
+	case "flat":
+		for i := 0; i < count; i++ {
+			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
+		}
+	case "nested":
+		// e.g. 1000 dirs, 1000 files each
+		for d := 0; d < 1000; d++ {
+			for f := 0; f < 1000; f++ {
+				paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
+			}
+		}
+	case "deeply_nested":
+		// e.g. 50 classes, 100 batches, 200 images = 1,000,000 keys
+		for c := 0; c < 50; c++ {
+			for b := 0; b < 100; b++ {
+				for i := 0; i < 200; i++ {
+					paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, i))
+				}
+			}
+		}
+	}
+
+	rand.Shuffle(len(paths), func(i, j int) {
+		paths[i], paths[j] = paths[j], paths[i]
+	})
+
+	return paths
+}
+
+type dummyValue struct{}
+
+func (d dummyValue) Size() uint64 {
+	return 10
+}
+
+func TestMapCacheWorkloads(t *testing.T) {
+	count := 1000000 // 1 Million files
+	capacity := uint64(count * 1000)
+	workloads := []string{"flat", "nested", "deeply_nested"}
+
+	for _, w := range workloads {
+		t.Logf("=== WORKLOAD: %s (%d files) ===", w, count)
+
+		// 1. Pure MapLRU
+		baseMem := getMemStats()
+
+		paths := generatePaths(w, count)
+		pureCache := lru.NewCache(capacity)
+		for _, p := range paths {
+			pureCache.Insert(p, dummyValue{})
+		}
+		alloc := getMemStats()
+		pureMem := alloc - baseMem
+		runtime.KeepAlive(pureCache)
+		pureCache = nil
+
+		t.Logf("%-20s Heap Used: %10.2f MB", "Pure MapLRU", float64(pureMem)/(1024*1024))
+		t.Logf("")
+	}
+}

--- a/internal/cache/lru/lru_workload_benchmark_test.go
+++ b/internal/cache/lru/lru_workload_benchmark_test.go
@@ -96,7 +96,7 @@ func runBenchmarks(b *testing.B, name string, depth int) {
 	itemsPerPrefix := 1000
 	keys := generateKeys(prefixCount, itemsPerPrefix, depth)
 
-	// pre-calculate which keys belong to which prefix so we can
+	// Pre-calculate which keys belong to which prefix so we can
 	// quickly repair the cache in benchmarkErasePrefix
 	var prefixes []string
 	prefixMap := make(map[string][]string)

--- a/internal/cache/lru/lru_workload_benchmark_test.go
+++ b/internal/cache/lru/lru_workload_benchmark_test.go
@@ -24,20 +24,22 @@ import (
 
 func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
 	var keys []string
-	for p := 0; p < prefixCount; p++ {
+	for p := range prefixCount {
 		prefix := ""
 		if depth == 0 {
 			prefix = fmt.Sprintf("prefix%d-", p)
 		} else {
-			for d := 0; d < depth; d++ {
+			for d := range depth {
 				prefix += fmt.Sprintf("dir%d/", p*depth+d)
 			}
 		}
-		for i := 0; i < itemsPerPrefix; i++ {
+		for i := range itemsPerPrefix {
 			keys = append(keys, fmt.Sprintf("%sfile%d", prefix, i))
 		}
 	}
-	// Shuffle to simulate random access
+
+	//shuffle the paths to simulate a realistic, unpredictable workload
+	//inserting keys in perfectly sorted lexicographical order can benefit or penalize certain tree/map data structures
 	rand.Shuffle(len(keys), func(i, j int) {
 		keys[i], keys[j] = keys[j], keys[i]
 	})
@@ -47,9 +49,12 @@ func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
 func benchmarkInsert(b *testing.B, cache *lru.Cache, keys []string) {
 	data := testData{Value: 1, DataSize: 10}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	i := 0
+	for b.Loop() {
 		key := keys[i%len(keys)]
 		_, _ = cache.Insert(key, data)
+		i++
 	}
 }
 
@@ -59,9 +64,12 @@ func benchmarkLookup(b *testing.B, cache *lru.Cache, keys []string) {
 		_, _ = cache.Insert(key, data)
 	}
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	i := 0
+	for b.Loop() {
 		key := keys[i%len(keys)]
 		_ = cache.LookUp(key)
+		i++
 	}
 }
 
@@ -75,7 +83,9 @@ func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][
 	}
 
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+
+	i := 0
+	for b.Loop() {
 		prefix := prefixes[i%len(prefixes)]
 
 		b.StartTimer()
@@ -88,6 +98,8 @@ func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][
 		for _, key := range keysToRestore {
 			_, _ = cache.Insert(key, data)
 		}
+
+		i++
 	}
 }
 
@@ -101,19 +113,19 @@ func runBenchmarks(b *testing.B, name string, depth int) {
 	var prefixes []string
 	prefixMap := make(map[string][]string)
 
-	for p := 0; p < prefixCount; p++ {
+	for p := range prefixCount {
 		prefix := ""
 		if depth == 0 {
 			prefix = fmt.Sprintf("prefix%d-", p)
 		} else {
-			for d := 0; d < depth; d++ {
+			for d := range depth {
 				prefix += fmt.Sprintf("dir%d/", p*depth+d)
 			}
 		}
 		prefixes = append(prefixes, prefix)
 
 		var keysForPrefix []string
-		for i := 0; i < itemsPerPrefix; i++ {
+		for i := range itemsPerPrefix {
 			keysForPrefix = append(keysForPrefix, fmt.Sprintf("%sfile%d", prefix, i))
 		}
 		prefixMap[prefix] = keysForPrefix

--- a/internal/cache/lru/lru_workload_benchmark_test.go
+++ b/internal/cache/lru/lru_workload_benchmark_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lru_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+)
+
+func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
+	var keys []string
+	for p := 0; p < prefixCount; p++ {
+		prefix := ""
+		if depth == 0 {
+			prefix = fmt.Sprintf("prefix%d-", p)
+		} else {
+			for d := 0; d < depth; d++ {
+				prefix += fmt.Sprintf("dir%d/", p*depth+d)
+			}
+		}
+		for i := 0; i < itemsPerPrefix; i++ {
+			keys = append(keys, fmt.Sprintf("%sfile%d", prefix, i))
+		}
+	}
+	// Shuffle to simulate random access
+	rand.Shuffle(len(keys), func(i, j int) {
+		keys[i], keys[j] = keys[j], keys[i]
+	})
+	return keys
+}
+
+func benchmarkInsert(b *testing.B, cache *lru.Cache, keys []string) {
+	data := testData{Value: 1, DataSize: 10}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		_, _ = cache.Insert(key, data)
+	}
+}
+
+func benchmarkLookup(b *testing.B, cache *lru.Cache, keys []string) {
+	data := testData{Value: 1, DataSize: 10}
+	for _, key := range keys {
+		_, _ = cache.Insert(key, data)
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		key := keys[i%len(keys)]
+		_ = cache.LookUp(key)
+	}
+}
+
+func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][]string, prefixes []string) {
+	data := testData{Value: 1, DataSize: 10}
+
+	for _, keysInPrefix := range prefixMap {
+		for _, key := range keysInPrefix {
+			_, _ = cache.Insert(key, data)
+		}
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		prefix := prefixes[i%len(prefixes)]
+
+		b.StartTimer()
+		cache.EraseEntriesWithGivenPrefix(prefix)
+		//reset the timer so that we only measure erasure time
+		b.StopTimer()
+
+		//restore the map
+		keysToRestore := prefixMap[prefix]
+		for _, key := range keysToRestore {
+			_, _ = cache.Insert(key, data)
+		}
+	}
+}
+
+func runBenchmarks(b *testing.B, name string, depth int) {
+	prefixCount := 1000
+	itemsPerPrefix := 1000
+	keys := generateKeys(prefixCount, itemsPerPrefix, depth)
+
+	// pre-calculate which keys belong to which prefix so we can
+	// quickly repair the cache in benchmarkErasePrefix
+	var prefixes []string
+	prefixMap := make(map[string][]string)
+
+	for p := 0; p < prefixCount; p++ {
+		prefix := ""
+		if depth == 0 {
+			prefix = fmt.Sprintf("prefix%d-", p)
+		} else {
+			for d := 0; d < depth; d++ {
+				prefix += fmt.Sprintf("dir%d/", p*depth+d)
+			}
+		}
+		prefixes = append(prefixes, prefix)
+
+		var keysForPrefix []string
+		for i := 0; i < itemsPerPrefix; i++ {
+			keysForPrefix = append(keysForPrefix, fmt.Sprintf("%sfile%d", prefix, i))
+		}
+		prefixMap[prefix] = keysForPrefix
+	}
+
+	capacity := uint64(len(keys) * 100)
+
+	b.Run(name+"_MapLRU_Insert", func(b *testing.B) {
+		benchmarkInsert(b, lru.NewCache(capacity), keys)
+	})
+
+	b.Run(name+"_MapLRU_Lookup", func(b *testing.B) {
+		benchmarkLookup(b, lru.NewCache(capacity), keys)
+	})
+
+	b.Run(name+"_MapLRU_ErasePrefix", func(b *testing.B) {
+		benchmarkErasePrefix(b, lru.NewCache(capacity), prefixMap, prefixes)
+	})
+}
+
+func BenchmarkLRU_Flat(b *testing.B) {
+	runBenchmarks(b, "Flat", 0)
+}
+
+func BenchmarkLRU_Nested(b *testing.B) {
+	runBenchmarks(b, "Nested", 2)
+}
+
+func BenchmarkLRU_DeeplyNested(b *testing.B) {
+	runBenchmarks(b, "DeeplyNested", 10)
+}

--- a/internal/cache/lru/lru_workload_benchmark_test.go
+++ b/internal/cache/lru/lru_workload_benchmark_test.go
@@ -22,8 +22,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 )
 
-func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
-	var keys []string
+func generateKeys(prefixCount, itemsPerPrefix, depth int) (keys []string, prefixMap map[string][]string, prefixes []string) {
+	prefixMap = make(map[string][]string)
+
 	for p := range prefixCount {
 		prefix := ""
 		if depth == 0 {
@@ -33,9 +34,15 @@ func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
 				prefix += fmt.Sprintf("dir%d/", p*depth+d)
 			}
 		}
+		prefixes = append(prefixes, prefix)
+
+		var keysForPrefix []string
 		for i := range itemsPerPrefix {
-			keys = append(keys, fmt.Sprintf("%sfile%d", prefix, i))
+			key := fmt.Sprintf("%sfile%d", prefix, i)
+			keysForPrefix = append(keysForPrefix, key)
+			keys = append(keys, key)
 		}
+		prefixMap[prefix] = keysForPrefix
 	}
 
 	//shuffle the paths to simulate a realistic, unpredictable workload
@@ -43,12 +50,11 @@ func generateKeys(prefixCount, itemsPerPrefix, depth int) []string {
 	rand.Shuffle(len(keys), func(i, j int) {
 		keys[i], keys[j] = keys[j], keys[i]
 	})
-	return keys
+	return keys, prefixMap, prefixes
 }
 
 func benchmarkInsert(b *testing.B, cache *lru.Cache, keys []string) {
 	data := testData{Value: 1, DataSize: 10}
-	b.ResetTimer()
 
 	i := 0
 	for b.Loop() {
@@ -63,7 +69,6 @@ func benchmarkLookup(b *testing.B, cache *lru.Cache, keys []string) {
 	for _, key := range keys {
 		_, _ = cache.Insert(key, data)
 	}
-	b.ResetTimer()
 
 	i := 0
 	for b.Loop() {
@@ -81,8 +86,6 @@ func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][
 			_, _ = cache.Insert(key, data)
 		}
 	}
-
-	b.ResetTimer()
 
 	i := 0
 	for b.Loop() {
@@ -106,30 +109,7 @@ func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][
 func runBenchmarks(b *testing.B, name string, depth int) {
 	prefixCount := 1000
 	itemsPerPrefix := 1000
-	keys := generateKeys(prefixCount, itemsPerPrefix, depth)
-
-	// Pre-calculate which keys belong to which prefix so we can
-	// quickly repair the cache in benchmarkErasePrefix
-	var prefixes []string
-	prefixMap := make(map[string][]string)
-
-	for p := range prefixCount {
-		prefix := ""
-		if depth == 0 {
-			prefix = fmt.Sprintf("prefix%d-", p)
-		} else {
-			for d := range depth {
-				prefix += fmt.Sprintf("dir%d/", p*depth+d)
-			}
-		}
-		prefixes = append(prefixes, prefix)
-
-		var keysForPrefix []string
-		for i := range itemsPerPrefix {
-			keysForPrefix = append(keysForPrefix, fmt.Sprintf("%sfile%d", prefix, i))
-		}
-		prefixMap[prefix] = keysForPrefix
-	}
+	keys, prefixMap, prefixes := generateKeys(prefixCount, itemsPerPrefix, depth)
 
 	capacity := uint64(len(keys) * 100)
 

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -1,3 +1,16 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package metadata_test
 
 import (
@@ -65,9 +78,8 @@ func TestStatCacheMemoryWorkloads(t *testing.T) {
 		t.Logf("=== WORKLOAD: %s (%d files) ===", w, count)
 
 		// 1. StatCache
-		baseMem := getMemStats()
-
 		paths := generatePaths(w, count)
+		baseMem := getMemStats()
 
 		sharedCache := lru.NewCache(capacity)
 		statCache := metadata.NewStatCacheBucketView(sharedCache, "")

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -1,0 +1,87 @@
+package metadata_test
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"runtime/debug"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+)
+
+func getMemStats() uint64 {
+	runtime.GC()
+	runtime.GC()
+	debug.FreeOSMemory()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.Alloc
+}
+
+func generatePaths(workload string, count int) []string {
+	var paths []string
+
+	switch workload {
+	case "flat":
+		for i := 0; i < count; i++ {
+			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
+		}
+	case "nested":
+		// e.g. 1000 dirs, 1000 files each
+		for d := 0; d < 1000; d++ {
+			for f := 0; f < 1000; f++ {
+				paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
+			}
+		}
+	case "deeply_nested":
+		// e.g. 50 classes, 100 batches, 200 images = 1,000,000 keys
+		for c := 0; c < 50; c++ {
+			for b := 0; b < 100; b++ {
+				for i := 0; i < 200; i++ {
+					paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, i))
+				}
+			}
+		}
+	}
+
+	rand.Shuffle(len(paths), func(i, j int) {
+		paths[i], paths[j] = paths[j], paths[i]
+	})
+
+	return paths
+}
+
+func TestStatCacheMemoryWorkloads(t *testing.T) {
+	count := 1000000                   // 1 Million files
+	capacity := uint64(count * 100000) // high capacity to avoid eviction
+	workloads := []string{"flat", "nested", "deeply_nested"}
+	expiration := time.Now().Add(time.Hour)
+
+	for _, w := range workloads {
+		t.Logf("=== WORKLOAD: %s (%d files) ===", w, count)
+
+		// 1. StatCache
+		baseMem := getMemStats()
+
+		paths := generatePaths(w, count)
+
+		sharedCache := lru.NewCache(capacity)
+		statCache := metadata.NewStatCacheBucketView(sharedCache, "")
+
+		for _, p := range paths {
+			statCache.Insert(&gcs.MinObject{Name: p}, expiration)
+		}
+
+		alloc := getMemStats()
+		pureMem := alloc - baseMem
+		runtime.KeepAlive(statCache)
+		statCache = nil
+
+		t.Logf("%-20s Heap Used: %10.2f MB", "StatCache", float64(pureMem)/(1024*1024))
+		t.Logf("")
+	}
+}

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -93,9 +93,8 @@ func TestStatCacheMemoryWorkloads(t *testing.T) {
 		alloc := getMemStats()
 		pureMem := alloc - baseMem
 		runtime.KeepAlive(statCache)
-		statCache = nil
+		runtime.KeepAlive(paths)
 
-		t.Logf("%-20s Heap Used: %10.2f MB", "StatCache", float64(pureMem)/(1024*1024))
-		t.Logf("")
+		t.Logf("%-20s Heap Used: %10.2f MB\n", "StatCache", float64(pureMem)/(1024*1024))
 	}
 }

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -44,20 +44,20 @@ func generatePaths(workload string, count int) []string {
 			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
 		}
 	case "nested":
-		// e.g. 1000 dirs, 1000 files each
-		for d := 0; d < 1000; d++ {
-			for f := 0; f < 1000; f++ {
-				paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
-			}
+		filesPerDir := 1000
+		for i := 0; i < count; i++ {
+			d := i / filesPerDir
+			f := i % filesPerDir
+			paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
 		}
 	case "deeply_nested":
-		// e.g. 50 classes, 100 batches, 200 images = 1,000,000 keys
-		for c := 0; c < 50; c++ {
-			for b := 0; b < 100; b++ {
-				for i := 0; i < 200; i++ {
-					paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, i))
-				}
-			}
+		batches := 100
+		images := 200
+		for i := 0; i < count; i++ {
+			c := i / (batches * images)
+			b := (i / images) % batches
+			img := i % images
+			paths = append(paths, fmt.Sprintf("projects/ai-vision/training/class_%04d/batch_%04d/img_%06d.jpg", c, b, img))
 		}
 	}
 

--- a/internal/cache/metadata/statcache_memory_test.go
+++ b/internal/cache/metadata/statcache_memory_test.go
@@ -40,12 +40,12 @@ func generatePaths(workload string, count int) []string {
 
 	switch workload {
 	case "flat":
-		for i := 0; i < count; i++ {
+		for i := range count {
 			paths = append(paths, fmt.Sprintf("file_%d.txt", i))
 		}
 	case "nested":
 		filesPerDir := 1000
-		for i := 0; i < count; i++ {
+		for i := range count {
 			d := i / filesPerDir
 			f := i % filesPerDir
 			paths = append(paths, fmt.Sprintf("dir_%04d/file_%04d.txt", d, f))
@@ -53,7 +53,7 @@ func generatePaths(workload string, count int) []string {
 	case "deeply_nested":
 		batches := 100
 		images := 200
-		for i := 0; i < count; i++ {
+		for i := range count {
 			c := i / (batches * images)
 			b := (i / images) % batches
 			img := i % images
@@ -61,6 +61,8 @@ func generatePaths(workload string, count int) []string {
 		}
 	}
 
+	//shuffle the generated file paths to simulate a realistic, unpredictable workload
+	//inserting keys in perfectly sorted lexicographical order can benefit or penalize certain tree/map data structures
 	rand.Shuffle(len(paths), func(i, j int) {
 		paths[i], paths[j] = paths[j], paths[i]
 	})


### PR DESCRIPTION
### Description
Adding memory profiling tests and CPU benchmarks for the GCSfuse caching layer. 

A baseline metric of the current architecture's footprint is required to evaluate performance for any further cache implementations. These tests measure the performance of the standard `MapLRU` and the `StatCache` wrapper.

**Changes Included:**
* **Memory Profiling (`TestMapCacheWorkloads` & `TestStatCacheMemoryWorkloads`)**: Simulates a 1,000,000-file workload across three different string geometries (`flat`, `nested`, and `deeply_nested`) to accurately measure the heap cost of the structural overhead and string pointers.
* **CPU Benchmarks (`BenchmarkLRU_...`)**: Adds targeted performance benchmarks to measure nanoseconds-per-operation for `Insert`, `LookUp`, and `ErasePrefix` across the different workloads.

### Link to the issue in case of a bug fix.
[b/512335162](https://b.corp.google.com/issues/512335162)


### Testing details
1. Manual - NA
2. Unit tests - Added standalone benchmark files `lru_memory_test.go`, `lru_workload_benchmark_test.go`, and `statcache_memory_test.go` to be executed explicitly via `go test` and `go test -bench`.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
