### PR TITLE
feat(native-retries): add custom should-retry logic for mount initialization

### DIFF
--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -39,6 +39,14 @@ const (
 	retry401
 	// retryUnauthenticated indicates a gRPC Unauthenticated error which requires a retry due to credentials refresh.
 	retryUnauthenticated
+	// retry404BucketDoesNotExist indicates an HTTP 404 error where the bucket was not found during mount.
+	retry404BucketDoesNotExist
+	// retryNotFoundBucketDoesNotExist indicates a gRPC NotFound error where the bucket was not found during mount.
+	retryNotFoundBucketDoesNotExist
+	// retry403 indicates an HTTP 403 Permission Denied error during mount.
+	retry403
+	// retryPermissionDenied indicates a gRPC PermissionDenied error during mount.
+	retryPermissionDenied
 )
 
 const errStrBucketNotExist = "bucket does not exist"
@@ -48,25 +56,38 @@ func determineRetryAction(err error) retryAction {
 		return retryTransient
 	}
 
-	// HTTP 401 errors - Invalid Credentials
-	// This is a work-around to fix the corner case where GCSFuse checks the token
-	// as valid but GCS says invalid. This might be due to client-server timer
-	// issues. Actual fix will be refresh the token earlier than 1 hr.
-	// Changes will be done post resolution of the below issue:
-	// https://github.com/golang/oauth2/issues/623
-	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
-	if typed, ok := err.(*googleapi.Error); ok {
-		if typed.Code == 401 {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		// HTTP 401 errors - Invalid Credentials
+		// This is a work-around to fix the corner case where GCSFuse checks the token
+		// as valid but GCS says invalid. This might be due to client-server timer
+		// issues. Actual fix will be refresh the token earlier than 1 hr.
+		// Changes will be done post resolution of the below issue:
+		// https://github.com/golang/oauth2/issues/623
+		// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
+		if apiErr.Code == 401 {
 			return retry401
+		}
+		if apiErr.Code == 403 {
+			return retry403
+		}
+		if apiErr.Code == 404 && strings.Contains(strings.ToLower(apiErr.Message), errStrBucketNotExist) {
+			return retry404BucketDoesNotExist
 		}
 	}
 
-	// This is the same case as above, but for gRPC UNAUTHENTICATED errors. See
-	// https://github.com/golang/oauth2/issues/623
-	// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 	if status, ok := status.FromError(err); ok {
+		// This is the same case as above, but for gRPC UNAUTHENTICATED errors. See
+		// https://github.com/golang/oauth2/issues/623
+		// TODO(b/518674297): Please incorporate the correct fix post resolution of the above issue.
 		if status.Code() == codes.Unauthenticated {
 			return retryUnauthenticated
+		}
+		if status.Code() == codes.PermissionDenied {
+			return retryPermissionDenied
+		}
+		if status.Code() == codes.NotFound && strings.Contains(strings.ToLower(status.Message()), errStrBucketNotExist) {
+			return retryNotFoundBucketDoesNotExist
 		}
 	}
 	return noRetry
