### PR TITLE
Add experimental logical quota guardrails

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -562,6 +562,10 @@ type FileSystemConfig struct {
 
 	ExperimentalEnableReaddirplus bool `yaml:"experimental-enable-readdirplus"`
 
+	ExperimentalMaxFileCount int64 `yaml:"experimental-max-file-count"`
+
+	ExperimentalMaxSizeMb int64 `yaml:"experimental-max-size-mb"`
+
 	ExperimentalODirect bool `yaml:"experimental-o-direct"`
 
 	FileMode Octal `yaml:"file-mode"`
@@ -1068,6 +1072,18 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.StringP("experimental-local-socket-address", "", "", "The local socket address to bind to. This is useful in multi-NIC scenarios. This is an experimental flag.")
 
 	if err := flagSet.MarkHidden("experimental-local-socket-address"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("experimental-max-file-count", "", 0, "Experimental: best-effort maximum count of logical files allowed in this mount process. 0 disables the limit. Initialized from existing object metadata at mount time and then maintained only for operations through this process.")
+
+	if err := flagSet.MarkHidden("experimental-max-file-count"); err != nil {
+		return err
+	}
+
+	flagSet.IntP("experimental-max-size-mb", "", 0, "Experimental: best-effort maximum logical size, in MiB, allowed in this mount process. 0 disables the limit. Initialized from existing object metadata at mount time and then maintained only for operations through this process.")
+
+	if err := flagSet.MarkHidden("experimental-max-size-mb"); err != nil {
 		return err
 	}
 
@@ -1669,6 +1685,14 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("gcs-connection.experimental-local-socket-address", flagSet.Lookup("experimental-local-socket-address")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.experimental-max-file-count", flagSet.Lookup("experimental-max-file-count")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.experimental-max-size-mb", flagSet.Lookup("experimental-max-size-mb")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -432,6 +432,28 @@ params:
     default: false
     hide-flag: true
 
+  - config-path: "file-system.experimental-max-file-count"
+    flag-name: "experimental-max-file-count"
+    type: "int"
+    usage: >-
+      Experimental: best-effort maximum count of logical files allowed in this
+      mount process. 0 disables the limit. Initialized from existing object
+      metadata at mount time and then maintained only for operations through this
+      process.
+    default: 0
+    hide-flag: true
+
+  - config-path: "file-system.experimental-max-size-mb"
+    flag-name: "experimental-max-size-mb"
+    type: "int"
+    usage: >-
+      Experimental: best-effort maximum logical size, in MiB, allowed in this
+      mount process. 0 disables the limit. Initialized from existing object
+      metadata at mount time and then maintained only for operations through this
+      process.
+    default: 0
+    hide-flag: true
+
   - config-path: "file-system.experimental-o-direct"
     flag-name: "experimental-o-direct"
     type: "bool"

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -190,6 +190,11 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 	}
 
 	// Set up the basic struct.
+	logicalQuota, err := newLogicalQuotaForServerConfig(serverCfg)
+	if err != nil {
+		return nil, err
+	}
+
 	fs := &fileSystem{
 		mtimeClock:                 mtimeClock,
 		cacheClock:                 serverCfg.CacheClock,
@@ -225,6 +230,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		globalMaxWriteBlocksSem:    semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks),
 		globalMaxReadBlocksSem:     semaphore.NewWeighted(serverCfg.NewConfig.Read.GlobalMaxBlocks),
 		globalMetadataPrefetchSem:  semaphore.NewWeighted(serverCfg.NewConfig.MetadataCache.MetadataPrefetchMaxWorkers),
+		quota:                      logicalQuota,
 	}
 
 	// Initialize MRD cache if enabled
@@ -290,6 +296,11 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 			kernelParams.SetCongestionWindowThreshold(int(serverCfg.NewConfig.FileSystem.CongestionThreshold))
 			kernelParams.SetMaxBackgroundRequests(int(serverCfg.NewConfig.FileSystem.MaxBackground))
 			kernelParams.ApplyGKE(string(serverCfg.NewConfig.FileSystem.KernelParamsFile))
+		}
+		if fs.quota != nil {
+			if err := fs.quota.initialize(ctx, syncerBucket, inode.NewRootName("")); err != nil {
+				return nil, err
+			}
 		}
 		root = makeRootForBucket(fs, syncerBucket)
 	}
