### PR TITLE
test(pirlo): Add tests to validate the finalization logic and metadata eventual consistency for Rapid bucket

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -426,7 +426,7 @@ TEST_DIR_PARALLEL_ZONAL=(
   mounting
   negative_stat_cache
   operations
-  rapid_appends
+  rapid_operations
   read_large_files
   # Reenable when b/461334834 is done.
   # readdirplus

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -385,7 +385,7 @@ filter_array() {
 # Test packages for regional buckets.
 TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "inactive_stream_timeout" "cloud_profiler" "requester_pays_bucket")
 # Test packages for zonal buckets.
-TEST_PACKAGES_FOR_ZB=("${TEST_PACKAGES_COMMON[@]}" "rapid_appends" "unfinalized_object")
+TEST_PACKAGES_FOR_ZB=("${TEST_PACKAGES_COMMON[@]}" "rapid_operations" "unfinalized_object")
 # Test packages for TPC buckets.
 TEST_PACKAGES_FOR_TPC=("operations")
 

--- a/tools/integration_tests/rapid_operations/appends_test.go
+++ b/tools/integration_tests/rapid_operations/appends_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid_appends
+package rapid_operations
 
 import (
 	"os"

--- a/tools/integration_tests/rapid_operations/finalize_test.go
+++ b/tools/integration_tests/rapid_operations/finalize_test.go
@@ -1,0 +1,76 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rapid_operations
+
+import (
+	"path"
+	"strings"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func (t *FinalizeRapidWritesTestSuite) TestFileClosedInFinalizedState() {
+	if !t.isFinalizeEnabled {
+		t.T().Skip("Skipping test since finalize-file-for-rapid is false")
+	}
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
+	defer t.deleteUnfinalizedObject()
+	initialContent := "test content"
+	bucket := testEnv.storageClient.Bucket(testEnv.cfg.TestBucket)
+	objHandle := bucket.Object(path.Join(testDirName, t.fileName))
+
+	operations.CreateFileWithContent(filePath, operations.FilePermission_0600, initialContent, t.T())
+
+	attrs, err := objHandle.Attrs(testEnv.ctx)
+	require.NoError(t.T(), err)
+	assert.False(t.T(), attrs.Finalized.IsZero(), "Finalized field should not be zero for a finalized object")
+}
+
+func (t *FinalizeRapidWritesTestSuite) TestFileClosedInUnfinalizedState() {
+	if t.isFinalizeEnabled {
+		t.T().Skip("Skipping test since finalize-file-for-rapid is true")
+	}
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
+	defer t.deleteUnfinalizedObject()
+	initialContent := "test content"
+	bucket := testEnv.storageClient.Bucket(testEnv.cfg.TestBucket)
+	objHandle := bucket.Object(path.Join(testDirName, t.fileName))
+
+	operations.CreateFileWithContent(filePath, operations.FilePermission_0600, initialContent, t.T())
+
+	attrs, err := objHandle.Attrs(testEnv.ctx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), attrs.Finalized.IsZero(), "Finalized field should be zero for an unfinalized object")
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Runner
+////////////////////////////////////////////////////////////////////////
+
+func TestFinalizeRapidWritesTestSuite(t *testing.T) {
+	RunTests(t, "TestFinalizeRapidWritesTestSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
+		return &FinalizeRapidWritesTestSuite{
+			BaseSuite:         BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+			isFinalizeEnabled: strings.Contains(strings.Join(primaryFlags, " "), "finalize-file-for-rapid=true"),
+		}
+	})
+}

--- a/tools/integration_tests/rapid_operations/helpers_test.go
+++ b/tools/integration_tests/rapid_operations/helpers_test.go
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rapid_operations
+
+import (
+	"math/rand/v2"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
+)
+
+func (t *BaseSuite) createGCSFile(useAppendableAPI bool, fileSize int64) (filePath string, content []byte) {
+	t.T().Helper()
+
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	filePath = path.Join(t.primaryMount.testDirPath, t.fileName)
+	content, err := operations.GenerateRandomData(fileSize)
+	require.NoError(t.T(), err)
+
+	// Create file directly in GCS using Go SDK with the chosen API.
+	err = client.CreateObjectWithAPI(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, t.fileName), content, useAppendableAPI)
+	require.NoError(t.T(), err)
+	return filePath, content
+}
+
+// declare a function type for read and verify
+type readAndVerifyFunc func(t *testing.T, filePath string, expectedContent []byte)
+
+func readSequentiallyAndVerify(t *testing.T, filePath string, expectedContent []byte) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, setup.FilePermission_0600)
+	require.NoError(t, err)
+	readContent, err := operations.ReadFileSequentially(file, 1024*1024)
+
+	// For sequential reads, we expect the content to be exactly as expected.
+	require.NoErrorf(t, err, "failed to read file %q sequentially: %v", filePath, err)
+	require.Equal(t, expectedContent, readContent)
+}
+
+func readRandomlyAndVerify(t *testing.T, filePath string, expectedContent []byte) {
+	file, err := os.OpenFile(filePath, os.O_RDONLY, setup.FilePermission_0600)
+	require.NoErrorf(t, err, "failed to open file %q: %v", filePath, err)
+	defer operations.CloseFileShouldNotThrowError(t, file) // This line is already correct.
+	if len(expectedContent) == 0 {
+		t.SkipNow()
+	}
+	fileInfo, err := file.Stat()
+	require.NoError(t, err)
+	fileSize := fileInfo.Size()
+	require.GreaterOrEqualf(t, fileSize, int64(len(expectedContent)), "file %q is too small to read %d bytes", filePath, len(expectedContent))
+
+	// Content to be read from [0, maxOffset) .
+	maxOffset := len(expectedContent)
+	// Limit number of reads if the content to read is too small.
+	numReads := min(maxOffset, 10)
+	for i := range numReads {
+		// Ensure offset <= maxOffset-1 .
+		offset := rand.IntN(maxOffset)
+		// Ensure (offset+readSize) <= maxOffset and readSize >= 1.
+		readSize := rand.IntN(maxOffset-offset) + 1
+		buffer := make([]byte, readSize)
+
+		n, err := file.ReadAt(buffer, int64(offset))
+
+		require.NoErrorf(t, err, "Random-read failed at iter#%d to read file %q at [%d, %d): %v", i, filePath, offset, offset+readSize, err)
+		require.Equalf(t, readSize, n, "failed to read %v bytes from %q at offset %v. Read bytes = %v.", readSize, filePath, offset, n)
+		require.Equalf(t, expectedContent[offset:offset+n], buffer[:n], "content mismatch in random read at iter#%d at offset [%d, %d): expected %q, got %q", i, offset, offset+readSize, expectedContent[offset:offset+n], buffer[:n])
+	}
+}

