### PR TITLE
feat(tracing): add read.offset attribute and read.size attributes to fs.file.read traces

### DIFF
--- a/internal/fs/wrappers/tracing.go
+++ b/internal/fs/wrappers/tracing.go
@@ -130,7 +130,14 @@ func (fs *tracedFS) OpenFile(ctx context.Context, op *fuseops.OpenFileOp) error 
 }
 
 func (fs *tracedFS) ReadFile(ctx context.Context, op *fuseops.ReadFileOp) error {
-	return fs.invokeWrapped(ctx, tracing.ReadFile, func(ctx context.Context) error { return fs.wrapped.ReadFile(ctx, op) })
+	ctx, span := fs.traceHandle.StartServerSpan(ctx, tracing.ReadFile)
+	defer fs.traceHandle.EndSpan(span)
+	err := fs.wrapped.ReadFile(ctx, op)
+	if err != nil {
+		fs.traceHandle.RecordError(span, err)
+	}
+	fs.traceHandle.SetReadFileAttributes(span, op.BytesRead, op.Offset)
+	return err
 }
 
 func (fs *tracedFS) WriteFile(ctx context.Context, op *fuseops.WriteFileOp) error {

--- a/internal/fs/wrappers/tracing_test.go
+++ b/internal/fs/wrappers/tracing_test.go
@@ -16,12 +16,14 @@ package wrappers
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 	"go.opentelemetry.io/otel/trace"
@@ -184,4 +186,73 @@ func TestSpanCreation(t *testing.T) {
 	require.Len(t, ss, 1)
 	assert.Equal(t, "fs.stat_fs", ss[0].Name)
 	assert.Equal(t, trace.SpanKindServer, ss[0].SpanKind)
+}
+
+type mockReadFileFS struct {
+	dummyFS
+	bytesToRead int
+	errToReturn error
+}
+
+func (m mockReadFileFS) ReadFile(_ context.Context, op *fuseops.ReadFileOp) error {
+	op.BytesRead = m.bytesToRead
+	return m.errToReturn
+}
+
+func TestReadFileSpanAttributes(t *testing.T) {
+	testCases := []struct {
+		name         string
+		bytesToRead  int
+		offset       int64
+		errToReturn  error
+		expectedSize int
+	}{
+		{
+			name:         "Success",
+			bytesToRead:  2048,
+			offset:       512,
+			errToReturn:  nil,
+			expectedSize: 2048,
+		},
+		{
+			name:         "Error",
+			bytesToRead:  0,
+			offset:       1024,
+			errToReturn:  errors.New("read failure"),
+			expectedSize: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ex := newInMemoryExporter(t)
+			t.Cleanup(func() {
+				ex.Reset()
+			})
+			m := tracedFS{
+				wrapped: mockReadFileFS{
+					bytesToRead: tc.bytesToRead,
+					errToReturn: tc.errToReturn,
+				},
+				traceHandle: tracing.NewOTELTracer(),
+			}
+
+			op := &fuseops.ReadFileOp{
+				Offset: tc.offset,
+			}
+			err := m.ReadFile(context.Background(), op)
+			if tc.errToReturn != nil {
+				assert.ErrorIs(t, err, tc.errToReturn)
+			} else {
+				assert.NoError(t, err)
+			}
+
+			ss := ex.GetSpans()
+			require.Len(t, ss, 1)
+			assert.Equal(t, tracing.ReadFile, ss[0].Name)
+			assert.Equal(t, trace.SpanKindServer, ss[0].SpanKind)
+			assert.Contains(t, ss[0].Attributes, attribute.Int(tracing.BYTES_READ, tc.expectedSize))
+			assert.Contains(t, ss[0].Attributes, attribute.Int64(tracing.READ_OFFSET, tc.offset))
+		})
+	}
 }

--- a/tracing/benchmark_test.go
+++ b/tracing/benchmark_test.go
@@ -120,6 +120,16 @@ func BenchmarkTrace(b *testing.B) {
 			th.EndSpan(span)
 		})
 