@@ -502,6 +513,7 @@ type fileSystem struct {
 	enableNonexistentTypeCache bool
 	inodeAttributeCacheTTL     time.Duration
 	dirTypeCacheTTL            time.Duration
+	quota                      *logicalQuota
 
 	// kernelListCacheTTL specifies the duration to keep the readdir response cached
 	// in kernel. After ttl, gcsfuse, (filesystem) on next opendir call (just before as part
@@ -1890,6 +1902,9 @@ func (fs *fileSystem) StatFS(
 	// Prefer large transfers. This is the largest value that OS X will
 	// faithfully pass on, according to fuseops/ops.go.
 	op.IoSize = 1 << 20
+	if fs.quota != nil {
+		op.Blocks, op.BlocksFree, op.BlocksAvailable, op.Inodes, op.InodesFree = fs.quota.statFS(uint64(op.BlockSize))
+	}
 
 	return
 }
@@ -1993,6 +2008,24 @@ func (fs *fileSystem) SetInodeAttributes(
 		if err != nil {
 			return
 		}
+		commitQuota := func() {}
+		rollbackQuota := func() {}
+		var oldSize uint64
+		newSize := uint64(*op.Size)
+		if fs.quota != nil {
+			attrs, attrErr := file.Attributes(ctx, false)
+			if attrErr != nil {
+				err = fmt.Errorf("Attributes: %w", attrErr)
+				return err
+			}
+			oldSize = fs.quota.sizeForName(file.Name(), attrs.Size)
+			if newSize > oldSize {
+				commitQuota, rollbackQuota, err = fs.quota.tryReserveGrowth(file.Name(), oldSize, newSize)
+				if err != nil {
+					return err
+				}
+			}
+		}
 		gcsSynced, err := file.Truncate(ctx, int64(*op.Size))
 		// Sync the inode if finalize during truncate is successful
 		// even if the truncate operation later resulted error.
@@ -2000,8 +2033,13 @@ func (fs *fileSystem) SetInodeAttributes(
 			fs.promoteToGenerationBacked(file)
 		}
 		if err != nil {
+			rollbackQuota()
 			err = fmt.Errorf("truncate: %w", err)
 			return err
+		}
+		commitQuota()
+		if fs.quota != nil && newSize < oldSize {
+			fs.quota.applyShrink(file.Name(), newSize)
 		}
 	}
 
@@ -2234,6 +2272,26 @@ func (fs *fileSystem) CreateFile(
 	ctx context.Context,
 	op *fuseops.CreateFileOp) (err error) {
 	ctx = fs.getInterruptlessContext(ctx)
+
+	fs.mu.Lock()
+	parent := fs.dirInodeOrDie(op.Parent)
+	fullName := inode.NewFileName(parent.Name(), op.Name)
+	fs.mu.Unlock()
+
+	rollbackQuota := func() {}
+	if fs.quota != nil {
+		rollbackQuota, err = fs.quota.tryReserveFile(fullName)
+		if err != nil {
+			return err
+		}
+	}
+	quotaCommitted := false
+	defer func() {
+		if err != nil && !quotaCommitted {
+			rollbackQuota()
+		}
+	}()
+
 	// Create the child.
 	var child inode.Inode
 	openMode := util.FileOpenMode(op.OpenFlags)
@@ -2246,6 +2304,7 @@ func (fs *fileSystem) CreateFile(
 	if err != nil {
 		return err
 	}
+	quotaCommitted = true
 
 	defer fs.unlockAndMaybeDisposeOfInode(child, &err)
 
@@ -2294,7 +2353,32 @@ func (fs *fileSystem) CreateSymlink(
 	// Find the parent.
 	fs.mu.Lock()
 	parent := fs.dirInodeOrDie(op.Parent)
+	fullName := inode.NewFileName(parent.Name(), op.Name)
 	fs.mu.Unlock()
+
+	rollbackFileQuota := func() {}
+	commitSizeQuota := func() {}
+	rollbackSizeQuota := func() {}
+	if fs.quota != nil {
+		rollbackFileQuota, err = fs.quota.tryReserveFile(fullName)
+		if err != nil {
+			return err
+		}
+	}
+	if fs.quota != nil && fs.newConfig.EnableStandardSymlinks {
+		commitSizeQuota, rollbackSizeQuota, err = fs.quota.tryReserveGrowth(fullName, 0, uint64(len(op.Target)))
+		if err != nil {
+			rollbackFileQuota()
+			return err
+		}
+	}
+	quotaCommitted := false
+	defer func() {
+		if err != nil && !quotaCommitted {
+			rollbackSizeQuota()
+			rollbackFileQuota()
+		}
+	}()
 
 	// Create the object in GCS, failing if it already exists.
 	parent.Lock()
@@ -2325,6 +2409,8 @@ func (fs *fileSystem) CreateSymlink(
 		err = fmt.Errorf("newly-created record is already stale")
 		return err
 	}
+	commitSizeQuota()
+	quotaCommitted = true
 
 	defer fs.unlockAndMaybeDisposeOfInode(child, &err)
 
@@ -2535,10 +2621,20 @@ func (fs *fileSystem) renameFile(ctx context.Context, op *fuseops.RenameOp, chil
 	default:
 		return fmt.Errorf("child inode (id %v) is not a file or symlink inode", child.ID())
 	}
+	oldName := inode.NewFileName(oldParent.Name(), op.OldName)
+	newName := inode.NewFileName(newParent.Name(), op.NewName)
 	if fs.enableAtomicRenameObject || child.Bucket().BucketType().IsRapid() {
-		return fs.atomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
+		err = fs.atomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
+	} else {
+		err = fs.nonAtomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
 	}
-	return fs.nonAtomicRename(ctx, oldParent, op.OldName, updatedMinObject, newParent, op.NewName)
+	if err != nil {
+		return err
+	}
+	if fs.quota != nil {
+		fs.quota.applyRename(oldName, newName, updatedMinObject.Size)
+	}
+	return nil
 }
 
 // LOCKS_EXCLUDED(fileInode)
@@ -2883,6 +2979,9 @@ func (fs *fileSystem) Unlink(
 	// If the inode represents a local file, we don't need to delete
 	// the backing object on GCS, so return early.
 	if isLocalFile {
+		if fs.quota != nil {
+			fs.quota.releaseName(fileName)
+		}
 		return
 	}
 
@@ -2901,6 +3000,9 @@ func (fs *fileSystem) Unlink(
 	// which is not precondition error.
 	if err != nil && !errors.As(err, &preconditionErr) {
 		return fmt.Errorf("DeleteChildFile: %w", err)
+	}
+	if fs.quota != nil {
+		fs.quota.releaseName(fileName)
 	}
 
 	// In case of successful delete or precondition error, we should invalidate
@@ -3210,11 +3312,41 @@ func (fs *fileSystem) WriteFile(
 		}
 		return err
 	}
+
+	if op.Offset < 0 {
+		return syscall.EINVAL
+	}
+	commitQuota := func() {}
+	rollbackQuota := func() {}
+	if fs.quota != nil {
+		attrs, attrErr := in.Attributes(ctx, false)
+		if attrErr != nil {
+			return fmt.Errorf("Attributes: %w", attrErr)
+		}
+		oldSize := fs.quota.sizeForName(in.Name(), attrs.Size)
+		newSize := oldSize
+		dataLen := uint64(len(op.Data))
+		if fh.OpenMode().IsAppend() {
+			if dataLen > math.MaxUint64-oldSize {
+				return syscall.EFBIG
+			}
+			newSize = oldSize + dataLen
+		} else if endOffset := uint64(op.Offset) + dataLen; endOffset > newSize {
+			newSize = endOffset
+		}
+		commitQuota, rollbackQuota, err = fs.quota.tryReserveGrowth(in.Name(), oldSize, newSize)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Serve the request.
 	gcsSynced, err = in.Write(ctx, op.Data, op.Offset, fh.OpenMode())
 	if err != nil {
+		rollbackQuota()
 		return
 	}
+	commitQuota()
 	// Sync the inode if finalize during write is successful
 	// even if the write operation later resulted in error.
 	if gcsSynced {

--- a/internal/fs/quota.go
+++ b/internal/fs/quota.go
@@ -1,0 +1,387 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+)
+
+const logicalQuotaListPageSize = 1000
+
+const logicalQuotaAllBucketsMountError = "experimental logical quotas require a single mounted bucket or --only-dir prefix; all-buckets mounts are not supported"
+
+type logicalQuota struct {
+	mu sync.Mutex
+
+	maxFiles uint64
+	maxBytes uint64
+
+	// When the corresponding limit is enabled, these are exactly the sums of
+	// the entries in byName. Disabled dimensions are intentionally not tracked.
+	usedFiles uint64
+	usedBytes uint64
+
+	byName map[inode.Name]quotaEntry
+}
+
+type quotaEntry struct {
+	size uint64
+}
+
+func newLogicalQuota(maxFiles int64, maxSizeMb int64) (*logicalQuota, error) {
+	if maxFiles < 0 {
+		return nil, fmt.Errorf("experimental-max-file-count must be non-negative")
+	}
+	if maxSizeMb < 0 {
+		return nil, fmt.Errorf("experimental-max-size-mb must be non-negative")
+	}
+	if maxFiles == 0 && maxSizeMb == 0 {
+		return nil, nil
+	}
+
+	var maxBytes uint64
+	if maxSizeMb > 0 {
+		if uint64(maxSizeMb) > math.MaxUint64/(1<<20) {
+			return nil, fmt.Errorf("experimental-max-size-mb is too large")
+		}
+		maxBytes = uint64(maxSizeMb) * (1 << 20)
+	}
+
+	return &logicalQuota{
+		maxFiles: uint64(maxFiles),
+		maxBytes: maxBytes,
+		byName:   make(map[inode.Name]quotaEntry),
+	}, nil
+}
+
+func newLogicalQuotaForServerConfig(serverCfg *ServerConfig) (*logicalQuota, error) {
+	q, err := newLogicalQuota(
+		serverCfg.NewConfig.FileSystem.ExperimentalMaxFileCount,
+		serverCfg.NewConfig.FileSystem.ExperimentalMaxSizeMb)
+	if err != nil {
+		return nil, err
+	}
+	if q == nil {
+		return nil, nil
+	}
+
+	if serverCfg.BucketName == "" || serverCfg.BucketName == "_" {
+		return nil, fmt.Errorf(logicalQuotaAllBucketsMountError)
+	}
+
+	return q, nil
+}
+
+func (q *logicalQuota) hasFileLimit() bool {
+	return q != nil && q.maxFiles != 0
+}
+
+func (q *logicalQuota) hasSizeLimit() bool {
+	return q != nil && q.maxBytes != 0
+}
+
+func (q *logicalQuota) initialize(ctx context.Context, bucket gcs.Bucket, root inode.Name) error {
+	for token := ""; ; {
+		listing, err := bucket.ListObjects(ctx, &gcs.ListObjectsRequest{
+			ContinuationToken: token,
+			MaxResults:        logicalQuotaListPageSize,
+		})
+		if err != nil {
+			return fmt.Errorf("quota cold-start scan: %w", err)
+		}
+
+		q.mu.Lock()
+		for _, object := range listing.MinObjects {
+			if object == nil || strings.HasSuffix(object.Name, "/") {
+				continue
+			}
+			q.addInitialEntryLocked(inode.NewDescendantName(root, object.Name), object.Size)
+		}
+		q.mu.Unlock()
+
+		token = listing.ContinuationToken
+		if token == "" {
+			logger.Infof(
+				"logical quota initialized: used_files=%d used_bytes=%d max_files=%d max_bytes=%d",
+				q.usedFiles,
+				q.usedBytes,
+				q.maxFiles,
+				q.maxBytes)
+			if q.hasFileLimit() && q.usedFiles > q.maxFiles {
+				logger.Warnf("logical quota starts over file limit: used_files=%d max_files=%d", q.usedFiles, q.maxFiles)
+			}
+			if q.hasSizeLimit() && q.usedBytes > q.maxBytes {
+				logger.Warnf("logical quota starts over size limit: used_bytes=%d max_bytes=%d", q.usedBytes, q.maxBytes)
+			}
+			return nil
+		}
+	}
+}
+
+func (q *logicalQuota) addInitialEntryLocked(name inode.Name, size uint64) {
+	old, existed := q.byName[name]
+	if existed {
+		if q.hasSizeLimit() {
+			q.usedBytes -= old.size
+		}
+	} else if q.hasFileLimit() {
+		q.usedFiles++
+	}
+
+	if q.hasSizeLimit() {
+		q.usedBytes += size
+	} else {
+		size = 0
+	}
+	q.byName[name] = quotaEntry{size: size}
+}
+
+func (q *logicalQuota) tryReserveFile(name inode.Name) (rollback func(), err error) {
+	if q == nil || !q.hasFileLimit() {
+		return func() {}, nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	if _, ok := q.byName[name]; ok {
+		return func() {}, nil
+	}
+	if q.usedFiles >= q.maxFiles {
+		logger.Warnf("logical file quota exceeded: op=create name=%s used_files=%d max_files=%d", name.GcsObjectName(), q.usedFiles, q.maxFiles)
+		return nil, syscall.ENOSPC
+	}
+
+	q.usedFiles++
+	q.byName[name] = quotaEntry{}
+	rolledBack := false
+	return func() {
+		q.mu.Lock()
+		defer q.mu.Unlock()
+		if rolledBack {
+			return
+		}
+		rolledBack = true
+		entry, ok := q.byName[name]
+		if ok {
+			q.usedFiles--
+			if q.hasSizeLimit() {
+				q.usedBytes -= entry.size
+			}
+			delete(q.byName, name)
+		}
+	}, nil
+}
+
+func (q *logicalQuota) tryReserveGrowth(name inode.Name, oldSize uint64, newSize uint64) (commit func(), rollback func(), err error) {
+	noOp := func() {}
+	if q == nil {
+		return noOp, noOp, nil
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	oldEntry, existed := q.byName[name]
+	newFile := !existed
+	if !newFile {
+		oldSize = oldEntry.size
+	}
+
+	targetSize := newSize
+	if oldSize > targetSize {
+		targetSize = oldSize
+	}
+
+	var fileDelta uint64
+	if newFile && q.hasFileLimit() {
+		if q.usedFiles >= q.maxFiles {
+			logger.Warnf("logical file quota exceeded: op=write name=%s used_files=%d max_files=%d", name.GcsObjectName(), q.usedFiles, q.maxFiles)
+			return nil, nil, syscall.ENOSPC
+		}
+		fileDelta = 1
+	}
+
+	var byteDelta uint64
+	if q.hasSizeLimit() {
+		if newFile {
+			byteDelta = targetSize
+		} else if targetSize > oldSize {
+			byteDelta = targetSize - oldSize
+		}
+		if byteDelta > 0 && (byteDelta > q.maxBytes || q.usedBytes > q.maxBytes-byteDelta) {
+			logger.Warnf("logical quota exceeded: op=write name=%s old_size=%d new_size=%d used_bytes=%d max_bytes=%d", name.GcsObjectName(), oldSize, targetSize, q.usedBytes, q.maxBytes)
+			return nil, nil, syscall.ENOSPC
+		}
+	}
+
+	if fileDelta == 0 && byteDelta == 0 {
+		return noOp, noOp, nil
+	}
+
+	q.usedFiles += fileDelta
+	q.usedBytes += byteDelta
+	if q.hasSizeLimit() {
+		q.byName[name] = quotaEntry{size: targetSize}
+	} else {
+		q.byName[name] = quotaEntry{}
+	}
+
+	committed := false
+	return func() {
+			q.mu.Lock()
+			defer q.mu.Unlock()
+			committed = true
+		}, func() {
+			q.mu.Lock()
+			defer q.mu.Unlock()
+			if committed {
+				return
+			}
+			q.usedFiles -= fileDelta
+			q.usedBytes -= byteDelta
+			if newFile {
+				delete(q.byName, name)
+			} else {
+				q.byName[name] = oldEntry
+			}
+		}, nil
+}
+
+func (q *logicalQuota) applyShrink(name inode.Name, newSize uint64) {
+	if q == nil || !q.hasSizeLimit() {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	entry, ok := q.byName[name]
+	if !ok || newSize >= entry.size {
+		return
+	}
+	q.usedBytes -= entry.size - newSize
+	q.byName[name] = quotaEntry{size: newSize}
+}
+
+func (q *logicalQuota) releaseName(name inode.Name) {
+	if q == nil {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	entry, ok := q.byName[name]
+	if !ok {
+		return
+	}
+	if q.hasFileLimit() {
+		q.usedFiles--
+	}
+	if q.hasSizeLimit() {
+		q.usedBytes -= entry.size
+	}
+	delete(q.byName, name)
+}
+
+func (q *logicalQuota) applyRename(oldName inode.Name, newName inode.Name, fallbackSize uint64) {
+	if q == nil || oldName == newName {
+		return
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	src, srcOK := q.byName[oldName]
+	dst, dstOK := q.byName[newName]
+	if !srcOK && !dstOK {
+		return
+	}
+
+	if !srcOK {
+		src = quotaEntry{}
+		if q.hasSizeLimit() {
+			src.size = fallbackSize
+			q.usedBytes += fallbackSize
+		}
+		if q.hasFileLimit() {
+			q.usedFiles++
+		}
+	}
+
+	if dstOK {
+		if q.hasFileLimit() {
+			q.usedFiles--
+		}
+		if q.hasSizeLimit() {
+			q.usedBytes -= dst.size
+		}
+	}
+
+	delete(q.byName, oldName)
+	q.byName[newName] = src
+}
+
+func (q *logicalQuota) sizeForName(name inode.Name, fallback uint64) uint64 {
+	if q == nil || !q.hasSizeLimit() {
+		return fallback
+	}
+
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	entry, ok := q.byName[name]
+	if !ok {
+		return fallback
+	}
+	return entry.size
+}
+
+func (q *logicalQuota) statFS(blockSize uint64) (blocks uint64, free uint64, available uint64, inodes uint64, inodesFree uint64) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	blocks = 1 << 33
+	free = blocks
+	available = blocks
+	if q.hasSizeLimit() {
+		blocks = (q.maxBytes + blockSize - 1) / blockSize
+		if q.usedBytes < q.maxBytes {
+			free = (q.maxBytes - q.usedBytes) / blockSize
+		} else {
+			free = 0
+		}
+		available = free
+	}
+
+	inodes = 1 << 50
+	inodesFree = inodes
+	if q.hasFileLimit() {
+		inodes = q.maxFiles
+		if q.usedFiles < q.maxFiles {
+			inodesFree = q.maxFiles - q.usedFiles
+		} else {
+			inodesFree = 0
+		}
+	}
+	return
+}

--- a/internal/fs/quota_acceptance_test.go
+++ b/internal/fs/quota_acceptance_test.go
@@ -1,0 +1,277 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+)
+
+type quotaAcceptanceBucketManager struct {
+	bucket  gcs.Bucket
+	onlyDir string
+}
+
+func (bm quotaAcceptanceBucketManager) ShutDown() {}
+
+func (bm quotaAcceptanceBucketManager) SetUpBucket(
+	_ context.Context,
+	name string,
+	_ bool,
+	_ metrics.MetricHandle) (gcsx.SyncerBucket, error) {
+	if bm.bucket.Name() != name {
+		return gcsx.SyncerBucket{}, fmt.Errorf("bucket %q does not exist", name)
+	}
+	bucket := bm.bucket
+	if bm.onlyDir != "" {
+		var err error
+		bucket, err = gcsx.NewPrefixBucket(path.Clean(bm.onlyDir)+"/", bucket)
+		if err != nil {
+			return gcsx.SyncerBucket{}, err
+		}
+	}
+	return gcsx.NewSyncerBucket(0, 0, 10, ".gcsfuse_tmp/", gcsx.NewContentTypeBucket(bucket)), nil
+}
+
+func newQuotaAcceptanceFileSystem(t *testing.T, bucket gcs.Bucket, configure func(*cfg.Config)) *fileSystem {
+	t.Helper()
+	return newQuotaAcceptanceFileSystemWithOnlyDir(t, bucket, "", configure)
+}
+
+func newQuotaAcceptanceFileSystemWithOnlyDir(t *testing.T, bucket gcs.Bucket, onlyDir string, configure func(*cfg.Config)) *fileSystem {
+	t.Helper()
+
+	config := &cfg.Config{
+		EnableNewReader: true,
+		FileCache: cfg.FileCacheConfig{
+			MaxSizeMb: -1,
+		},
+		MetadataCache: cfg.MetadataCacheConfig{
+			MetadataPrefetchMaxWorkers: 1,
+			StatCacheMaxSizeMb:         33,
+			TypeCacheMaxSizeMb:         4,
+		},
+		Read: cfg.ReadConfig{
+			GlobalMaxBlocks: 1,
+		},
+		Write: cfg.WriteConfig{
+			GlobalMaxBlocks: 1,
+		},
+	}
+	configure(config)
+
+	rawFS, err := NewFileSystem(context.Background(), &ServerConfig{
+		CacheClock:    timeutil.RealClock(),
+		BucketManager: quotaAcceptanceBucketManager{bucket: bucket, onlyDir: onlyDir},
+		BucketName:    bucket.Name(),
+		NewConfig:     config,
+		MetricHandle:  metrics.NewNoopMetrics(),
+		TraceHandle:   tracing.NewNoopTracer(),
+		Uid:           uint32(os.Getuid()),
+		Gid:           uint32(os.Getgid()),
+		FilePerms:     0644,
+		DirPerms:      0755,
+	})
+	require.NoError(t, err)
+
+	fs, ok := rawFS.(*fileSystem)
+	require.True(t, ok)
+	return fs
+}
+
+func TestLogicalQuotaAcceptanceOnlyDirScopesColdStartScan(t *testing.T) {
+	ctx := context.Background()
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), "bucket", gcs.BucketType{})
+	_, err := storageutil.CreateObject(ctx, bucket, "quota-prefix/existing", make([]byte, 4<<20))
+	require.NoError(t, err)
+	_, err = storageutil.CreateObject(ctx, bucket, "outside-prefix/ignored", make([]byte, 4<<20))
+	require.NoError(t, err)
+
+	fs := newQuotaAcceptanceFileSystemWithOnlyDir(t, bucket, "quota-prefix", func(config *cfg.Config) {
+		config.FileSystem.ExperimentalMaxSizeMb = 5
+	})
+
+	stat := &fuseops.StatFSOp{}
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(40), stat.Blocks)
+	assert.Equal(t, uint64(8), stat.BlocksFree)
+
+	create := &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "new",
+		OpenFlags: syscall.O_WRONLY,
+	}
+	require.NoError(t, fs.CreateFile(ctx, create))
+	require.NoError(t, fs.WriteFile(ctx, &fuseops.WriteFileOp{
+		Inode:  create.Entry.Child,
+		Handle: create.Handle,
+		Data:   make([]byte, 1<<20),
+	}))
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(0), stat.BlocksFree)
+}
+
+func TestLogicalQuotaAcceptanceSizeLimit(t *testing.T) {
+	ctx := context.Background()
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), "bucket", gcs.BucketType{})
+	_, err := storageutil.CreateObject(ctx, bucket, "existing", make([]byte, 4<<20))
+	require.NoError(t, err)
+	fs := newQuotaAcceptanceFileSystem(t, bucket, func(config *cfg.Config) {
+		config.FileSystem.ExperimentalMaxSizeMb = 5
+	})
+
+	stat := &fuseops.StatFSOp{}
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(40), stat.Blocks)
+	assert.Equal(t, uint64(8), stat.BlocksFree)
+
+	create := &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "new",
+		OpenFlags: syscall.O_WRONLY,
+	}
+	require.NoError(t, fs.CreateFile(ctx, create))
+
+	err = fs.WriteFile(ctx, &fuseops.WriteFileOp{
+		Inode:  create.Entry.Child,
+		Handle: create.Handle,
+		Data:   make([]byte, 2<<20),
+	})
+	assert.ErrorIs(t, err, syscall.ENOSPC)
+
+	require.NoError(t, fs.WriteFile(ctx, &fuseops.WriteFileOp{
+		Inode:  create.Entry.Child,
+		Handle: create.Handle,
+		Data:   make([]byte, 1<<20),
+	}))
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(0), stat.BlocksFree)
+
+	require.NoError(t, fs.Unlink(ctx, &fuseops.UnlinkOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "new",
+	}))
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(8), stat.BlocksFree)
+}
+
+func TestLogicalQuotaAcceptanceInitialOverLimitAllowsDeleteRecovery(t *testing.T) {
+	ctx := context.Background()
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), "bucket", gcs.BucketType{})
+	_, err := storageutil.CreateObject(ctx, bucket, "too-large", make([]byte, 6<<20))
+	require.NoError(t, err)
+	fs := newQuotaAcceptanceFileSystem(t, bucket, func(config *cfg.Config) {
+		config.FileSystem.ExperimentalMaxSizeMb = 5
+	})
+
+	stat := &fuseops.StatFSOp{}
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(0), stat.BlocksFree)
+
+	create := &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "new",
+		OpenFlags: syscall.O_WRONLY,
+	}
+	require.NoError(t, fs.CreateFile(ctx, create))
+	err = fs.WriteFile(ctx, &fuseops.WriteFileOp{
+		Inode:  create.Entry.Child,
+		Handle: create.Handle,
+		Data:   []byte("x"),
+	})
+	assert.ErrorIs(t, err, syscall.ENOSPC)
+
+	require.NoError(t, fs.Unlink(ctx, &fuseops.UnlinkOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "too-large",
+	}))
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(40), stat.BlocksFree)
+}
+
+func TestLogicalQuotaAcceptanceRenameOverExistingReleasesDestination(t *testing.T) {
+	ctx := context.Background()
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), "bucket", gcs.BucketType{})
+	_, err := storageutil.CreateObject(ctx, bucket, "src", make([]byte, 1<<20))
+	require.NoError(t, err)
+	_, err = storageutil.CreateObject(ctx, bucket, "dst", make([]byte, 4<<20))
+	require.NoError(t, err)
+	fs := newQuotaAcceptanceFileSystem(t, bucket, func(config *cfg.Config) {
+		config.FileSystem.ExperimentalMaxSizeMb = 5
+	})
+
+	stat := &fuseops.StatFSOp{}
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(0), stat.BlocksFree)
+
+	require.NoError(t, fs.Rename(ctx, &fuseops.RenameOp{
+		OldParent: fuseops.RootInodeID,
+		OldName:   "src",
+		NewParent: fuseops.RootInodeID,
+		NewName:   "dst",
+	}))
+	require.NoError(t, fs.StatFS(ctx, stat))
+	assert.Equal(t, uint64(32), stat.BlocksFree)
+}
+
+func TestLogicalQuotaAcceptanceFileLimit(t *testing.T) {
+	ctx := context.Background()
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), "bucket", gcs.BucketType{})
+	_, err := storageutil.CreateObject(ctx, bucket, "existing", []byte("data"))
+	require.NoError(t, err)
+	fs := newQuotaAcceptanceFileSystem(t, bucket, func(config *cfg.Config) {
+		config.FileSystem.ExperimentalMaxFileCount = 2
+	})
+
+	first := &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "first",
+		OpenFlags: syscall.O_WRONLY,
+	}
+	require.NoError(t, fs.CreateFile(ctx, first))
+
+	err = fs.CreateFile(ctx, &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "second",
+		OpenFlags: syscall.O_WRONLY,
+	})
+	assert.ErrorIs(t, err, syscall.ENOSPC)
+
+	require.NoError(t, fs.Unlink(ctx, &fuseops.UnlinkOp{
+		Parent: fuseops.RootInodeID,
+		Name:   "first",
+	}))
+	require.NoError(t, fs.CreateFile(ctx, &fuseops.CreateFileOp{
+		Parent:    fuseops.RootInodeID,
+		Name:      "third",
+		OpenFlags: syscall.O_WRONLY,
+	}))
+}