--- a/tools/integration_tests/rapid_operations/read_routing_test.go
+++ b/tools/integration_tests/rapid_operations/read_routing_test.go
@@ -1,0 +1,67 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// limitations under the License.
+
+package rapid_operations
+
+import (
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/stretchr/testify/suite"
+)
+
+const (
+	fileSizeForReadRouting = 50 * operations.OneMiB
+)
+
+// ReadRoutingTestSuite groups all tests related to read routing across different topologies.
+type ReadRoutingTestSuite struct {
+	BaseSuite
+}
+
+////////////////////////////////////////////////////////////////////////
+// Tests
+////////////////////////////////////////////////////////////////////////
+
+func (t *ReadRoutingTestSuite) TestSequentialReadAfterAppendableUpload() {
+	filePath, expectedContent := t.createGCSFile(true, fileSizeForReadRouting)
+
+	readSequentiallyAndVerify(t.T(), filePath, expectedContent)
+}
+
+func (t *ReadRoutingTestSuite) TestRandomReadAfterAppendableUpload() {
+	filePath, expectedContent := t.createGCSFile(true, fileSizeForReadRouting)
+
+	readRandomlyAndVerify(t.T(), filePath, expectedContent)
+}
+
+func (t *ReadRoutingTestSuite) TestSequentialReadAfterResumableUpload() {
+	filePath, expectedContent := t.createGCSFile(false, fileSizeForReadRouting)
+
+	readSequentiallyAndVerify(t.T(), filePath, expectedContent)
+}
+
+func (t *ReadRoutingTestSuite) TestRandomReadAfterResumableUpload() {
+	filePath, expectedContent := t.createGCSFile(false, fileSizeForReadRouting)
+
+	readRandomlyAndVerify(t.T(), filePath, expectedContent)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Runner
+////////////////////////////////////////////////////////////////////////
+
+func TestReadRoutingTestSuite(t *testing.T) {
+	RunTests(t, "ReadRoutingTestSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
+		return &ReadRoutingTestSuite{BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags}}
+	})
+}