+		b.Run(fmt.Sprintf("BenchmarkSetReadFileAttributes_%s", prefix), func(b *testing.B) {
+			ctx := context.Background()
+
+			_, span := th.StartSpan(ctx, "TestSpanName")
+			for b.Loop() {
+				th.SetReadFileAttributes(span, 100, 500)
+			}
+			th.EndSpan(span)
+		})
+
 		b.Run(fmt.Sprintf("BenchmarkSetUploadAttributes_%s", prefix), func(b *testing.B) {
 			ctx := context.Background()
 

--- a/tracing/noop_tracer.go
+++ b/tracing/noop_tracer.go
@@ -41,6 +41,8 @@ func (*noopTracer) RecordError(span trace.Span, err error) {}
 
 func (o *noopTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int) {}
 
+func (o *noopTracer) SetReadFileAttributes(span trace.Span, bytesRead int, offset int64) {}
+
 func (o *noopTracer) SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string) {}
 
 func (*noopTracer) TraceUpload(ctx context.Context, name string, objName string, bytes *int64, err *error) (context.Context, func()) {

--- a/tracing/otel_tracer.go
+++ b/tracing/otel_tracer.go
@@ -31,6 +31,7 @@ type otelTracer struct {
 
 var (
 	bytesReadKey     = attribute.Key(BYTES_READ)
+	readOffsetKey    = attribute.Key(READ_OFFSET)
 	bytesUploadedKey = attribute.Key(BYTES_UPLOADED)
 	objectNameKey    = attribute.Key(OBJECT_NAME)
 	cacheHit         = attribute.Bool(IS_CACHE_HIT, true)
@@ -64,6 +65,15 @@ func (o *otelTracer) SetCacheReadAttributes(span trace.Span, isCacheHit bool, by
 	} else {
 		attrSet[1] = cacheMiss
 	}
+	span.SetAttributes(attrSet...)
+}
+
+func (o *otelTracer) SetReadFileAttributes(span trace.Span, bytesRead int, offset int64) {
+	attrSetPtr := o.slicePool.Get().(*[]attribute.KeyValue)
+	attrSet := *attrSetPtr
+	defer o.slicePool.Put(attrSetPtr)
+	attrSet[0] = bytesReadKey.Int(bytesRead)
+	attrSet[1] = readOffsetKey.Int64(offset)
 	span.SetAttributes(attrSet...)
 }
 

--- a/tracing/otel_tracer_test.go
+++ b/tracing/otel_tracer_test.go
@@ -124,6 +124,26 @@ func TestOtelTracer_SetCacheReadAttributes(t *testing.T) {
 	}
 }
 
+func TestOtelTracer_SetReadFileAttributes(t *testing.T) {
+	recorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))
+	otel.SetTracerProvider(provider)
+	tracer := NewOTELTracer()
+	spanName := "test-read-file-span"
+	bytesRead := 4096
+	offset := int64(1024)
+
+	_, span := tracer.StartSpan(context.Background(), spanName)
+	tracer.SetReadFileAttributes(span, bytesRead, offset)
+	tracer.EndSpan(span)
+
+	spans := recorder.Ended()
+	assert.Len(t, spans, 1)
+	assert.Len(t, spans[0].Attributes(), 2)
+	assert.Contains(t, spans[0].Attributes(), attribute.Int(BYTES_READ, bytesRead))
+	assert.Contains(t, spans[0].Attributes(), attribute.Int64(READ_OFFSET, offset))
+}
+
 func TestOtelTracer_PropagateTraceContext(t *testing.T) {
 	recorder := tracetest.NewSpanRecorder()
 	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(recorder))

--- a/tracing/span_attributes.go
+++ b/tracing/span_attributes.go
@@ -17,6 +17,7 @@ package tracing
 const (
 	IS_CACHE_HIT   = "cache.hit"         // Indicates if the response was served from cache or not.
 	BYTES_READ     = "read.size"         // Indicates the number of bytes read from the given reader
+	READ_OFFSET    = "read.offset"       // Indicates the file offset for the read operation
 	BYTES_UPLOADED = "write.chunk.size"  // Indicates the number of bytes uploaded
 	OBJECT_NAME    = "write.object_name" // Indicates the object name uploaded
 )

--- a/tracing/trace_handle.go
+++ b/tracing/trace_handle.go
@@ -43,6 +43,9 @@ type TraceHandle interface {
 	// This allows skipping the attribute creation entirely in case of noop tracer which is selected when tracing is disabled.
 	SetCacheReadAttributes(span trace.Span, isCacheHit bool, bytesRead int)
 
+	// A handle interface method to set attributes for read file operations (read.size and read.offset)
+	SetReadFileAttributes(span trace.Span, bytesRead int, offset int64)
+
 	// A handle interface method to set attributes for upload
 	SetUploadAttributes(span trace.Span, bytesUploaded int64, objectName string)
 


### PR DESCRIPTION
### Description
Record read.size and read.offset as span attributes for fs.read.file spans.

Imagine that we want to check whether read-ahead-kb is taking effect or not. The size of the reads issued will help us get to that. Offsets are generally not useful though but at a sampling ratio of 1.0, this can actually help characterize the workload exactly

<img width="2507" height="1286" alt="image" src="https://github.com/user-attachments/assets/d3fb6cc8-d5c6-45b7-8f6c-ae58240050e4" />

### Perf

| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   | 529.44MiB/s  | 1.19MiB/s  |  75.98MiB/s  |  1.21MiB/s   |
|   PR   |  0.25MiB   | 528.85MiB/s  | 1.21MiB/s  |  78.14MiB/s  |  1.32MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 48.828MiB  | 4546.16MiB/s | 76.55MiB/s | 1466.18MiB/s |  78.41MiB/s  |
|   PR   | 48.828MiB  | 4494.36MiB/s | 78.57MiB/s | 1473.01MiB/s |  78.1MiB/s   |
|        |            |              |            |              |              |
|        |            |              |            |              |              |
| Master | 976.562MiB | 4510.65MiB/s | 35.26MiB/s | 492.15MiB/s  |  37.71MiB/s  |
|   PR   | 976.562MiB | 4494.53MiB/s | 37.55MiB/s | 797.54MiB/s  |  40.26MiB/s  |

### Link to the issue in case of a bug fix.
b/529233052

### Testing details
1. Manual - tested by running a workload
2. Unit tests - Added
3. Integration tests - Executed

### Any backward incompatible change? If so, please explain.
N/A