--- a/internal/fs/quota_test.go
+++ b/internal/fs/quota_test.go
@@ -1,0 +1,239 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func quotaTestName(objectName string) inode.Name {
+	return inode.NewDescendantName(inode.NewRootName(""), objectName)
+}
+
+func TestLogicalQuotaDisabledNeverRejects(t *testing.T) {
+	var q *logicalQuota
+	name := quotaTestName("file")
+
+	commit, rollback, err := q.tryReserveGrowth(name, 0, 1<<30)
+
+	require.NoError(t, err)
+	rollback()
+	commit()
+}
+
+func TestLogicalQuotaFileCountRejectsNextFile(t *testing.T) {
+	q, err := newLogicalQuota(1, 0)
+	require.NoError(t, err)
+
+	rollback, err := q.tryReserveFile(quotaTestName("a"))
+	require.NoError(t, err)
+	defer rollback()
+
+	_, err = q.tryReserveFile(quotaTestName("b"))
+
+	assert.ErrorIs(t, err, syscall.ENOSPC)
+}
+
+func TestLogicalQuotaSizeRejectsGrowthBeyondLimit(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+
+	_, _, err = q.tryReserveGrowth(quotaTestName("file"), 0, 1<<20+1)
+
+	assert.ErrorIs(t, err, syscall.ENOSPC)
+}
+
+func TestLogicalQuotaOverwriteWithinExistingSize(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+	name := quotaTestName("file")
+
+	commit, _, err := q.tryReserveGrowth(name, 0, 512)
+	require.NoError(t, err)
+	commit()
+
+	commit, rollback, err := q.tryReserveGrowth(name, 512, 512)
+
+	require.NoError(t, err)
+	rollback()
+	commit()
+	assert.Equal(t, uint64(512), q.usedBytes)
+}
+
+func TestLogicalQuotaShrinkReleasesBytes(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+	name := quotaTestName("file")
+	commit, _, err := q.tryReserveGrowth(name, 0, 1<<20)
+	require.NoError(t, err)
+	commit()
+
+	q.applyShrink(name, 128)
+
+	assert.Equal(t, uint64(128), q.usedBytes)
+}
+
+func TestLogicalQuotaRollbackReleasesReservedGrowth(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+	name := quotaTestName("file")
+
+	_, rollback, err := q.tryReserveGrowth(name, 0, 512)
+	require.NoError(t, err)
+	rollback()
+
+	assert.Equal(t, uint64(0), q.usedBytes)
+	_, ok := q.byName[name]
+	assert.False(t, ok)
+}
+
+func TestLogicalQuotaFileOnlyDoesNotTrackBytes(t *testing.T) {
+	q, err := newLogicalQuota(2, 0)
+	require.NoError(t, err)
+	name := quotaTestName("file")
+
+	commit, _, err := q.tryReserveGrowth(name, 0, 1<<20)
+	require.NoError(t, err)
+	commit()
+
+	assert.Equal(t, uint64(1), q.usedFiles)
+	assert.Equal(t, uint64(0), q.usedBytes)
+	assert.Equal(t, uint64(0), q.byName[name].size)
+}
+
+func TestLogicalQuotaSizeOnlyDoesNotTrackFiles(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+
+	commit, _, err := q.tryReserveGrowth(quotaTestName("file"), 0, 512)
+	require.NoError(t, err)
+	commit()
+
+	assert.Equal(t, uint64(0), q.usedFiles)
+	assert.Equal(t, uint64(512), q.usedBytes)
+}
+
+func TestLogicalQuotaUntrackedExistingFileChargesFullSize(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+	name := quotaTestName("file")
+
+	commit, rollback, err := q.tryReserveGrowth(name, 512, 1024)
+	require.NoError(t, err)
+	commit()
+
+	assert.Equal(t, uint64(1024), q.usedBytes)
+	assert.Equal(t, uint64(1024), q.byName[name].size)
+
+	rollback()
+	assert.Equal(t, uint64(1024), q.usedBytes)
+}
+
+func TestLogicalQuotaStatFSReportsBoundedCapacity(t *testing.T) {
+	q, err := newLogicalQuota(10, 1)
+	require.NoError(t, err)
+	commit, _, err := q.tryReserveGrowth(quotaTestName("file"), 0, 512*1024)
+	require.NoError(t, err)
+	commit()
+
+	blocks, free, available, inodes, inodesFree := q.statFS(128 * 1024)
+
+	assert.Equal(t, uint64(8), blocks)
+	assert.Equal(t, uint64(4), free)
+	assert.Equal(t, free, available)
+	assert.Equal(t, uint64(10), inodes)
+	assert.Equal(t, uint64(9), inodesFree)
+}
+
+func TestLogicalQuotaApplyRenameOverExistingReleasesDestination(t *testing.T) {
+	q, err := newLogicalQuota(10, 1)
+	require.NoError(t, err)
+	src := quotaTestName("src")
+	dst := quotaTestName("dst")
+	q.addInitialEntryLocked(src, 128)
+	q.addInitialEntryLocked(dst, 512)
+
+	q.applyRename(src, dst, 128)
+
+	assert.Equal(t, uint64(1), q.usedFiles)
+	assert.Equal(t, uint64(128), q.usedBytes)
+	_, ok := q.byName[src]
+	assert.False(t, ok)
+	assert.Equal(t, uint64(128), q.byName[dst].size)
+}
+
+func TestLogicalQuotaConcurrentReservationsCannotOversubscribe(t *testing.T) {
+	q, err := newLogicalQuota(0, 1)
+	require.NoError(t, err)
+
+	const goroutines = 16
+	const chunkSize = 256 * 1024
+
+	var wg sync.WaitGroup
+	successes := make(chan struct{}, goroutines)
+	for i := range goroutines {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			name := quotaTestName(string(rune('a' + i)))
+			commit, _, err := q.tryReserveGrowth(name, 0, chunkSize)
+			if err == nil {
+				commit()
+				successes <- struct{}{}
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(successes)
+
+	assert.Len(t, successes, 4)
+	assert.Equal(t, uint64(1<<20), q.usedBytes)
+}
+
+func TestLogicalQuotaRejectsAllBucketsMount(t *testing.T) {
+	_, err := newLogicalQuotaForServerConfig(&ServerConfig{
+		BucketName: "",
+		NewConfig: &cfg.Config{
+			FileSystem: cfg.FileSystemConfig{
+				ExperimentalMaxSizeMb: 1,
+			},
+		},
+	})
+
+	assert.ErrorContains(t, err, "single mounted bucket or --only-dir prefix")
+	assert.ErrorContains(t, err, "all-buckets mounts are not supported")
+}
+
+func TestLogicalQuotaAllowsSingleBucketMount(t *testing.T) {
+	q, err := newLogicalQuotaForServerConfig(&ServerConfig{
+		BucketName: "bucket",
+		NewConfig: &cfg.Config{
+			FileSystem: cfg.FileSystemConfig{
+				ExperimentalMaxSizeMb: 1,
+			},
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, q)
+	assert.True(t, q.hasSizeLimit())
+}

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -359,6 +359,7 @@ TEST_PACKAGES_COMMON=(
   "buffered_read"
   "flag_optimizations"
   "symlink_handling"
+  "logical_quota"
 )
 
 # filter_array: Filters an array in place keeping only elements matching the regex.

--- a/tools/integration_tests/logical_quota/logical_quota_test.go
+++ b/tools/integration_tests/logical_quota/logical_quota_test.go
@@ -1,0 +1,178 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logical_quota
+
+import (
+	"errors"
+	"log"
+	"os"
+	"path"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	oneMiB = 1024 * 1024
+)
+
+type logicalQuotaSuite struct {
+	flags  []string
+	prefix string
+	suite.Suite
+}
+
+func (s *logicalQuotaSuite) SetupSuite() {
+	setup.SetUpLogFilePath(s.T().Name(), s.flags, "", "", testEnv.cfg)
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(
+		testEnv.cfg,
+		s.flags,
+		static_mounting.MountGcsfuseWithStaticMountingWithConfigFile)
+	setup.SetMntDir(testEnv.cfg.GCSFuseMountedDirectory)
+}
+
+func (s *logicalQuotaSuite) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, s.prefix))
+}
+
+func (s *logicalQuotaSuite) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+type sizeQuotaSuite struct {
+	logicalQuotaSuite
+}
+
+func (s *sizeQuotaSuite) SetupSuite() {
+	s.prefix = sizeQuotaPrefix
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, s.prefix))
+	require.NoError(
+		s.T(),
+		client.CreateObjectOnGCS(
+			testEnv.ctx,
+			testEnv.storageClient,
+			path.Join(s.prefix, "existing.bin"),
+			strings.Repeat("a", 4*oneMiB)))
+	s.logicalQuotaSuite.SetupSuite()
+}
+
+func (s *sizeQuotaSuite) TestSizeQuota() {
+	initialStat := statFS(s.T())
+	initialBlockSize := uint64(initialStat.Frsize)
+	require.NotZero(s.T(), initialBlockSize)
+	assert.Equal(s.T(), ceilDiv(5*oneMiB, initialBlockSize), uint64(initialStat.Blocks))
+	assert.Equal(s.T(), uint64(initialStat.Bfree), uint64(initialStat.Bavail))
+	assert.Equal(s.T(), uint64(oneMiB)/initialBlockSize, uint64(initialStat.Bavail))
+
+	withinQuotaFile := path.Join(setup.MntDir(), "within-quota.bin")
+	require.NoError(s.T(), os.WriteFile(withinQuotaFile, []byte(strings.Repeat("b", oneMiB)), 0600))
+
+	fullStat := statFS(s.T())
+	assert.Zero(s.T(), uint64(fullStat.Bavail))
+
+	beyondQuotaFile := path.Join(setup.MntDir(), "beyond-quota.bin")
+	err := os.WriteFile(beyondQuotaFile, []byte("x"), 0600)
+	assertNoSpaceLeft(s.T(), err)
+
+	require.NoError(s.T(), os.Remove(withinQuotaFile))
+	recoveredStat := statFS(s.T())
+	assert.GreaterOrEqual(s.T(), uint64(recoveredStat.Bavail), uint64(oneMiB)/uint64(recoveredStat.Frsize))
+
+	require.NoError(s.T(), os.WriteFile(path.Join(setup.MntDir(), "after-delete.bin"), []byte(strings.Repeat("c", oneMiB)), 0600))
+}
+
+type fileCountQuotaSuite struct {
+	logicalQuotaSuite
+}
+
+func (s *fileCountQuotaSuite) SetupSuite() {
+	s.prefix = fileCountQuotaPrefix
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, s.prefix))
+	require.NoError(
+		s.T(),
+		client.CreateObjectOnGCS(
+			testEnv.ctx,
+			testEnv.storageClient,
+			path.Join(s.prefix, "existing.txt"),
+			"existing"))
+	s.logicalQuotaSuite.SetupSuite()
+}
+
+func (s *fileCountQuotaSuite) TestFileCountQuota() {
+	initialStat := statFS(s.T())
+	assert.Equal(s.T(), uint64(2), uint64(initialStat.Files))
+	assert.Equal(s.T(), uint64(1), uint64(initialStat.Ffree))
+
+	firstFile := path.Join(setup.MntDir(), "first.txt")
+	require.NoError(s.T(), os.WriteFile(firstFile, []byte("first"), 0600))
+
+	fullStat := statFS(s.T())
+	assert.Zero(s.T(), uint64(fullStat.Ffree))
+
+	err := os.WriteFile(path.Join(setup.MntDir(), "second.txt"), []byte("second"), 0600)
+	assertNoSpaceLeft(s.T(), err)
+
+	require.NoError(s.T(), os.Remove(firstFile))
+	recoveredStat := statFS(s.T())
+	assert.Equal(s.T(), uint64(1), uint64(recoveredStat.Ffree))
+
+	require.NoError(s.T(), os.WriteFile(path.Join(setup.MntDir(), "after-delete.txt"), []byte("after-delete"), 0600))
+}
+
+func TestSizeQuota(t *testing.T) {
+	ts := &sizeQuotaSuite{}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running logical quota size test with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
+}
+
+func TestFileCountQuota(t *testing.T) {
+	ts := &fileCountQuotaSuite{}
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running logical quota file count test with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
+}
+
+func statFS(t *testing.T) syscall.Statfs_t {
+	t.Helper()
+	var stat syscall.Statfs_t
+	require.NoError(t, syscall.Statfs(setup.MntDir(), &stat))
+	return stat
+}
+
+func assertNoSpaceLeft(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	if errors.Is(err, syscall.ENOSPC) {
+		return
+	}
+	assert.Contains(t, strings.ToLower(err.Error()), "no space left")
+}
+
+func ceilDiv(n int, d uint64) uint64 {
+	return (uint64(n) + d - 1) / d
+}