--- a/tools/integration_tests/rapid_operations/reads_after_appends_test.go
+++ b/tools/integration_tests/rapid_operations/reads_after_appends_test.go
@@ -12,11 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid_appends
+package rapid_operations
 
 import (
-	"math/rand/v2"
-	"os"
 	"path"
 	"syscall"
 	"testing"
@@ -24,57 +22,8 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
-
-////////////////////////////////////////////////////////////////////////
-// Helpers
-////////////////////////////////////////////////////////////////////////
-
-// declare a function type for read and verify
-type readAndVerifyFunc func(t *testing.T, filePath string, expectedContent []byte)
-
-func readSequentiallyAndVerify(t *testing.T, filePath string, expectedContent []byte) {
-	file, err := os.OpenFile(filePath, os.O_RDONLY, setup.FilePermission_0600)
-	require.NoError(t, err)
-	readContent, err := operations.ReadFileSequentially(file, 1024*1024)
-
-	// For sequential reads, we expect the content to be exactly as expected.
-	require.NoErrorf(t, err, "failed to read file %q sequentially: %v", filePath, err)
-	require.Equal(t, expectedContent, readContent)
-}
-
-func readRandomlyAndVerify(t *testing.T, filePath string, expectedContent []byte) {
-	file, err := os.OpenFile(filePath, os.O_RDONLY, setup.FilePermission_0600)
-	require.NoErrorf(t, err, "failed to open file %q: %v", filePath, err)
-	defer operations.CloseFileShouldNotThrowError(t, file) // This line is already correct.
-	if len(expectedContent) == 0 {
-		t.SkipNow()
-	}
-	fileInfo, err := file.Stat()
-	require.NoError(t, err)
-	fileSize := fileInfo.Size()
-	require.GreaterOrEqualf(t, fileSize, int64(len(expectedContent)), "file %q is too small to read %d bytes", filePath, len(expectedContent))
-
-	// Content to be read from [0, maxOffset) .
-	maxOffset := len(expectedContent)
-	// Limit number of reads if the content to read is too small.
-	numReads := min(maxOffset, 10)
-	for i := range numReads {
-		// Ensure offset <= maxOffset-1 .
-		offset := rand.IntN(maxOffset)
-		// Ensure (offset+readSize) <= maxOffset and readSize >= 1.
-		readSize := rand.IntN(maxOffset-offset) + 1
-		buffer := make([]byte, readSize)
-
-		n, err := file.ReadAt(buffer, int64(offset))
-
-		require.NoErrorf(t, err, "Random-read failed at iter#%d to read file %q at [%d, %d): %v", i, filePath, offset, offset+readSize, err)
-		require.Equalf(t, readSize, n, "failed to read %v bytes from %q at offset %v. Read bytes = %v.", readSize, filePath, offset, n)
-		require.Equalf(t, expectedContent[offset:offset+n], buffer[:n], "content mismatch in random read at iter#%d at offset [%d, %d): expected %q, got %q", i, offset, offset+readSize, expectedContent[offset:offset+n], buffer[:n])
-	}
-}
 
 ////////////////////////////////////////////////////////////////////////
 // Tests for the SingleMountReadsTestSuite

--- a/tools/integration_tests/rapid_operations/setup_test.go
+++ b/tools/integration_tests/rapid_operations/setup_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid_appends
+package rapid_operations
 
 import (
 	"context"
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	testDirName           = "RapidAppendsTest"
-	fileNamePrefix        = "rapid-append-file-"
+	testDirName           = "RapidOperationsTest"
+	fileNamePrefix        = "rapid-operations-file-"
 	contentSizeForBW      = 3
 	blockSize             = operations.OneMiB
 	numAppends            = 2
@@ -57,12 +57,12 @@ func TestMain(m *testing.M) {
 
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
-	if len(cfg.RapidAppends) == 0 {
+	if len(cfg.RapidOperations) == 0 {
 		log.Fatal("No configuration found for RapidAppends in config file.")
 	}
 
 	testEnv.ctx = context.Background()
-	testEnv.cfg = &cfg.RapidAppends[0]
+	testEnv.cfg = &cfg.RapidOperations[0]
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 	if !setup.IsZonalBucketRun() && !setup.IsPirloBucketRun() {
 		log.Fatalf("This test package is only compatible for zonal and pirlo bucket runs")
@@ -98,7 +98,7 @@ func TestMain(m *testing.M) {
 	}
 	testEnv.cfg.GCSFuseMountedDirectorySecondary = secondaryDir
 
-	log.Println("Running static mounting tests for rapid appends...")
+	log.Println("Running static mounting tests for rapid_operations...")
 	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/rapid_operations/stat_and_list_test.go
+++ b/tools/integration_tests/rapid_operations/stat_and_list_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rapid_operations
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func (t *StatAndListTestSuite) TestStatOfNewFile() {
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
+	defer t.deleteUnfinalizedObject()
+	expectedSize := int64(len("test content"))
+	client.CreateFinalizedObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "test content", t.T())
+
+	size := operations.RetryUntil(testEnv.ctx, t.T(), 2*time.Second, defaultMetadataCacheTTL, func() (int64, error) {
+		fi, err := os.Stat(filePath)
+		if err != nil {
+			return 0, err
+		}
+		if fi.Size() != expectedSize {
+			return 0, fmt.Errorf("expected size %d, got %d", expectedSize, fi.Size())
+		}
+		return fi.Size(), nil
+	})
+
+	require.Equal(t.T(), expectedSize, size)
+}
+
+func (t *StatAndListTestSuite) TestListOfNewFile() {
+	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
+	defer t.deleteUnfinalizedObject()
+	expectedSize := int64(len("test content"))
+	client.CreateFinalizedObjectInGCSTestDir(testEnv.ctx, testEnv.storageClient, testDirName, t.fileName, "test content", t.T())
+
+	size := operations.RetryUntil(testEnv.ctx, t.T(), 2*time.Second, defaultMetadataCacheTTL, func() (int64, error) {
+		entries, err := os.ReadDir(t.primaryMount.testDirPath)
+		if err != nil {
+			return 0, err
+		}
+		for _, entry := range entries {
+			if entry.Name() == t.fileName {
+				info, err := entry.Info()
+				if err != nil {
+					return 0, err
+				}
+				if info.Size() != expectedSize {
+					return 0, fmt.Errorf("listing expected size %d, got %d", expectedSize, info.Size())
+				}
+				return info.Size(), nil
+			}
+		}
+		return 0, fmt.Errorf("file not found in directory listing")
+	})
+
+	require.Equal(t.T(), expectedSize, size)
+}
+
+////////////////////////////////////////////////////////////////////////
+// Test Runner
+////////////////////////////////////////////////////////////////////////
+
+func TestStatAndListTestSuite(t *testing.T) {
+	RunTests(t, "TestStatAndListTestSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
+		return &StatAndListTestSuite{BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags}}
+	})
+}

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package rapid_appends
+package rapid_operations
 
 import (
 	"log"
@@ -43,7 +43,7 @@ const (
 type mountPoint struct {
 	rootDir     string // Root directory of the test folder, which contains mnt and gcsfuse.log.
 	mntDir      string // Directory where the GCS bucket is mounted. This is 'mnt' inside rootDir.
-	testDirPath string // Path to the 'RapidAppendsTest' directory inside mntDir.
+	testDirPath string // Path to the 'RapidOperationsTest' directory inside mntDir.
 	logFilePath string // Path to the GCSFuse log file. This is gcsfuse.log inside rootDir.
 }
 
@@ -70,6 +70,15 @@ type SingleMountAppendsTestSuite struct{ BaseSuite }
 
 // DualMountAppendsTestSuite groups general dual-mount tests for append behavior.
 type DualMountAppendsTestSuite struct{ BaseSuite }
+
+// FinalizeRapidWritesTestSuite groups tests for verifying transition to finalized state.
+type FinalizeRapidWritesTestSuite struct {
+	BaseSuite
+	isFinalizeEnabled bool
+}
+
+// StatAndListTestSuite groups tests for checking new file discovery.
+type StatAndListTestSuite struct{ BaseSuite }
 
 ////////////////////////////////////////////////////////////////////////
 // Common Suite Logic

--- a/tools/integration_tests/run_e2e_tests.sh
+++ b/tools/integration_tests/run_e2e_tests.sh
@@ -152,7 +152,7 @@ TEST_DIR_PARALLEL_FOR_ZB=(
   "mounting"
   "negative_stat_cache"
   "operations"
-  "rapid_appends"
+  "rapid_operations"
   "read_cache"
   "read_large_files"
   "rename_dir_limit"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1707,7 +1707,7 @@ kernel_list_cache:
         run: "TestDisabledKernelListCacheTest"
         run_on_gke: true
 
-rapid_appends:
+rapid_operations:
   - mounted_directory: "${MOUNTED_DIR}"
     mounted_directory_secondary: "${MOUNTED_DIR_SECONDARY}"
     test_bucket: "${BUCKET_NAME}"
@@ -1856,6 +1856,57 @@ rapid_appends:
           hns:
             same_zone: true
             different_zone: false
+        run_on_gke: true
+      - run: TestFinalizeRapidWritesTestSuite
+        flags:
+          - "--finalize-file-for-rapid=true"
+          - "--finalize-file-for-rapid=false"
+        compatible:
+          flat: false
+          hns: false
+          zonal: true
+        run_on_gke: true
+      - run: TestFinalizeRapidWritesTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+      - run: TestStatAndListTestSuite
+        flags:
+          - "--metadata-cache-ttl-secs=0"
+        compatible:
+          flat: false
+          hns: false
+          zonal: true
+        run_on_gke: true
+      - run: TestStatAndListTestSuite
+        flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+      - run: ReadRoutingTestSuite
+        flags:
+          - "--experimental-enable-pirlo"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: true
+          hns:
+            same_zone: true
+            different_zone: true
         run_on_gke: true
 
 monitoring:

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -277,6 +277,24 @@ func CreateFinalizedObjectOnGCS(ctx context.Context, client *storage.Client, obj
 	return nil
 }
 
+// CreateObjectWithAPI creates an object on GCS with the given content, allowing the choice of whether to use the appendable API.
+func CreateObjectWithAPI(ctx context.Context, client *storage.Client, object string, content []byte, useAppendableAPI bool) error {
+	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
+	o := getBucketHandle(client, bucket).Object(object)
+
+	wc := o.NewWriter(ctx)
+	wc.Append = useAppendableAPI
+	wc.FinalizeOnClose = true
+
+	if _, err := wc.Write(content); err != nil {
+		return fmt.Errorf("wc.Write failed for object %q: %w", object, err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("wc.Close failed for object %q: %w", object, err)
+	}
+	return nil
+}
+
 // CreateStorageClientWithCancel creates a new storage client with a cancelable context and returns a function that can be used to cancel the client's operations
 func CreateStorageClientWithCancel(ctx *context.Context, storageClient **storage.Client) func() error {
 	var err error

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -114,7 +114,7 @@ type Config struct {
 	ReadGCSAlgo           []TestConfig `yaml:"read_gcs_algo"`
 	Interrupt             []TestConfig `yaml:"interrupt"`
 	UnfinalizedObject     []TestConfig `yaml:"unfinalized_object"`
-	RapidAppends          []TestConfig `yaml:"rapid_appends"`
+	RapidOperations       []TestConfig `yaml:"rapid_operations"`
 	MountTimeout          []TestConfig `yaml:"mount_timeout"`
 	Monitoring            []TestConfig `yaml:"monitoring"`
 	FlagOptimizations     []TestConfig `yaml:"flag_optimizations"`


### PR DESCRIPTION
### Description

This PR renames and generalizes the `rapid_appends` integration test package to `rapid` and introduces new test coverage for zonal bucket environments. 

**Key Changes:**
1. **Rename test package:** Renamed directories, packages, config structures, and test scripts from `rapid_appends` to `rapid` to represent a broader set of rapid validation tests.
2. **Add Finalize test suite:** Introduced `TestFinalizeRapidWritesTestSuite` in `tools/integration_tests/rapid/finalize_test.go` to verify file closure behaviors in both finalized and unfinalized states depending on the `--finalize-file-for-rapid` configuration.
3. **Add Stat & List test suite:** Added `TestStatAndListTestSuite` in `tools/integration_tests/rapid/stat_and_list_test.go` to validate that eventually we get correct size for objects created in the GCSFuse test directory through directory listing and stat operations.


### Link to the issue in case of a bug fix.
b/526451412, b/526451679,b/526451122

### Testing details
1. Manual - Verified by running on zonal bucket in same and different zones and flat and hns buckets.
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
