### PR TITLE
fix: promoteToGenerationBacked collision bug causing ESTALE errors

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1369,9 +1369,7 @@ func (fs *fileSystem) lookUpOrCreateChildDirInode(
 func (fs *fileSystem) promoteToGenerationBacked(f *inode.FileInode) {
 	fs.mu.Lock()
 	delete(fs.localFileInodes, f.Name())
-	if _, ok := fs.generationBackedInodes[f.Name()]; !ok {
-		fs.generationBackedInodes[f.Name()] = f
-	}
+	fs.generationBackedInodes[f.Name()] = f
 	fs.mu.Unlock()
 
 	// We need not update fileIndex:


### PR DESCRIPTION
We unconditionally update generationBackedInodes with the synced file inode in promoteToGenerationBacked instead of checking if it is already present. This ensures that when a local (unsynced) file is flushed and synced to GCS, its inode is correctly registered as the active generation-backed inode for that path, replacing any stale or unlinked inode that might still linger in the map from a previous run or deletion.

Detailed Description of the Error Case:
When running concurrent create-write-close cycles in a loop on the same path (e.g., "foo" in RunCreateInParallelTest_NoTruncate), the following race condition occurs:

1. In a previous test run or loop iteration, "foo" is unlinked. The unlink operation deletes "foo" from GCS and marks the old inode (inode_A) as unlinked. However, because the Linux kernel's dentry eviction is asynchronous, FUSE does not send the Forget request for inode_A immediately, leaving it lingering in the generationBackedInodes map for "foo".
2. The test starts the next loop iteration and recreates "foo". Since "foo" does not exist on GCS, gcsfuse mints a new local inode, inode_B, and maps it in localFileInodes["foo"].
3. Multiple workers are launched concurrently and open "foo", all getting handles to the same inode_B.
4. The first worker (Worker 0) finishes writing and closes the file, causing inode_B to be flushed to GCS, creating generation 68. promoteToGenerationBacked(inode_B) is called to register inode_B in the GCS map.
5. The bug occurs here: The code checks if the path is already in generationBackedInodes. Since it still points to the stale inode_A, the check is true, and the assignment is skipped. inode_B is deleted from localFileInodes but never inserted into generationBackedInodes.
6. A delayed worker (Worker 2) now calls OpenFile("foo"). gcsfuse checks GCS (finds generation 68) and checks generationBackedInodes["foo"] (finds stale inode_A at generation 67). Since GCS is newer, gcsfuse mints a new inode, inode_C, and registers it.
7. Now we have a split-brain: Worker 1 holds a handle to inode_B, and Worker 2 holds a handle to inode_C.
8. Worker 2 writes to inode_C and closes it, uploading it to GCS and creating generation 69. Generation 68 is now deleted on GCS.
9. Worker 1 (holding inode_B) tries to write. Because inode_B's local temp file was cleared during Worker 0's close, it calls openReader to reload the file state from GCS. openReader requests inode_B's generation (68) from GCS. Since GCS only has generation 69, GCS returns NotFoundError.
10. gcsfuse wraps this as FileClobberedError and returns syscall.ESTALE (Stale file handle) to the user application, failing the test.

Validation via Unique Filenames:
To isolate the test runs and prove the stale inode collision theory, we linked go.mod to a local copy of github.com/jacobsa/fuse and modified fusetesting/parallel.go to use unique filenames for each loop iteration (e.g. foo_notrunc_iteration).
With unique filenames, since each loop iteration used a new name, there were no stale entries in generationBackedInodes for that name, and the stress test passed 20 times in a row with zero flakes. When we reverted the filenames back to "foo", the test failed immediately on the first run (after 84ms) with the stale file handle error.
With the original "foo" name restored, we applied this patch to unconditionally overwrite generationBackedInodes, and the test passed 20 times in a row with zero flakes.

Safety Analysis:
Removing the check and unconditionally overwriting the map entry is safe because:
1. Inodes are tracked globally by Inode ID. Overwriting the path name key does not leak the old inode. When the kernel eventually sends a Forget request for the stale inode_A, unlockAndDecrementLookupCount cleans it up from the global inodes map.
2. In unlockAndDecrementLookupCount, the cleanup of generationBackedInodes is guarded by an identity check. If the map has already been updated to point to the new inode_B, the stale inode_A will not match, and inode_B is left safely in the map.
3. Unlinked inodes with open file descriptors will continue to receive FUSE operations via their Inode ID, which remains valid until closed. Any new lookups by path name should naturally find the active file, which is achieved by overwriting the name map.

TAG=agy
CONV=66026e49-1f0c-4a05-872f-0759ca611cde
