### PR TITLE
fix(test): update fuseMaxNameLen on Linux to match newer kernel limits

### DIFF
--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -47,6 +47,8 @@ import (
 // writeback caching enabled the kernel manufactures them based on wall time.
 const timeSlop = 25 * time.Millisecond
 
+const gcsMaxNameLen = 1024
+
 var fuseMaxNameLen int
 
 func init() {
@@ -62,7 +64,8 @@ func init() {
 	case "linux":
 		// On Linux, we're looking at FUSE_NAME_MAX (https://tinyurl.com/2fr4y7fu),
 		// used in e.g. fuse_lookup_name (https://tinyurl.com/4pacanh3).
-		fuseMaxNameLen = 1024
+		// On newer kernels it is PATH_MAX - 1 (4095).
+		fuseMaxNameLen = 4095
 
 	default:
 		panic(fmt.Sprintf("Unknown runtime.GOOS: %s", runtime.GOOS))
@@ -90,7 +93,7 @@ func interestingLegalNames() (names []string) {
 		"*![]&&||;",
 
 		// Longest legal name
-		strings.Repeat("a", fuseMaxNameLen),
+		strings.Repeat("a", gcsMaxNameLen),
 
 		// Angstrom symbol singleton and normalized forms.
 		// Cf. http://unicode.org/reports/tr15/


### PR DESCRIPTION
The Linux kernel (since commit 27992ef8077) increased FUSE_NAME_MAX to PATH_MAX (4096). Updating the test constant to match this behavior allows the kernel to catch the illegal name length and return the expected ENAMETOOLONG error instead of passing it to GCSFuse.