--- a/tools/integration_tests/logical_quota/setup_test.go
+++ b/tools/integration_tests/logical_quota/setup_test.go
@@ -1,0 +1,96 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logical_quota
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path"
+	"testing"
+
+	"cloud.google.com/go/storage"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+)
+
+const (
+	sizeQuotaPrefix      = "LogicalQuotaSizeTest"
+	fileCountQuotaPrefix = "LogicalQuotaFileCountTest"
+)
+
+type env struct {
+	storageClient *storage.Client
+	ctx           context.Context
+	cfg           *test_suite.TestConfig
+	bucketType    string
+}
+
+var testEnv env
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
+	if len(cfg.LogicalQuota) == 0 {
+		log.Println("No configuration found for logical_quota tests in config. Using flags instead.")
+		cfg.LogicalQuota = []test_suite.TestConfig{
+			{
+				TestBucket:          setup.TestBucket(),
+				GKEMountedDirectory: setup.MountedDirectory(),
+				LogFile:             setup.LogFile(),
+				Configs: []test_suite.ConfigItem{
+					{
+						Flags:      []string{fmt.Sprintf("--only-dir=%s --experimental-max-size-mb=5", sizeQuotaPrefix)},
+						Compatible: map[string]bool{"flat": true, "hns": true, "zonal": true},
+						Run:        "TestSizeQuota",
+					},
+					{
+						Flags:      []string{fmt.Sprintf("--only-dir=%s --experimental-max-file-count=2", fileCountQuotaPrefix)},
+						Compatible: map[string]bool{"flat": true, "hns": true, "zonal": true},
+						Run:        "TestFileCountQuota",
+					},
+				},
+			},
+		}
+	}
+
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.LogicalQuota[0])
+	testEnv.cfg = &cfg.LogicalQuota[0]
+
+	var err error
+	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
+	if err != nil {
+		log.Printf("Error creating storage client: %v\n", err)
+		os.Exit(1)
+	}
+	defer testEnv.storageClient.Close()
+
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		log.Println("Skipping logical_quota tests for pre-mounted directory; tests require quota flags at mount time.")
+		os.Exit(0)
+	}
+
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+
+	successCode := m.Run()
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, sizeQuotaPrefix))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, fileCountQuotaPrefix))
+	setup.SaveLogFileInCaseOfFailure(successCode)
+	os.Exit(successCode)
+}

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -125,6 +125,7 @@ TEST_DIR_PARALLEL=(
   "flag_optimizations"
   "unsupported_path"
   "symlink_handling"
+  "logical_quota"
 )
 
 # These tests never become parallel as it is changing bucket permissions.
