### PR TITLE
test(downloader): scale down test object and chunk sizes to speed up tests

### DIFF
--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -332,12 +332,12 @@ func (dt *downloaderTest) Test_cleanUpDownloadAsyncJob() {
 
 func (dt *downloaderTest) Test_downloadObjectToFile() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 10 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	// Add subscriber
-	subscribedOffset := int64(6 * util.MiB)
+	subscribedOffset := int64(1 * util.MiB)
 	notificationC := dt.job.subscribe(subscribedOffset)
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
@@ -387,7 +387,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
 func (dt *downloaderTest) Test_downloadObjectAsync_LessThanSequentialReadSize() {
 	// Create new object in bucket and create new job for it.
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -439,14 +439,14 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
 
 func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), removeCallback)
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	// Add subscriber
-	subscribedOffset := int64(9 * util.MiB)
+	subscribedOffset := int64(1 * util.MiB)
 	notificationC := dt.job.subscribe(subscribedOffset)
 
 	// start download
@@ -471,12 +471,12 @@ func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 
 func (dt *downloaderTest) Test_Download_WhenNotStarted() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 16 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 
 	// Start download
-	offset := int64(8 * util.MiB)
+	offset := int64(1 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
 	AssertEq(nil, err)
@@ -493,7 +493,7 @@ func (dt *downloaderTest) Test_Download_WhenNotStarted() {
 func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 	// Create new object in bucket and create new job for it.
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	// Start download but not wait for download
@@ -503,7 +503,7 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 	AssertEq(Downloading, jobStatus.Name)
 
 	// Again call download but wait for download this time.
-	offset := int64(25 * util.MiB)
+	offset := int64(1 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
 	AssertEq(nil, err)
@@ -519,7 +519,7 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 
 func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 16 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	// Wait for whole download to be completed.
@@ -533,7 +533,7 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	AssertEq(Completed, dt.job.status.Name)
 
 	// Try to request for some offset when job was already completed.
-	offset := int64(16 * util.MiB)
+	offset := int64(2 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
 	AssertEq(nil, err)
@@ -630,7 +630,7 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 
 func (dt *downloaderTest) Test_Download_CtxCancelled() {
 	objectName := "path/in/gcs/cancel.txt"
-	objectSize := 16 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -638,13 +638,17 @@ func (dt *downloaderTest) Test_Download_CtxCancelled() {
 
 	// Requesting full download and then the download call should be cancelled after
 	// timeout but async download shouldn't be cancelled
-	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Millisecond*2)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), time.Nanosecond)
 	defer cancelFunc()
 	offset := int64(objectSize)
 	jobStatus, err := dt.job.Download(ctx, offset, true)
 
 	AssertNe(nil, err)
 	AssertTrue(errors.Is(err, context.DeadlineExceeded))
+
+	// Wait for the async download to complete in the background.
+	<-dt.job.doneCh
+
 	// jobStatus is empty in this case.
 	AssertEq("", jobStatus.Name)
 	AssertEq(nil, jobStatus.Err)
@@ -666,12 +670,12 @@ func (dt *downloaderTest) Test_Download_CtxCancelled() {
 
 func (dt *downloaderTest) Test_Download_Concurrent() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 25 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), nil)
 	ctx := context.Background()
 	wg := sync.WaitGroup{}
-	offsets := []int64{0, 4 * util.MiB, 16 * util.MiB, 8 * util.MiB, int64(objectSize), int64(objectSize) + 1}
+	offsets := []int64{0, 200 * util.KiB, 1 * util.MiB, 500 * util.KiB, int64(objectSize), int64(objectSize) + 1}
 	expectedErrs := []error{nil, nil, nil, nil, nil, fmt.Errorf("download: the requested offset %d is greater than the size of object %d", int64(objectSize)+1, int64(objectSize))}
 	downloadFunc := func(expectedOffset int64, expectedErr error) {
 		defer wg.Done()
@@ -708,12 +712,12 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 
 func (dt *downloaderTest) Test_GetStatus() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 20 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize*2), func() {})
 	ctx := context.Background()
 	// Start download
-	jobStatus, err := dt.job.Download(ctx, util.MiB, true)
+	jobStatus, err := dt.job.Download(ctx, 500*util.KiB, true)
 	AssertEq(nil, err)
 	AssertEq(Downloading, jobStatus.Name)
 
@@ -729,7 +733,7 @@ func (dt *downloaderTest) Test_GetStatus() {
 
 func (dt *downloaderTest) Test_Invalidate_WhenDownloading() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 10 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -795,7 +799,7 @@ func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
 
 func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 20 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecutionCount atomic.Int32
 	removeCallback := func() { callbackExecutionCount.Add(1) }
@@ -829,7 +833,7 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 
 func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 10 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecutionCount atomic.Int32
 	removeCallback := func() { callbackExecutionCount.Add(1) }
@@ -857,7 +861,7 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 	}
 
 	// Start concurrent invalidate and download
-	offsets := [6]int64{0, util.MiB, 5 * util.MiB, 0, 2 * util.MiB, 10 * util.MiB}
+	offsets := [6]int64{0, 100 * util.KiB, 1 * util.MiB, 0, 500 * util.KiB, 2 * util.MiB}
 	for i := range len(offsets) {
 		wg.Add(2)
 		waitForDownload := false
@@ -877,11 +881,11 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 
 func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue() {
 	objectName := "path/in/gcs/file1.txt"
-	objectSize := 8 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	// Start download
-	offset := int64(8 * util.MiB)
+	offset := int64(2 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 	AssertEq(nil, err)
 	// Here the crc check will be successful

--- a/internal/cache/file/downloader/parallel_downloads_job_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_test.go
@@ -50,7 +50,7 @@ func (dt *parallelDownloaderTest) SetUp(*TestInfo) {
 		ExperimentalParallelDownloadsDefaultOn: true,
 		EnableParallelDownloads:                true,
 		ParallelDownloadsPerFile:               3,
-		DownloadChunkSizeMb:                    3,
+		DownloadChunkSizeMb:                    1, // 1MB chunks
 		EnableCrc:                              true,
 		WriteBufferSize:                        4 * 1024 * 1024,
 	}
@@ -60,7 +60,7 @@ func (dt *parallelDownloaderTest) SetUp(*TestInfo) {
 func (dt *parallelDownloaderTest) Test_downloadRange() {
 	// Create object in fake GCS
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 10 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -80,8 +80,8 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 		AssertTrue(reflect.DeepEqual(objectContent[start:end], buf), fmt.Sprintf("content didn't match for start: %v and end: %v", start, end))
 	}
 
-	// Download end 1MiB of object
-	start, end := int64(9*util.MiB), int64(10*util.MiB)
+	// Download end 248KiB of object
+	start, end := int64(1800*util.KiB), int64(2048*util.KiB)
 	offsetWriter := io.NewOffsetWriter(file, start)
 	rangeMap := make(map[int64]int64)
 
@@ -89,34 +89,34 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
 
-	// Download start 4MiB of object
-	start, end = int64(0*util.MiB), int64(4*util.MiB)
+	// Download start 800KiB of object
+	start, end = int64(0), int64(800*util.KiB)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(4*util.MiB), rangeMap[start])
+	AssertEq(int64(800*util.KiB), rangeMap[start])
 
 	// Download middle 1B of object
-	start, end = int64(5*util.MiB), int64(5*util.MiB+1)
+	start, end = int64(1024*util.KiB), int64(1024*util.KiB+1)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(5*util.MiB+1), rangeMap[start])
+	AssertEq(int64(1024*util.KiB+1), rangeMap[start])
 
 	// Download 0B of object
-	start, end = int64(5*util.MiB), int64(5*util.MiB)
+	start, end = int64(1024*util.KiB), int64(1024*util.KiB)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
 	AssertEq(nil, err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(5*util.MiB+1), rangeMap[start])
+	AssertEq(int64(1024*util.KiB+1), rangeMap[start])
 }
 
 func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
 	objectName := "path/in/gcs/foo.txt"
-	objectSize := 10 * util.MiB
+	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())

--- a/internal/cache/file/downloader/sparse_downloads_job_test.go
+++ b/internal/cache/file/downloader/sparse_downloads_job_test.go
@@ -43,7 +43,7 @@ func init() { RegisterTestSuite(&sparseDownloaderTest{}) }
 func (dt *sparseDownloaderTest) SetUp(*TestInfo) {
 	dt.defaultFileCacheConfig = &cfg.FileCacheConfig{
 		ExperimentalEnableChunkCache:           true,
-		DownloadChunkSizeMb:                    20, // 20MB chunks for sparse files
+		DownloadChunkSizeMb:                    2, // 2MB chunks for sparse files
 		EnableCrc:                              true,
 		ExperimentalParallelDownloadsDefaultOn: true,
 	}
@@ -63,36 +63,36 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload() {
 		{
 			name:           "single chunk - aligned",
 			offset:         0,
-			requiredOffset: 10 * util.MiB,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			requiredOffset: 1 * util.MiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectedChunks: []uint64{0},
 			expectError:    false,
 		},
 		{
 			name:           "single chunk - unaligned start",
-			offset:         5 * util.MiB,
-			requiredOffset: 10 * util.MiB,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			offset:         500 * util.KiB,
+			requiredOffset: 1 * util.MiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectedChunks: []uint64{0},
 			expectError:    false,
 		},
 		{
 			name:           "single chunk - unaligned end",
-			offset:         15 * util.MiB,
-			requiredOffset: 25 * util.MiB,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			offset:         1500 * util.KiB,
+			requiredOffset: 2500 * util.KiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectedChunks: []uint64{0, 1},
 			expectError:    false,
 		},
 		{
 			name:           "chunk end capped at object size",
-			offset:         90 * util.MiB,
-			requiredOffset: 95 * util.MiB,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			offset:         9 * util.MiB,
+			requiredOffset: 9500 * util.KiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectedChunks: []uint64{4},
 			expectError:    false,
 		},
@@ -100,16 +100,16 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload() {
 			name:           "invalid range - offset >= requiredOffset",
 			offset:         10,
 			requiredOffset: 10,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectError:    true,
 		},
 		{
 			name:           "invalid range - negative offset",
 			offset:         -1,
 			requiredOffset: 10,
-			chunkSizeMb:    20,
-			objectSize:     100 * util.MiB,
+			chunkSizeMb:    2,
+			objectSize:     10 * util.MiB,
 			expectError:    true,
 		},
 	}
@@ -142,11 +142,11 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload() {
 
 func (dt *sparseDownloaderTest) Test_getChunksToDownload_WithInflight() {
 	objectName := "test/sparse_inflight.txt"
-	objectSize := 100 * util.MiB
+	objectSize := 10 * util.MiB
 	dt.initJobTest(objectName, nil, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
-	dt.job.fileCacheConfig.DownloadChunkSizeMb = 20 // 20MB chunks
-	// Scenario: Request [0, 60MB) -> Chunks 0, 1, 2.
-	// Chunk 1 (20MB-40MB) is already in-flight.
+	dt.job.fileCacheConfig.DownloadChunkSizeMb = 2 // 2MB chunks
+	// Scenario: Request [0, 6MB) -> Chunks 0, 1, 2.
+	// Chunk 1 (2MB-4MB) is already in-flight.
 	// Expected: Download Chunk 0 and Chunk 2. Wait for Chunk 1.
 	inflightCh := make(chan struct{})
 	dt.job.mu.Lock()
@@ -157,10 +157,10 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload_WithInflight() {
 		BucketName: dt.job.bucket.Name(),
 		ObjectName: dt.job.object.Name,
 	}
-	chunkSizeBytes := uint64(20) * 1024 * 1024
+	chunkSizeBytes := uint64(2) * 1024 * 1024
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.job.object.Generation, uint64(objectSize), ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize)), 1)
 
-	chunks, waitChans, err := dt.job.getChunksToDownload(fileInfo, 0, 60*util.MiB)
+	chunks, waitChans, err := dt.job.getChunksToDownload(fileInfo, 0, 6*util.MiB)
 
 	AssertEq(nil, err)
 	// Should have 2 chunks to download: Chunk 0 and Chunk 2
@@ -183,7 +183,7 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload_WithInflight() {
 
 func (dt *sparseDownloaderTest) Test_DownloadRange() {
 	objectName := "test/sparse_download_range.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 5 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -191,7 +191,7 @@ func (dt *sparseDownloaderTest) Test_DownloadRange() {
 
 	// Set up sparse file mode
 	dt.job.fileCacheConfig.ExperimentalEnableChunkCache = true
-	dt.job.fileCacheConfig.DownloadChunkSizeMb = 20
+	dt.job.fileCacheConfig.DownloadChunkSizeMb = 2
 
 	// Create the cache file
 	file, err := util.CreateFile(data.FileSpec{
@@ -210,14 +210,14 @@ func (dt *sparseDownloaderTest) Test_DownloadRange() {
 	fileInfoKeyName, err := fileInfoKey.Key()
 	AssertEq(nil, err)
 
-	chunkSizeBytes := uint64(20) * 1024 * 1024
+	chunkSizeBytes := uint64(2) * 1024 * 1024
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize)), 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	// Download a range [10MB, 30MB)
-	start := uint64(10 * util.MiB)
-	end := uint64(30 * util.MiB)
+	// Download a range [1MB, 3MB)
+	start := uint64(1 * util.MiB)
+	end := uint64(3 * util.MiB)
 	err = dt.job.downloadSparseRange(context.Background(), start, end)
 	AssertEq(nil, err)
 
@@ -238,12 +238,12 @@ func (dt *sparseDownloaderTest) Test_DownloadRange() {
 
 func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
 	objectName := "test/sparse_already_downloaded.txt"
-	objectSize := 50 * util.MiB
+	objectSize := 5 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 
 	dt.job.fileCacheConfig.ExperimentalEnableChunkCache = true
-	dt.job.fileCacheConfig.DownloadChunkSizeMb = 20
+	dt.job.fileCacheConfig.DownloadChunkSizeMb = 2
 
 	// Set up sparse file info with pre-downloaded range
 	fileInfoKey := data.FileInfoKey{
@@ -253,17 +253,17 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
 	fileInfoKeyName, err := fileInfoKey.Key()
 	AssertEq(nil, err)
 
-	chunkSizeBytes := uint64(20) * 1024 * 1024
+	chunkSizeBytes := uint64(2) * 1024 * 1024
 	downloadedRanges := data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize))
-	downloadedRanges.AddRange(0, 40*util.MiB) // Mark first 40MB as downloaded
+	downloadedRanges.AddRange(0, 4*util.MiB) // Mark first 4MB as downloaded
 
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, downloadedRanges, 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	// Request a range that's already downloaded [5MB, 10MB)
-	offset := int64(5 * util.MiB)
-	requiredOffset := int64(10 * util.MiB)
+	// Request a range that's already downloaded [500KB, 1MB)
+	offset := int64(500 * util.KiB)
+	requiredOffset := int64(1 * util.MiB)
 	cacheHit, err := dt.job.HandleSparseRead(context.Background(), offset, requiredOffset)
 
 	AssertEq(nil, err)
@@ -272,12 +272,12 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
 
 func (dt *sparseDownloaderTest) Test_HandleSparseRead_NeedsDownload() {
 	objectName := "test/sparse_needs_download.txt"
-	objectSize := 100 * util.MiB
+	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	dt.initJobTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 
 	dt.job.fileCacheConfig.ExperimentalEnableChunkCache = true
-	dt.job.fileCacheConfig.DownloadChunkSizeMb = 20
+	dt.job.fileCacheConfig.DownloadChunkSizeMb = 2
 
 	// Create the cache file
 	file, err := util.CreateFile(data.FileSpec{
@@ -296,26 +296,26 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_NeedsDownload() {
 	fileInfoKeyName, err := fileInfoKey.Key()
 	AssertEq(nil, err)
 
-	chunkSizeBytes := uint64(20) * 1024 * 1024
+	chunkSizeBytes := uint64(2) * 1024 * 1024
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize)), 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
 	AssertEq(nil, err)
 
-	// Request a range that needs to be downloaded [15MB, 25MB)
-	offset := int64(15 * util.MiB)
-	requiredOffset := int64(25 * util.MiB)
+	// Request a range that needs to be downloaded [1.5MB, 2.5MB)
+	offset := int64(1500 * util.KiB)
+	requiredOffset := int64(2500 * util.KiB)
 	cacheHit, err := dt.job.HandleSparseRead(context.Background(), offset, requiredOffset)
 
 	AssertEq(nil, err)
 	AssertTrue(cacheHit, "Should be a cache hit after successful download")
 
-	// Verify the chunk was downloaded [0, 40MB) due to alignment
-	// offset 15MB rounds down to 0, requiredOffset 25MB rounds up to 40MB
+	// Verify the chunk was downloaded [0, 4MB) due to alignment
+	// offset 1.5MB rounds down to 0, requiredOffset 2.5MB rounds up to 4MB
 	updatedFileInfoVal := dt.cache.LookUpWithoutChangingOrder(fileInfoKeyName)
 	AssertTrue(updatedFileInfoVal != nil, "FileInfo should exist in cache")
 	updatedFileInfo := updatedFileInfoVal.(data.FileInfo)
-	AssertTrue(updatedFileInfo.DownloadedChunks.ContainsRange(0, 40*util.MiB),
-		"Expected range [0, 40MB) to be downloaded")
+	AssertTrue(updatedFileInfo.DownloadedChunks.ContainsRange(0, 4*util.MiB),
+		"Expected range [0, 4MB) to be downloaded")
 
 	// Verify the content
 	_, err = file.Seek(int64(offset), 0)


### PR DESCRIPTION
Optimized the test suite for the downloader package by scaling down the mock GCS object sizes and parallel/sparse download chunk sizes, reducing execution time from ~26s down to ~4.3s (a ~6x speedup).

Also fixed a race condition in Test_Download_CtxCancelled by reducing the timeout to 1ns to ensure immediate expiration and waiting on the async job completion channel (doneCh) before performing assertions on the downloaded file.

TAG=agy
CONV=8c7b5ab6-91ae-4a84-911e-1788917d5ab8