@@ -75,7 +96,12 @@ func determineRetryAction(err error) retryAction {
 // ShouldRetryWithoutLogging checks if the error is transient and should be retried.
 // This method is same as ShouldRetry except it doesn't add warning logs.
 func ShouldRetryWithoutLogging(err error) bool {
-	return determineRetryAction(err) != noRetry
+	switch determineRetryAction(err) {
+	case retryTransient, retry401, retryUnauthenticated:
+		return true
+	default:
+		return false
+	}
 }
 
 // ShouldRetryWithRetryContext checks if the given error is transient and should be retried,
@@ -121,69 +147,5 @@ func ShouldRetryWithMonitoringAndRetryContext(
 // ShouldRetryOnMount checks if the error is retryable during mount initialization.
 // In addition to standard transient errors, it retries HTTP 403/404 and gRPC PermissionDenied/NotFound errors.
 func ShouldRetryOnMount(err error) bool {
-	if err == nil {
-		return false
-	}
-	if ShouldRetryWithoutLogging(err) {
-		return true
-	}
-
-	var apiErr *googleapi.Error
-	if errors.As(err, &apiErr) {
-		if apiErr.Code == 403 ||
-			(apiErr.Code == 404 && strings.Contains(strings.ToLower(apiErr.Message), errStrBucketNotExist)) {
-			return true
-		}
-	}
-
-	if st, ok := status.FromError(err); ok {
-		if st.Code() == codes.PermissionDenied ||
-			(st.Code() == codes.NotFound && strings.Contains(strings.ToLower(st.Message()), errStrBucketNotExist)) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// ShouldRetryOnMountWithRetryContext checks if the error is retryable during mount initialization,
-// logging the retry error with RetryContext.
-func ShouldRetryOnMountWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
-	if !ShouldRetryOnMount(err) {
-		return false
-	}
-	if retryCtx == nil {
-		logger.Errorf("Retrying for error: %v", err)
-		return true
-	}
-	logger.Errorf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
-		retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
-	return true
-}
-
-// ShouldRetryOnMountWithMonitoringAndRetryContext checks if the error is retryable during mount initialization,
-// recording metrics and logging with RetryContext.
-func ShouldRetryOnMountWithMonitoringAndRetryContext(
-	ctx context.Context,
-	err error,
-	retryCtx *storage.RetryContext,
-	metricHandle metrics.MetricHandle,
-) bool {
-	if err == nil {
-		return false
-	}
-
-	retry := ShouldRetryOnMountWithRetryContext(err, retryCtx)
-	if !retry {
-		return false
-	}
-
-	// Record metrics
-	val := metrics.RetryErrorCategoryOTHERERRORSAttr
-	if errors.Is(err, context.DeadlineExceeded) {
-		val = metrics.RetryErrorCategorySTALLEDREADREQUESTAttr
-	}
-
-	metricHandle.GcsRetryCount(1, val)
-	return retry
+	return determineRetryAction(err) != noRetry
 }

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -17,6 +17,7 @@ package storageutil
 import (
 	"context"
 	"errors"
+	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
@@ -39,6 +40,8 @@ const (
 	// retryUnauthenticated indicates a gRPC Unauthenticated error which requires a retry due to credentials refresh.
 	retryUnauthenticated
 )
+
+const errStrBucketNotExist = "bucket does not exist"
 
 func determineRetryAction(err error) retryAction {
 	if storage.ShouldRetry(err) {
@@ -105,6 +108,76 @@ func ShouldRetryWithMonitoringAndRetryContext(
 	if !retry {
 		return false
 	}
+	// Record metrics
+	val := metrics.RetryErrorCategoryOTHERERRORSAttr
+	if errors.Is(err, context.DeadlineExceeded) {
+		val = metrics.RetryErrorCategorySTALLEDREADREQUESTAttr
+	}
+
+	metricHandle.GcsRetryCount(1, val)
+	return retry
+}
+
+// ShouldRetryOnMount checks if the error is retryable during mount initialization.
+// In addition to standard transient errors, it retries HTTP 403/404 and gRPC PermissionDenied/NotFound errors.
+func ShouldRetryOnMount(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ShouldRetryWithoutLogging(err) {
+		return true
+	}
+
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) {
+		if apiErr.Code == 403 ||
+			(apiErr.Code == 404 && strings.Contains(strings.ToLower(apiErr.Message), errStrBucketNotExist)) {
+			return true
+		}
+	}
+
+	if st, ok := status.FromError(err); ok {
+		if st.Code() == codes.PermissionDenied ||
+			(st.Code() == codes.NotFound && strings.Contains(strings.ToLower(st.Message()), errStrBucketNotExist)) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ShouldRetryOnMountWithRetryContext checks if the error is retryable during mount initialization,
+// logging the retry error with RetryContext.
+func ShouldRetryOnMountWithRetryContext(err error, retryCtx *storage.RetryContext) bool {
+	if !ShouldRetryOnMount(err) {
+		return false
+	}
+	if retryCtx == nil {
+		logger.Errorf("Retrying for error: %v", err)
+		return true
+	}
+	logger.Errorf("Retrying %s for %q: InvocationID: %s, Attempt: %d, due to error: %v",
+		retryCtx.Operation, retryCtx.Object, retryCtx.InvocationID, retryCtx.Attempt+1, err)
+	return true
+}
+
+// ShouldRetryOnMountWithMonitoringAndRetryContext checks if the error is retryable during mount initialization,
+// recording metrics and logging with RetryContext.
+func ShouldRetryOnMountWithMonitoringAndRetryContext(
+	ctx context.Context,
+	err error,
+	retryCtx *storage.RetryContext,
+	metricHandle metrics.MetricHandle,
+) bool {
+	if err == nil {
+		return false
+	}
+
+	retry := ShouldRetryOnMountWithRetryContext(err, retryCtx)
+	if !retry {
+		return false
+	}
+
 	// Record metrics
 	val := metrics.RetryErrorCategoryOTHERERRORSAttr
 	if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/url"
@@ -489,6 +490,16 @@ func TestShouldRetryOnMount(t *testing.T) {
 			name:     "permanent error HTTP 400",
 			err:      &googleapi.Error{Code: 400, Message: "Bad Request"},
 			expected: false,
+		},
+		{
+			name:     "permanent error gRPC InvalidArgument",
+			err:      status.Error(codes.InvalidArgument, "invalid bucket name"),
+			expected: false,
+		},
+		{
+			name:     "wrapped gRPC PermissionDenied",
+			err:      fmt.Errorf("mount failed: %w", status.Error(codes.PermissionDenied, "caller does not have required permission")),
+			expected: true,
 		},
 	}
 

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -181,6 +181,21 @@ func TestShouldRetryWithoutLogging(t *testing.T) {
 			},
 			expectedResult: false,
 		},
+		{
+			name: "403 error - non-retryable for regular ops",
+			err: &googleapi.Error{
+				Code: 403,
+			},
+			expectedResult: false,
+		},
+		{
+			name: "404 bucket missing error - non-retryable for regular ops",
+			err: &googleapi.Error{
+				Code:    404,
+				Message: "The specified bucket does not exist.",
+			},
+			expectedResult: false,
+		},
 	}
 
 	for _, tc := range testCases {
@@ -234,7 +249,22 @@ func TestDetermineRetryAction(t *testing.T) {
 		{
 			name:     "PermissionDeniedGrpcError",
 			err:      status.Error(codes.PermissionDenied, "permission denied"),
-			expected: noRetry,
+			expected: retryPermissionDenied,
+		},
+		{
+			name:     "GoogleApiError403",
+			err:      &googleapi.Error{Code: 403},
+			expected: retry403,
+		},
+		{
+			name:     "GoogleApiError404BucketNotExist",
+			err:      &googleapi.Error{Code: 404, Message: "The specified bucket does not exist."},
+			expected: retry404BucketDoesNotExist,
+		},
+		{
+			name:     "GrpcNotFoundBucketNotExist",
+			err:      status.Error(codes.NotFound, "The specified bucket does not exist."),
+			expected: retryNotFoundBucketDoesNotExist,
 		},
 		{
 			name:     "UnexpectedEOF",
@@ -508,114 +538,6 @@ func TestShouldRetryOnMount(t *testing.T) {
 			result := ShouldRetryOnMount(tc.err)
 
 			assert.Equal(t, tc.expected, result)
-		})
-	}
-}
-
-func TestShouldRetryOnMountWithRetryContext(t *testing.T) {
-	var buf logBuffer
-	logger.SetOutput(&buf)
-	defer logger.SetOutput(os.Stdout)
-	err403 := &googleapi.Error{Code: 403, Message: "Permission denied"}
-	retryCtx := &storage.RetryContext{
-		Attempt:      3,
-		InvocationID: "mock-invocation-id-123",
-		Operation:    "GetStorageLayout",
-		Bucket:       "my-test-bucket",
-		Object:       "some/file.txt",
-	}
-
-	retry := ShouldRetryOnMountWithRetryContext(err403, retryCtx)
-
-	assert.True(t, retry)
-	logMsg := buf.String()
-	assert.Contains(t, logMsg, "ERROR")
-	assert.Contains(t, logMsg, "Retrying GetStorageLayout for")
-	assert.Contains(t, logMsg, "some/file.txt")
-	assert.Contains(t, logMsg, "Permission denied")
-	assert.Contains(t, logMsg, "Attempt: 4")
-	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")
-}
-
-func TestShouldRetryOnMountWithNilRetryContext(t *testing.T) {
-	var buf logBuffer
-	logger.SetOutput(&buf)
-	defer logger.SetOutput(os.Stdout)
-	err403 := &googleapi.Error{Code: 403, Message: "Permission denied"}
-
-	retry := ShouldRetryOnMountWithRetryContext(err403, nil)
-
-	assert.True(t, retry)
-	logMsg := buf.String()
-	assert.Contains(t, logMsg, "ERROR")
-	assert.Contains(t, logMsg, "Retrying for error: googleapi: Error 403: Permission denied")
-	assert.NotContains(t, logMsg, "Op:")
-	assert.NotContains(t, logMsg, "Object:")
-	assert.NotContains(t, logMsg, "Attempt:")
-	assert.NotContains(t, logMsg, "InvocationID:")
-}
-
-func TestShouldRetryOnMountWithMonitoringForNonRetryableErrors(t *testing.T) {
-	testCases := []struct {
-		name string
-		err  error
-	}{
-		{
-			name: "nil error",
-			err:  nil,
-		},
-		{
-			name: "non-retryable error 400",
-			err:  &googleapi.Error{Code: 400},
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			fakeMetrics := &fakeMetricHandle{
-				MetricHandle: metrics.NewNoopMetrics(),
-			}
-
-			shouldRetry := ShouldRetryOnMountWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
-
-			assert.False(t, shouldRetry)
-			assert.False(t, fakeMetrics.gcsRetryCountCalled)
-		})
-	}
-}
-
-func TestShouldRetryOnMountWithMonitoringForRetryableErrors(t *testing.T) {
-	err404Bucket := &googleapi.Error{Code: 404, Message: "The specified bucket does not exist."}
-
-	testCases := []struct {
-		name                   string
-		err                    error
-		expectedMetricCategory string
-	}{
-		{
-			name:                   "retryable error, DeadlineExceeded joined with 404 missing bucket",
-			err:                    errors.Join(err404Bucket, context.DeadlineExceeded),
-			expectedMetricCategory: "STALLED_READ_REQUEST",
-		},
-		{
-			name:                   "retryable error, 404 missing bucket",
-			err:                    err404Bucket,
-			expectedMetricCategory: "OTHER_ERRORS",
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			fakeMetrics := &fakeMetricHandle{
-				MetricHandle: metrics.NewNoopMetrics(),
-			}
-
-			shouldRetry := ShouldRetryOnMountWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
-
-			assert.True(t, shouldRetry)
-			assert.True(t, fakeMetrics.gcsRetryCountCalled)
-			assert.Equal(t, int64(1), fakeMetrics.gcsRetryCountInc)
-			assert.Equal(t, tc.expectedMetricCategory, fakeMetrics.gcsRetryErrorCategory)
 		})
 	}
 }

--- a/internal/storage/storageutil/custom_retry_test.go
+++ b/internal/storage/storageutil/custom_retry_test.go
@@ -423,3 +423,188 @@ func TestShouldRetryWithMonitoringForRetryableErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldRetryOnMount(t *testing.T) {
+	testCases := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "standard transient error 502",
+			err:      &googleapi.Error{Code: 502},
+			expected: true,
+		},
+		{
+			name:     "standard transient error 401",
+			err:      &googleapi.Error{Code: 401},
+			expected: true,
+		},
+		{
+			name:     "HTTP 403 Forbidden",
+			err:      &googleapi.Error{Code: 403, Message: "Permission denied on resource"},
+			expected: true,
+		},
+		{
+			name:     "HTTP 404 missing bucket",
+			err:      &googleapi.Error{Code: 404, Message: "The specified bucket does not exist."},
+			expected: true,
+		},
+		{
+			name:     "HTTP 404 missing bucket mixed case",
+			err:      &googleapi.Error{Code: 404, Message: "The Specified Bucket Does Not Exist."},
+			expected: true,
+		},
+		{
+			name:     "HTTP 404 missing object",
+			err:      &googleapi.Error{Code: 404, Message: "No such object: my-bucket/test-object"},
+			expected: false,
+		},
+		{
+			name:     "gRPC PermissionDenied",
+			err:      status.Error(codes.PermissionDenied, "caller does not have required permission"),
+			expected: true,
+		},
+		{
+			name:     "gRPC NotFound missing bucket",
+			err:      status.Error(codes.NotFound, "The specified bucket does not exist."),
+			expected: true,
+		},
+		{
+			name:     "gRPC NotFound missing bucket mixed case",
+			err:      status.Error(codes.NotFound, "The Specified Bucket Does Not Exist."),
+			expected: true,
+		},
+		{
+			name:     "gRPC NotFound missing object",
+			err:      status.Error(codes.NotFound, "No such object: my-bucket/test-object"),
+			expected: false,
+		},
+		{
+			name:     "permanent error HTTP 400",
+			err:      &googleapi.Error{Code: 400, Message: "Bad Request"},
+			expected: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := ShouldRetryOnMount(tc.err)
+
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestShouldRetryOnMountWithRetryContext(t *testing.T) {
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	err403 := &googleapi.Error{Code: 403, Message: "Permission denied"}
+	retryCtx := &storage.RetryContext{
+		Attempt:      3,
+		InvocationID: "mock-invocation-id-123",
+		Operation:    "GetStorageLayout",
+		Bucket:       "my-test-bucket",
+		Object:       "some/file.txt",
+	}
+
+	retry := ShouldRetryOnMountWithRetryContext(err403, retryCtx)
+
+	assert.True(t, retry)
+	logMsg := buf.String()
+	assert.Contains(t, logMsg, "ERROR")
+	assert.Contains(t, logMsg, "Retrying GetStorageLayout for")
+	assert.Contains(t, logMsg, "some/file.txt")
+	assert.Contains(t, logMsg, "Permission denied")
+	assert.Contains(t, logMsg, "Attempt: 4")
+	assert.Contains(t, logMsg, "InvocationID: mock-invocation-id-123")
+}
+
+func TestShouldRetryOnMountWithNilRetryContext(t *testing.T) {
+	var buf logBuffer
+	logger.SetOutput(&buf)
+	defer logger.SetOutput(os.Stdout)
+	err403 := &googleapi.Error{Code: 403, Message: "Permission denied"}
+
+	retry := ShouldRetryOnMountWithRetryContext(err403, nil)
+
+	assert.True(t, retry)
+	logMsg := buf.String()
+	assert.Contains(t, logMsg, "ERROR")
+	assert.Contains(t, logMsg, "Retrying for error: googleapi: Error 403: Permission denied")
+	assert.NotContains(t, logMsg, "Op:")
+	assert.NotContains(t, logMsg, "Object:")
+	assert.NotContains(t, logMsg, "Attempt:")
+	assert.NotContains(t, logMsg, "InvocationID:")
+}
+
+func TestShouldRetryOnMountWithMonitoringForNonRetryableErrors(t *testing.T) {
+	testCases := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+		},
+		{
+			name: "non-retryable error 400",
+			err:  &googleapi.Error{Code: 400},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeMetrics := &fakeMetricHandle{
+				MetricHandle: metrics.NewNoopMetrics(),
+			}
+
+			shouldRetry := ShouldRetryOnMountWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
+
+			assert.False(t, shouldRetry)
+			assert.False(t, fakeMetrics.gcsRetryCountCalled)
+		})
+	}
+}
+
+func TestShouldRetryOnMountWithMonitoringForRetryableErrors(t *testing.T) {
+	err404Bucket := &googleapi.Error{Code: 404, Message: "The specified bucket does not exist."}
+
+	testCases := []struct {
+		name                   string
+		err                    error
+		expectedMetricCategory string
+	}{
+		{
+			name:                   "retryable error, DeadlineExceeded joined with 404 missing bucket",
+			err:                    errors.Join(err404Bucket, context.DeadlineExceeded),
+			expectedMetricCategory: "STALLED_READ_REQUEST",
+		},
+		{
+			name:                   "retryable error, 404 missing bucket",
+			err:                    err404Bucket,
+			expectedMetricCategory: "OTHER_ERRORS",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeMetrics := &fakeMetricHandle{
+				MetricHandle: metrics.NewNoopMetrics(),
+			}
+
+			shouldRetry := ShouldRetryOnMountWithMonitoringAndRetryContext(context.Background(), tc.err, nil, fakeMetrics)
+
+			assert.True(t, shouldRetry)
+			assert.True(t, fakeMetrics.gcsRetryCountCalled)
+			assert.Equal(t, int64(1), fakeMetrics.gcsRetryCountInc)
+			assert.Equal(t, tc.expectedMetricCategory, fakeMetrics.gcsRetryErrorCategory)
+		})
+	}
+}


### PR DESCRIPTION
Description
* Implemented `ShouldRetryOnMount` in `internal/storage/storageutil/custom_retry.go`.
* Centralized all HTTP and gRPC error classification into a single helper enum (`determineRetryAction`), which serves as the single source of truth for both standard and mount retries.
* Scoped mount initialization retries (`ShouldRetryOnMount`) to standard transient errors, missing buckets (`404` / `NotFound` with "bucket does not exist", case-insensitive), and `403` / `PermissionDenied`.

Link to the issue in case of a bug fix.
b/530765969

Testing details
Manual - NA
Unit tests - Added comprehensive table-driven test suites in `custom_retry_test.go` verifying standard transient errors, case-insensitive missing bucket matching, permanent error rejections, and error categorization in `TestDetermineRetryAction` and `TestShouldRetryOnMount`. Ran full package tests (`go test ./internal/storage/storageutil/...`).
Integration tests - NA

Any backward incompatible change? If so, please explain.
No