@@ -166,6 +167,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "flag_optimizations"
   "unsupported_path"
   "symlink_handling"
+  "logical_quota"
 )
 
 # Subset of TEST_DIR_NON_PARALLEL,

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1066,6 +1066,29 @@ symlink_handling:
           zonal: true
         run_on_gke: true
 
+logical_quota:
+  - mounted_directory: "${MOUNTED_DIR}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - run: TestSizeQuota
+        flags:
+          - "--only-dir=LogicalQuotaSizeTest --experimental-max-size-mb=5"
+          - "--only-dir=LogicalQuotaSizeTest --experimental-max-size-mb=5 --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - run: TestFileCountQuota
+        flags:
+          - "--only-dir=LogicalQuotaFileCountTest --experimental-max-file-count=2"
+          - "--only-dir=LogicalQuotaFileCountTest --experimental-max-file-count=2 --client-protocol=grpc"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+
 buffered_read:
   - mounted_directory: "${MOUNTED_DIR}"
     test_bucket: "${BUCKET_NAME}"

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -89,6 +89,7 @@ type Config struct {
 	ReleaseVersion        []TestConfig `yaml:"release_version"`
 	Mounting              []TestConfig `yaml:"mounting"`
 	NegativeStatCache     []TestConfig `yaml:"negative_stat_cache"`
+	LogicalQuota          []TestConfig `yaml:"logical_quota"`
 }
 
 // ReadConfigFile returns a Config struct from the YAML file.


### PR DESCRIPTION
## Summary

Adds hidden experimental logical quota guardrails for a single Cloud Storage FUSE mount process:

- `--experimental-max-size-mb`
- `--experimental-max-file-count`

When enabled, the mount performs a cold-start metadata scan of the mounted bucket or `--only-dir` prefix, tracks logical usage in memory for operations through this process, reports bounded `StatFS` capacity/inode counts, and returns `ENOSPC` when local accounting says the configured limit is exhausted.

## Notes

This is intentionally mount-local and best-effort. It does not coordinate across mounts, reconcile external GCS mutations after mount, or limit local cache/temp disk usage.

Unsupported all-buckets mounts fail at startup with a clear error because there is no single namespace to scan or account. `--only-dir` is supported and tested; the quota scan is scoped to the mounted prefix.

## Validation

- `go generate ./...`
- `go test ./cfg`
- `go test ./internal/fs -run 'TestLogicalQuota|TestCacheDirVolumeBlockSize'`
- `go test ./tools/integration_tests/logical_quota -run '^$'`
- `git diff --check`
- live targeted e2e:
  - `logical_quota` flat bucket: passed
  - `logical_quota` HNS bucket: passed
