### PR TITLE
test(build): support build cache inside tests via env var

### DIFF
--- a/tools/build_gcsfuse/main.go
+++ b/tools/build_gcsfuse/main.go
@@ -41,6 +41,7 @@ import (
 	"os/exec"
 	"path"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/pflag"
@@ -76,36 +77,43 @@ func buildBinaries(dstDir, srcDir, version, arch string, buildArgs []string) (er
 		return
 	}
 
-	// Create a directory to become GOPATH for our build below.
-	gopath, err := os.MkdirTemp("", "build_gcsfuse_gopath")
-	if err != nil {
-		err = fmt.Errorf("TempDir: %w", err)
-		return
-	}
-	defer os.RemoveAll(gopath)
+	useBuildCache, err := strconv.ParseBool(os.Getenv("GCSFUSE_USE_BUILD_CACHE"))
+	clean := err != nil || !useBuildCache
 
-	// Create a directory to become GOCACHE for our build below.
+	var gopath string
 	var gocache string
-	gocache, err = os.MkdirTemp("", "build_gcsfuse_gocache")
-	if err != nil {
-		err = fmt.Errorf("TempDir: %w", err)
-		return
-	}
-	defer os.RemoveAll(gocache)
 
-	// Make it appear as if the source directory is at the appropriate position
-	// in $GOPATH.
-	gcsfuseDir := path.Join(gopath, "src/github.com/googlecloudplatform/gcsfuse")
-	err = os.MkdirAll(path.Dir(gcsfuseDir), 0700)
-	if err != nil {
-		err = fmt.Errorf("MkdirAll: %w", err)
-		return
-	}
+	if clean {
+		// Create a directory to become GOPATH for our build below.
+		gopath, err = os.MkdirTemp("", "build_gcsfuse_gopath")
+		if err != nil {
+			err = fmt.Errorf("TempDir: %w", err)
+			return
+		}
+		defer func() { _ = os.RemoveAll(gopath) }()
 
-	err = os.Symlink(srcDir, gcsfuseDir)
-	if err != nil {
-		err = fmt.Errorf("symlink: %w", err)
-		return
+		// Create a directory to become GOCACHE for our build below.
+		gocache, err = os.MkdirTemp("", "build_gcsfuse_gocache")
+		if err != nil {
+			err = fmt.Errorf("TempDir: %w", err)
+			return
+		}
+		defer func() { _ = os.RemoveAll(gocache) }()
+
+		// Make it appear as if the source directory is at the appropriate position
+		// in $GOPATH.
+		gcsfuseDir := path.Join(gopath, "src/github.com/googlecloudplatform/gcsfuse")
+		err = os.MkdirAll(path.Dir(gcsfuseDir), 0700)
+		if err != nil {
+			err = fmt.Errorf("MkdirAll: %w", err)
+			return
+		}
+
+		err = os.Symlink(srcDir, gcsfuseDir)
+		if err != nil {
+			err = fmt.Errorf("symlink: %w", err)
+			return
+		}
 	}
 
 	// mount(8) expects a different name format on Linux.

--- a/tools/build_gcsfuse/main_test.go
+++ b/tools/build_gcsfuse/main_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func TestVersion(t *testing.T) {
+	t.Setenv("GCSFUSE_USE_BUILD_CACHE", "true")
 	dir, err := os.MkdirTemp(os.TempDir(), "gcsfuse-test")
 	if err != nil {
 		t.Fatalf("Error while creating temporary directory: %v", err)


### PR DESCRIPTION
Checking GCSFUSE_USE_BUILD_CACHE environment variable in buildBinaries. If it is set to "true", we skip creating temporary, isolated GOPATH and GOCACHE folders and compile in standard module mode.

This keeps GCSFuse building cleanly/isolated by default, but allows unit tests to set GCSFUSE_USE_BUILD_CACHE to speed up TestVersion execution time from ~24s to ~3.6s.

TAG=agy
CONV=8c7b5ab6-91ae-4a84-911e-1788917d5ab8