### PR TITLE
perf(stat-cache memory): storing expiry nanoseconds (int64) instead of time.Time

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -111,9 +111,9 @@ type statCacheBucketView struct {
 // An entry in the cache, pairing an object with the expiration time for the
 // entry. Nil object means negative entry.
 type entry struct {
-	m          *gcs.MinObject
-	f          *gcs.Folder
-	expiration time.Time
+	m            *gcs.MinObject
+	f            *gcs.Folder
+	expirationNS int64
 	// Set to true only for implicit directory entries. This flag will always remain false for negative entries and explicit objects.
 	implicitDir bool
 }
@@ -200,8 +200,8 @@ func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
 
 	// Insert an entry.
 	e := entry{
-		m:          m,
-		expiration: expiration,
+		m:            m,
+		expirationNS: expiration.UnixNano(),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -236,8 +236,8 @@ func (sc *statCacheBucketView) InsertImplicitDir(objectName string, expiration t
 
 	// Insert an entry.
 	e := entry{
-		implicitDir: true,
-		expiration:  expiration,
+		implicitDir:  true,
+		expirationNS: expiration.UnixNano(),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -250,8 +250,8 @@ func (sc *statCacheBucketView) AddNegativeEntry(objectName string, expiration ti
 
 	// Insert a negative entry.
 	e := entry{
-		m:          nil,
-		expiration: expiration,
+		m:            nil,
+		expirationNS: expiration.UnixNano(),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -264,8 +264,8 @@ func (sc *statCacheBucketView) AddNegativeEntryForFolder(folderName string, expi
 
 	// Insert a negative entry.
 	e := entry{
-		f:          nil,
-		expiration: expiration,
+		f:            nil,
+		expirationNS: expiration.UnixNano(),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -315,7 +315,7 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 	e := value.(entry)
 
 	// Has this entry expired?
-	if e.expiration.Before(now) {
+	if e.expirationNS < now.UnixNano() {
 		sc.Erase(key)
 		return false, nil
 	}
@@ -327,8 +327,8 @@ func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time)
 	name := sc.key(f.Name)
 
 	e := entry{
-		f:          f,
-		expiration: expiration,
+		f:            f,
+		expirationNS: expiration.UnixNano(),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {

--- a/internal/cache/metadata/stat_cache_benchmark_test.go
+++ b/internal/cache/metadata/stat_cache_benchmark_test.go
@@ -1,0 +1,84 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+)
+
+func BenchmarkStatCache_Insert(b *testing.B) {
+	lc := lru.NewCache(util.MiBsToBytes(100))
+	sc := metadata.NewStatCacheBucketView(lc, "")
+	expiration := time.Now().Add(time.Hour)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		name := fmt.Sprintf("file-%d", i)
+		m := &gcs.MinObject{
+			Name: name,
+			Size: 100,
+		}
+		sc.Insert(m, expiration)
+	}
+}
+
+func BenchmarkStatCache_AddNegativeEntry(b *testing.B) {
+	lc := lru.NewCache(util.MiBsToBytes(100))
+	sc := metadata.NewStatCacheBucketView(lc, "")
+	expiration := time.Now().Add(time.Hour)
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		name := fmt.Sprintf("file-%d", i)
+		sc.AddNegativeEntry(name, expiration)
+	}
+}
+
+func BenchmarkStatCache_LookUp(b *testing.B) {
+	lc := lru.NewCache(util.MiBsToBytes(100))
+	sc := metadata.NewStatCacheBucketView(lc, "")
+	expiration := time.Now().Add(time.Hour)
+
+	// Pre-populate
+	for i := 0; i < 10000; i++ {
+		name := fmt.Sprintf("file-%d", i)
+		m := &gcs.MinObject{
+			Name: name,
+			Size: 100,
+		}
+		sc.Insert(m, expiration)
+	}
+
+	now := time.Now()
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		name := fmt.Sprintf("file-%d", i%10000)
+		sc.LookUp(name, now)
+	}
+}


### PR DESCRIPTION
### Description
- Stat cache entries stores expiration time as time.Time struct (24 bytes), which is used to check expiry. This seems redundant and only storing the expirationNs-int64 (8 bytes) will be enough to check expiration. Saves 16bytes per entry.
- Without change:
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata
cpu: AMD EPYC 7B13
BenchmarkStatCache_Insert-64                     1724638               749.4 ns/op           299 B/op          6 allocs/op
BenchmarkStatCache_AddNegativeEntry-64           1679168               677.1 ns/op           224 B/op          5 allocs/op
BenchmarkStatCache_LookUp-64                     5474361               214.5 ns/op            71 B/op          2 allocs/op
```
- With change:
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata
cpu: AMD EPYC 7B13
BenchmarkStatCache_Insert-64                     1714723               745.1 ns/op           283 B/op          6 allocs/op
BenchmarkStatCache_AddNegativeEntry-64           2020422               647.2 ns/op           204 B/op          5 allocs/op
BenchmarkStatCache_LookUp-64                     6030410               195.4 ns/op            55 B/op          2 allocs/op
```

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
