### PR TITLE
feat(Improvements): Migrate caching, base_dir, util, and symlink test to testify and improvements

### DIFF
--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -72,7 +72,7 @@ func Test_CreateFile_FileDirNotPresent(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -95,7 +95,7 @@ func Test_CreateFile_FileDirPresent(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
@@ -107,7 +107,7 @@ func Test_CreateFile_ReadOnlyFile(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -126,7 +126,7 @@ func Test_CreateFile_ReadWriteFile(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -146,7 +146,7 @@ func Test_CreateFile_FilePerm0755(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -158,7 +158,7 @@ func Test_CreateFile_FilePerm0544(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -174,7 +174,7 @@ func Test_CreateFile_FilePresent(t *testing.T) {
 
 	file, err = CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
@@ -204,11 +204,11 @@ func Test_CreateFile_RelativePath(t *testing.T) {
 	uid := os.Getuid()
 	gid := os.Getgid()
 
-	defer os.RemoveAll("./some")
+	defer func() { _ = os.RemoveAll("./some") }()
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer file.Close()
+		defer func() { _ = file.Close() }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -72,7 +72,7 @@ func Test_CreateFile_FileDirNotPresent(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -95,7 +95,7 @@ func Test_CreateFile_FileDirPresent(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
@@ -107,7 +107,7 @@ func Test_CreateFile_ReadOnlyFile(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -126,7 +126,7 @@ func Test_CreateFile_ReadWriteFile(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -146,7 +146,7 @@ func Test_CreateFile_FilePerm0755(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -158,7 +158,7 @@ func Test_CreateFile_FilePerm0544(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
@@ -174,7 +174,7 @@ func Test_CreateFile_FilePresent(t *testing.T) {
 
 	file, err = CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
@@ -208,7 +208,7 @@ func Test_CreateFile_RelativePath(t *testing.T) {
 
 	file, err := CreateFile(fileSpec, flag)
 	if err == nil {
-		defer func() { _ = file.Close() }()
+		defer func() { assert.NoError(t, file.Close()) }()
 	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -31,7 +32,6 @@ import (
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 const FileName = "foo.txt"
@@ -578,6 +578,7 @@ func Test_CopyUsingMemoryAlignedBuffer(t *testing.T) {
 			content := testutil.GenerateRandomBytes(int(tc.contentSize))
 			src := bytes.NewReader(content)
 			ctx, cancelCtx := context.WithCancel(context.Background())
+			defer cancelCtx()
 			if tc.cancelCtx {
 				cancelCtx()
 			}

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -29,179 +29,176 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
-	. "github.com/jacobsa/ogletest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
-func TestUtil(t *testing.T) { RunTests(t) }
-
-type utilTest struct {
-	fileSpec data.FileSpec
-	flag     int
-	uid      int
-	gid      int
-}
-
-const FileDir = "/some/dir/"
 const FileName = "foo.txt"
 
-func init() { RegisterTestSuite(&utilTest{}) }
-
-func (ut *utilTest) SetUp(*TestInfo) {
-	operations.RemoveDir(FileDir)
-	ut.flag = os.O_RDWR
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		panic(fmt.Errorf("error while finding home directory: %w", err))
-	}
-	ut.fileSpec = data.FileSpec{
-		Path:     path.Join(homeDir, FileDir, FileName),
+func setupUtilTest(t *testing.T) (data.FileSpec, int, int, int) {
+	tempDir := t.TempDir()
+	fileSpec := data.FileSpec{
+		Path:     path.Join(tempDir, "subdir", FileName), // "subdir" does not exist yet
 		FilePerm: DefaultFilePerm,
 		DirPerm:  DefaultDirPerm,
 	}
-	ut.uid = os.Getuid()
-	ut.gid = os.Getgid()
+	flag := os.O_RDWR
+	uid := os.Getuid()
+	gid := os.Getgid()
+	return fileSpec, flag, uid, gid
 }
 
-func (ut *utilTest) TearDown() {
-	operations.RemoveDir(path.Dir(ut.fileSpec.Path))
-}
-
-func (ut *utilTest) assertFileAndDirCreationWithGivenDirPerm(file *os.File, err error, dirPerm os.FileMode) {
-	ExpectEq(nil, err)
+func assertFileAndDirCreationWithGivenDirPerm(t *testing.T, file *os.File, err error, fileSpec data.FileSpec, uid, gid int, dirPerm os.FileMode) {
+	require.NoError(t, err)
 
 	dirStat, dirErr := os.Stat(path.Dir(file.Name()))
-	ExpectEq(false, os.IsNotExist(dirErr))
-	ExpectEq(path.Dir(ut.fileSpec.Path), path.Dir(file.Name()))
-	ExpectEq(dirPerm, dirStat.Mode().Perm())
-	ExpectEq(ut.uid, dirStat.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(ut.gid, dirStat.Sys().(*syscall.Stat_t).Gid)
+	assert.False(t, os.IsNotExist(dirErr))
+	assert.Equal(t, path.Dir(fileSpec.Path), path.Dir(file.Name()))
+	assert.Equal(t, dirPerm, dirStat.Mode().Perm())
+	assert.Equal(t, uid, int(dirStat.Sys().(*syscall.Stat_t).Uid))
+	assert.Equal(t, gid, int(dirStat.Sys().(*syscall.Stat_t).Gid))
 
 	fileStat, fileErr := os.Stat(file.Name())
-	ExpectEq(false, os.IsNotExist(fileErr))
-	ExpectEq(ut.fileSpec.Path, file.Name())
-	ExpectEq(ut.fileSpec.FilePerm, fileStat.Mode())
-	ExpectEq(ut.uid, fileStat.Sys().(*syscall.Stat_t).Uid)
-	ExpectEq(ut.gid, fileStat.Sys().(*syscall.Stat_t).Gid)
+	assert.False(t, os.IsNotExist(fileErr))
+	assert.Equal(t, fileSpec.Path, file.Name())
+	assert.Equal(t, fileSpec.FilePerm, fileStat.Mode())
+	assert.Equal(t, uid, int(fileStat.Sys().(*syscall.Stat_t).Uid))
+	assert.Equal(t, gid, int(fileStat.Sys().(*syscall.Stat_t).Gid))
 }
 
-func (ut *utilTest) Test_CreateFile_FileDirNotPresent() {
+func Test_CreateFile_FileDirNotPresent(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	file, err := CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
-	ExpectEq(nil, file.Close())
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_ShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient() {
-	ut.fileSpec.DirPerm = 644
+func Test_CreateFile_ShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient(t *testing.T) {
+	fileSpec, flag, _, _ := setupUtilTest(t)
+	fileSpec.DirPerm = 0644 // No execute permission, cannot traverse
 
-	_, err := CreateFile(ut.fileSpec, ut.flag)
+	_, err := CreateFile(fileSpec, flag)
 
-	ExpectNe(nil, err)
-	ExpectEq("error in stating file "+ut.fileSpec.Path+": stat "+ut.fileSpec.Path+": permission denied", err.Error())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "permission denied")
 }
 
-func (ut *utilTest) Test_CreateFile_FileDirPresent() {
-	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
+func Test_CreateFile_FileDirPresent(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
+	err := os.MkdirAll(path.Dir(fileSpec.Path), 0755)
+	require.NoError(t, err)
 
-	ExpectEq(nil, err)
+	file, err := CreateFile(fileSpec, flag)
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
-
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0755)
-	ExpectEq(nil, file.Close())
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_ReadOnlyFile() {
-	ut.flag = os.O_RDONLY
+func Test_CreateFile_ReadOnlyFile(t *testing.T) {
+	fileSpec, _, uid, gid := setupUtilTest(t)
+	flag := os.O_RDONLY
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	file, err := CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
 	content := "foo"
 	_, err = file.Write([]byte(content))
-	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(err.Error(), "bad file descriptor"))
-	ExpectEq(nil, file.Close())
-	fileContent, err := os.ReadFile(ut.fileSpec.Path)
-	ExpectEq(nil, err)
-	ExpectEq("", string(fileContent))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "bad file descriptor")
+	assert.NoError(t, file.Close())
+
+	fileContent, err := os.ReadFile(fileSpec.Path)
+	assert.NoError(t, err)
+	assert.Equal(t, "", string(fileContent))
 }
 
-func (ut *utilTest) Test_CreateFile_ReadWriteFile() {
-	ut.flag = os.O_RDWR
+func Test_CreateFile_ReadWriteFile(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	file, err := CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
 	content := "foo"
 	n, err := file.Write([]byte(content))
-	ExpectEq(nil, err)
-	ExpectEq(3, n)
-	ExpectEq(nil, file.Close())
-	fileContent, err := os.ReadFile(ut.fileSpec.Path)
-	ExpectEq(nil, err)
-	ExpectEq(content, string(fileContent))
+	assert.NoError(t, err)
+	assert.Equal(t, 3, n)
+	assert.NoError(t, file.Close())
+
+	fileContent, err := os.ReadFile(fileSpec.Path)
+	assert.NoError(t, err)
+	assert.Equal(t, content, string(fileContent))
 }
 
-func (ut *utilTest) Test_CreateFile_FilePerm0755() {
-	ut.fileSpec.FilePerm = os.FileMode(0755)
+func Test_CreateFile_FilePerm0755(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
+	fileSpec.FilePerm = os.FileMode(0755)
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	file, err := CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
-	ExpectEq(nil, file.Close())
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_FilePerm0544() {
-	ut.fileSpec.FilePerm = os.FileMode(0544)
+func Test_CreateFile_FilePerm0544(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
+	fileSpec.FilePerm = os.FileMode(0544)
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	file, err := CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
-	ExpectEq(nil, file.Close())
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_FilePresent() {
-	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
-	ExpectEq(nil, err)
-	file, err := os.OpenFile(ut.fileSpec.Path, os.O_CREATE|os.O_RDWR, DefaultFilePerm)
-	ExpectEq(nil, err)
-	ExpectEq(nil, file.Close())
+func Test_CreateFile_FilePresent(t *testing.T) {
+	fileSpec, flag, uid, gid := setupUtilTest(t)
+	err := os.MkdirAll(path.Dir(fileSpec.Path), 0755)
+	require.NoError(t, err)
+	file, err := os.OpenFile(fileSpec.Path, os.O_CREATE|os.O_RDWR, DefaultFilePerm)
+	require.NoError(t, err)
+	assert.NoError(t, file.Close())
 
-	file, err = CreateFile(ut.fileSpec, ut.flag)
+	file, err = CreateFile(fileSpec, flag)
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0755)
-	ExpectEq(nil, file.Close())
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_CreateFile_FilePresentWithLessAccess() {
-	err := os.MkdirAll(path.Dir(ut.fileSpec.Path), 0755)
-	ExpectEq(nil, err)
-	file, err := os.OpenFile(ut.fileSpec.Path, os.O_CREATE, os.FileMode(0544))
-	ExpectEq(nil, err)
-	ExpectEq(nil, file.Close())
+func Test_CreateFile_FilePresentWithLessAccess(t *testing.T) {
+	fileSpec, flag, _, _ := setupUtilTest(t)
+	err := os.MkdirAll(path.Dir(fileSpec.Path), 0755)
+	require.NoError(t, err)
+	file, err := os.OpenFile(fileSpec.Path, os.O_CREATE, os.FileMode(0544))
+	require.NoError(t, err)
+	assert.NoError(t, file.Close())
 
-	_, err = CreateFile(ut.fileSpec, ut.flag)
+	_, err = CreateFile(fileSpec, flag)
 
-	ExpectNe(nil, err)
-	ExpectTrue(strings.Contains(strings.ToLower(err.Error()), "permission denied"))
+	assert.Error(t, err)
+	assert.Contains(t, strings.ToLower(err.Error()), "permission denied")
 }
 
-func (ut *utilTest) Test_CreateFile_RelativePath() {
-	ut.fileSpec.Path = "./some/path/foo.txt"
+func Test_CreateFile_RelativePath(t *testing.T) {
+	fileSpec := data.FileSpec{
+		Path:     "./some/path/foo.txt",
+		FilePerm: DefaultFilePerm,
+		DirPerm:  DefaultDirPerm,
+	}
+	flag := os.O_RDWR
+	uid := os.Getuid()
+	gid := os.Getgid()
 
-	file, err := CreateFile(ut.fileSpec, ut.flag)
+	defer os.RemoveAll("./some")
 
-	ut.assertFileAndDirCreationWithGivenDirPerm(file, err, 0700)
-	ExpectEq(nil, file.Close())
+	file, err := CreateFile(fileSpec, flag)
+
+	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
+	assert.NoError(t, file.Close())
 }
 
-func (ut *utilTest) Test_getObjectPath() {
+func Test_getObjectPath(t *testing.T) {
 	inputs := [][]string{{"", ""}, {"a", "b"}, {"a/b/", "/c/d"}, {"", "a"}, {"a", ""}}
 	expectedOutPuts := [5]string{"", "a/b", "a/b/c/d", "a", "a"}
 
@@ -210,10 +207,10 @@ func (ut *utilTest) Test_getObjectPath() {
 		results[i] = GetDownloadPath(inputs[i][0], inputs[i][1])
 	}
 
-	ExpectTrue(reflect.DeepEqual(expectedOutPuts, results))
+	assert.True(t, reflect.DeepEqual(expectedOutPuts, results))
 }
 
-func (ut *utilTest) Test_getDownloadPath() {
+func Test_getDownloadPath(t *testing.T) {
 	inputs := []string{"/", "a/b", "a/b/c/d", "/a", "a/"}
 	cacheDir := "/test/dir"
 	expectedOutputs := [5]string{cacheDir, cacheDir + "/a/b",
@@ -224,10 +221,10 @@ func (ut *utilTest) Test_getDownloadPath() {
 		results[i] = GetDownloadPath(cacheDir, inputs[i])
 	}
 
-	ExpectTrue(reflect.DeepEqual(expectedOutputs, results))
+	assert.True(t, reflect.DeepEqual(expectedOutputs, results))
 }
 
-func (ut *utilTest) Test_IsCacheHandleValid_True() {
+func Test_IsCacheHandleValid_True(t *testing.T) {
 	errs := []error{
 		fmt.Errorf("%w: %s", ErrInvalidFileHandle, "test"),
 		fmt.Errorf("%w: %s", ErrInvalidFileDownloadJob, "test"),
@@ -236,108 +233,106 @@ func (ut *utilTest) Test_IsCacheHandleValid_True() {
 	}
 
 	for _, err := range errs {
-		ExpectTrue(IsCacheHandleInvalid(err))
+		assert.True(t, IsCacheHandleInvalid(err))
 	}
 }
 
-func (ut *utilTest) Test_IsCacheHandleValid_False() {
+func Test_IsCacheHandleValid_False(t *testing.T) {
 	errs := []error{
 		fmt.Errorf("%w: %s", ErrFallbackToGCS, "test"),
 		fmt.Errorf("random error message"),
 	}
 
 	for _, err := range errs {
-		ExpectFalse(IsCacheHandleInvalid(err))
+		assert.False(t, IsCacheHandleInvalid(err))
 	}
 }
 
-func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnCrcForValidFile() {
+func Test_CalculateFileCRC32_ShouldReturnCrcForValidFile(t *testing.T) {
 	crc, err := CalculateFileCRC32(context.Background(), "testdata/validfile.txt")
 
-	ExpectEq(nil, err)
-	ExpectEq(515179668, crc)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(515179668), crc)
 }
 
-func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnZeroForEmptyFile() {
+func Test_CalculateFileCRC32_ShouldReturnZeroForEmptyFile(t *testing.T) {
 	crc, err := CalculateFileCRC32(context.Background(), "testdata/emptyfile.txt")
 
-	ExpectEq(nil, err)
-	ExpectEq(0, crc)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(0), crc)
 }
 
-func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist() {
+func Test_CalculateFileCRC32_ShouldReturnErrorForFileNotExist(t *testing.T) {
 	crc, err := CalculateFileCRC32(context.Background(), "testdata/nofile.txt")
 
-	ExpectTrue(strings.Contains(err.Error(), "no such file or directory"))
-	ExpectEq(0, crc)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no such file or directory")
+	assert.Equal(t, uint32(0), crc)
 }
 
-func (ut *utilTest) Test_CalculateFileCRC32_ShouldReturnErrorWhenContextIsCancelled() {
+func Test_CalculateFileCRC32_ShouldReturnErrorWhenContextIsCancelled(t *testing.T) {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	cancelFunc()
 	crc, err := CalculateFileCRC32(ctx, "testdata/validfile.txt")
 
-	ExpectTrue(errors.Is(err, context.Canceled))
-	ExpectTrue(strings.Contains(err.Error(), "CRC computation is cancelled"))
-	ExpectEq(0, crc)
+	assert.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	assert.Contains(t, err.Error(), "CRC computation is cancelled")
+	assert.Equal(t, uint32(0), crc)
 }
 
-func (ut *utilTest) Test_TruncateAndRemoveFile_FileExists() {
-	// Create a file to be deleted.
-	fileName := "temp.txt"
+func Test_TruncateAndRemoveFile_FileExists(t *testing.T) {
+	tempDir := t.TempDir()
+	fileName := path.Join(tempDir, "temp.txt")
 	file, err := os.Create(fileName)
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	_, err = file.WriteString("Writing some data")
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	err = file.Close()
-	AssertEq(nil, err)
+	require.NoError(t, err)
 
 	err = TruncateAndRemoveFile(fileName)
 
-	ExpectEq(nil, err)
-	// Check the file is deleted.
+	assert.NoError(t, err)
 	_, err = os.Stat(fileName)
-	ExpectTrue(os.IsNotExist(err), fmt.Sprintf("expected not exist error but got error: %v", err))
+	assert.True(t, os.IsNotExist(err))
 }
 
-func (ut *utilTest) Test_TruncateAndRemoveFile_FileDoesNotExist() {
-	// Create a file to be deleted.
-	fileName := "temp.txt"
+func Test_TruncateAndRemoveFile_FileDoesNotExist(t *testing.T) {
+	tempDir := t.TempDir()
+	fileName := path.Join(tempDir, "temp.txt")
 
 	err := TruncateAndRemoveFile(fileName)
 
-	ExpectTrue(os.IsNotExist(err), fmt.Sprintf("expected not exist error but got error: %v", err))
+	assert.True(t, os.IsNotExist(err))
 }
 
-func (ut *utilTest) Test_TruncateAndRemoveFile_OpenedFileDeleted() {
-	// Create a file to be deleted.
-	fileName := "temp.txt"
+func Test_TruncateAndRemoveFile_OpenedFileDeleted(t *testing.T) {
+	tempDir := t.TempDir()
+	fileName := path.Join(tempDir, "temp.txt")
 	file, err := os.Create(fileName)
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	fileString := "Writing some data"
 	_, err = file.WriteString(fileString)
-	AssertEq(nil, err)
-	// Close the file to get the contents synced.
+	require.NoError(t, err)
 	err = file.Close()
-	AssertEq(nil, err)
-	// Open the file again
-	file, err = os.Open(fileName)
-	defer func() {
-		_ = file.Close()
-	}()
-	AssertEq(nil, err)
-	fileInfo, err := file.Stat()
-	AssertEq(nil, err)
-	AssertEq(len(fileString), fileInfo.Size())
+	require.NoError(t, err)
 
-	// File is not closed and call TruncateAndRemoveFile
+	file, err = os.Open(fileName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = file.Close()
+	})
+	fileInfo, err := file.Stat()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(fileString)), fileInfo.Size())
+
 	err = TruncateAndRemoveFile(fileName)
 
-	ExpectEq(nil, err)
-	// The size of open file should be 0.
+	assert.NoError(t, err)
 	fileInfo, err = file.Stat()
-	ExpectEq(nil, err)
-	ExpectEq(0, fileInfo.Size())
+	assert.NoError(t, err)
+	assert.Equal(t, int64(0), fileInfo.Size())
 }
 
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryExists(t *testing.T) {
@@ -345,14 +340,14 @@ func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirector
 	dirPath := path.Join(base, "/", "path/cachedir")
 	dirCreationErr := os.MkdirAll(dirPath, 0700)
 	defer os.RemoveAll(base)
-	AssertEq(nil, dirCreationErr)
+	require.NoError(t, dirCreationErr)
 
 	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0000)
 
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	fileInfo, err := os.Stat(dirPath)
-	AssertEq(nil, err)
-	AssertEq(0700, fileInfo.Mode().Perm())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), fileInfo.Mode().Perm())
 }
 
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOwnerPermissions(t *testing.T) {
@@ -362,10 +357,10 @@ func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirector
 
 	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0700)
 
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	fileInfo, err := os.Stat(dirPath)
-	AssertEq(nil, err)
-	AssertEq(0700, fileInfo.Mode().Perm())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0700), fileInfo.Mode().Perm())
 }
 
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirectoryCanBeCreatedWithOthersPermissions(t *testing.T) {
@@ -375,22 +370,22 @@ func Test_CreateCacheDirectoryIfNotPresentAt_ShouldNotReturnAnyErrorWhenDirector
 
 	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0755)
 
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	fileInfo, err := os.Stat(dirPath)
-	AssertEq(nil, err)
-	AssertEq(0755, fileInfo.Mode().Perm())
+	require.NoError(t, err)
+	assert.Equal(t, os.FileMode(0755), fileInfo.Mode().Perm())
 }
 
 func Test_CreateCacheDirectoryIfNotPresentAt_ShouldReturnErrorWhenDirectoryDoesNotHavePermissions(t *testing.T) {
 	dirPath := path.Join("./", string(testutil.GenerateRandomBytes(4)))
 	dirCreationErr := os.MkdirAll(dirPath, 0444)
 	defer os.RemoveAll(dirPath)
-	AssertEq(nil, dirCreationErr)
+	require.NoError(t, dirCreationErr)
 
 	err := CreateCacheDirectoryIfNotPresentAt(dirPath, 0755)
 
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "error creating file at directory ("+dirPath+")"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "error creating file at directory ("+dirPath+")")
 }
 
 func Test_GetMemoryAlignedBuffer(t *testing.T) {

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -71,9 +71,11 @@ func Test_CreateFile_FileDirNotPresent(t *testing.T) {
 	fileSpec, flag, uid, gid := setupUtilTest(t)
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
-	assert.NoError(t, file.Close())
 }
 
 func Test_CreateFile_ShouldThrowErrorIfFileDirNotPresentAndProvidedPermissionsAreInsufficient(t *testing.T) {
@@ -92,9 +94,11 @@ func Test_CreateFile_FileDirPresent(t *testing.T) {
 	require.NoError(t, err)
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
-	assert.NoError(t, file.Close())
 }
 
 func Test_CreateFile_ReadOnlyFile(t *testing.T) {
@@ -102,13 +106,15 @@ func Test_CreateFile_ReadOnlyFile(t *testing.T) {
 	flag := os.O_RDONLY
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
 	content := "foo"
 	_, err = file.Write([]byte(content))
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "bad file descriptor")
-	assert.NoError(t, file.Close())
 
 	fileContent, err := os.ReadFile(fileSpec.Path)
 	assert.NoError(t, err)
@@ -119,13 +125,15 @@ func Test_CreateFile_ReadWriteFile(t *testing.T) {
 	fileSpec, flag, uid, gid := setupUtilTest(t)
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
 	content := "foo"
 	n, err := file.Write([]byte(content))
 	assert.NoError(t, err)
 	assert.Equal(t, 3, n)
-	assert.NoError(t, file.Close())
 
 	fileContent, err := os.ReadFile(fileSpec.Path)
 	assert.NoError(t, err)
@@ -137,9 +145,11 @@ func Test_CreateFile_FilePerm0755(t *testing.T) {
 	fileSpec.FilePerm = os.FileMode(0755)
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
-	assert.NoError(t, file.Close())
 }
 
 func Test_CreateFile_FilePerm0544(t *testing.T) {
@@ -147,9 +157,11 @@ func Test_CreateFile_FilePerm0544(t *testing.T) {
 	fileSpec.FilePerm = os.FileMode(0544)
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
-	assert.NoError(t, file.Close())
 }
 
 func Test_CreateFile_FilePresent(t *testing.T) {
@@ -161,9 +173,11 @@ func Test_CreateFile_FilePresent(t *testing.T) {
 	assert.NoError(t, file.Close())
 
 	file, err = CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0755)
-	assert.NoError(t, file.Close())
 }
 
 func Test_CreateFile_FilePresentWithLessAccess(t *testing.T) {
@@ -193,9 +207,11 @@ func Test_CreateFile_RelativePath(t *testing.T) {
 	defer os.RemoveAll("./some")
 
 	file, err := CreateFile(fileSpec, flag)
+	if err == nil {
+		defer file.Close()
+	}
 
 	assertFileAndDirCreationWithGivenDirPerm(t, file, err, fileSpec, uid, gid, 0700)
-	assert.NoError(t, file.Close())
 }
 
 func Test_getObjectPath(t *testing.T) {

--- a/internal/cache/util/util_test.go
+++ b/internal/cache/util/util_test.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"reflect"
 	"strings"
 	"syscall"
 	"testing"
@@ -220,10 +219,10 @@ func Test_getObjectPath(t *testing.T) {
 
 	results := [5]string{}
 	for i := range 5 {
-		results[i] = GetDownloadPath(inputs[i][0], inputs[i][1])
+		results[i] = GetObjectPath(inputs[i][0], inputs[i][1])
 	}
 
-	assert.True(t, reflect.DeepEqual(expectedOutPuts, results))
+	assert.Equal(t, expectedOutPuts, results)
 }
 
 func Test_getDownloadPath(t *testing.T) {
@@ -237,7 +236,7 @@ func Test_getDownloadPath(t *testing.T) {
 		results[i] = GetDownloadPath(cacheDir, inputs[i])
 	}
 
-	assert.True(t, reflect.DeepEqual(expectedOutputs, results))
+	assert.Equal(t, expectedOutputs, results)
 }
 
 func Test_IsCacheHandleValid_True(t *testing.T) {
@@ -626,7 +625,7 @@ func Test_CopyUsingMemoryAlignedBuffer(t *testing.T) {
 				if err != nil && err != io.EOF {
 					t.Errorf("error (%v) while reading contents at the time of assertion for: %v", err, tc.name)
 				}
-				assert.True(t, reflect.DeepEqual(string(content[:sizeToMatch]), string(buf)))
+				assert.Equal(t, content[:sizeToMatch], buf)
 			}
 		})
 	}

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -67,7 +67,7 @@ func (bm *fakeBucketManager) SetUpTimes() int {
 func setupBaseDirTest(t *testing.T) (context.Context, *timeutil.SimulatedClock, *fakeBucketManager, DirInode) {
 	ctx := context.Background()
 	clock := &timeutil.SimulatedClock{}
-	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.UTC))
 
 	bm := &fakeBucketManager{
 		buckets: make(map[string]gcsx.SyncerBucket),

--- a/internal/fs/inode/base_dir_test.go
+++ b/internal/fs/inode/base_dir_test.go
@@ -15,81 +15,29 @@
 package inode
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
-	"golang.org/x/net/context"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/jacobsa/fuse/fuseops"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
 	chunkRetryDeadlineSecs   = 120
 	chunkTransferTimeoutSecs = 10
 )
-
-func TestBaseDir(t *testing.T) { RunTests(t) }
-
-////////////////////////////////////////////////////////////////////////
-// Boilerplate
-////////////////////////////////////////////////////////////////////////
-
-type BaseDirTest struct {
-	ctx   context.Context
-	clock timeutil.SimulatedClock
-	bm    *fakeBucketManager
-	in    DirInode
-}
-
-var _ SetUpInterface = &BaseDirTest{}
-var _ TearDownInterface = &BaseDirTest{}
-
-func init() { RegisterTestSuite(&BaseDirTest{}) }
-
-func (t *BaseDirTest) SetUp(ti *TestInfo) {
-	t.ctx = ti.Ctx
-	t.clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
-
-	// Create a bucket manager for 2 buckets: bucketA and bucketB
-	t.bm = &fakeBucketManager{
-		buckets: make(map[string]gcsx.SyncerBucket),
-	}
-	t.bm.buckets["bucketA"] = gcsx.NewSyncerBucket(
-		/*appendThreshold=*/ 1,
-		chunkRetryDeadlineSecs,
-		chunkTransferTimeoutSecs,
-		".gcsfuse_tmp/",
-		fake.NewFakeBucket(&t.clock, "bucketA", gcs.BucketType{}),
-	)
-	t.bm.buckets["bucketB"] = gcsx.NewSyncerBucket(
-		/*appendThreshold=*/ 1,
-		chunkRetryDeadlineSecs,
-		chunkTransferTimeoutSecs,
-		".gcsfuse_tmp/",
-		fake.NewFakeBucket(&t.clock, "bucketB", gcs.BucketType{}),
-	)
-
-	// Create the inode. No implicit dirs by default.
-	t.resetInode()
-}
-
-func (t *BaseDirTest) TearDown() {
-	t.in.Unlock()
-}
-
-////////////////////////////////////////////////////////////////////////
-// Helpers
-////////////////////////////////////////////////////////////////////////
 
 type fakeBucketManager struct {
 	buckets    map[string]gcsx.SyncerBucket
@@ -116,137 +64,192 @@ func (bm *fakeBucketManager) SetUpTimes() int {
 	return bm.setupTimes
 }
 
-func (t *BaseDirTest) resetInode() {
-	if t.in != nil {
-		t.in.Unlock()
+func setupBaseDirTest(t *testing.T) (context.Context, *timeutil.SimulatedClock, *fakeBucketManager, DirInode) {
+	ctx := context.Background()
+	clock := &timeutil.SimulatedClock{}
+	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+
+	bm := &fakeBucketManager{
+		buckets: make(map[string]gcsx.SyncerBucket),
+	}
+	bm.buckets["bucketA"] = gcsx.NewSyncerBucket(
+		1,
+		chunkRetryDeadlineSecs,
+		chunkTransferTimeoutSecs,
+		".gcsfuse_tmp/",
+		fake.NewFakeBucket(clock, "bucketA", gcs.BucketType{}),
+	)
+	bm.buckets["bucketB"] = gcsx.NewSyncerBucket(
+		1,
+		chunkRetryDeadlineSecs,
+		chunkTransferTimeoutSecs,
+		".gcsfuse_tmp/",
+		fake.NewFakeBucket(clock, "bucketB", gcs.BucketType{}),
+	)
+
+	in := NewBaseDirInode(
+		dirInodeID,
+		NewRootName(""),
+		fuseops.InodeAttributes{
+			Uid:  uid,
+			Gid:  gid,
+			Mode: dirMode,
+		},
+		bm,
+		metrics.NewNoopMetrics(),
+		isTypeCacheDeprecationEnabled,
+	)
+
+	// Cast to sync.Locker to satisfy the linter which struggles with interface embedding.
+	if locker, ok := in.(sync.Locker); ok {
+		locker.Lock()
+	} else {
+		t.Fatal("DirInode does not implement sync.Locker")
 	}
 
-	t.in = NewBaseDirInode(
-		dirInodeID,
-		NewRootName(""),
-		fuseops.InodeAttributes{
-			Uid:  uid,
-			Gid:  gid,
-			Mode: dirMode,
-		},
-		t.bm,
-		metrics.NewNoopMetrics(),
-		isTypeCacheDeprecationEnabled)
-
-	t.in.Lock()
+	return ctx, clock, bm, in
 }
 
-////////////////////////////////////////////////////////////////////////
-// Tests
-////////////////////////////////////////////////////////////////////////
-
-func (t *BaseDirTest) ID() {
-	ExpectEq(dirInodeID, t.in.ID())
+func runWithBaseDirInode(t *testing.T, testFunc func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode)) {
+	ctx, clock, bm, in := setupBaseDirTest(t)
+	defer func() {
+		if locker, ok := in.(sync.Locker); ok {
+			locker.Unlock()
+		}
+	}()
+	testFunc(ctx, clock, bm, in)
 }
 
-func (t *BaseDirTest) Name() {
-	ExpectEq("", t.in.Name().LocalName())
+func TestBaseDir_ID(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		assert.Equal(t, fuseops.InodeID(dirInodeID), in.ID())
+	})
 }
 
-func (t *BaseDirTest) LookupCount() {
-	// Increment thrice. The count should now be three.
-	t.in.IncrementLookupCount()
-	t.in.IncrementLookupCount()
-	t.in.IncrementLookupCount()
-
-	// Decrementing twice shouldn't cause destruction. But one more should.
-	AssertFalse(t.in.DecrementLookupCount(2))
-	ExpectTrue(t.in.DecrementLookupCount(1))
+func TestBaseDir_Name(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		assert.Equal(t, "", in.Name().LocalName())
+	})
 }
 
-func (t *BaseDirTest) Attributes_ClobberedCheckTrue() {
-	attrs, err := t.in.Attributes(t.ctx, true)
+func TestBaseDir_LookupCount(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		// Increment thrice. The count should now be three.
+		in.IncrementLookupCount()
+		in.IncrementLookupCount()
+		in.IncrementLookupCount()
 
-	AssertEq(nil, err)
-	ExpectEq(uid, attrs.Uid)
-	ExpectEq(gid, attrs.Gid)
-	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
+		// Decrementing twice shouldn't cause destruction. But one more should.
+		require.False(t, in.DecrementLookupCount(2))
+		assert.True(t, in.DecrementLookupCount(1))
+	})
 }
 
-func (t *BaseDirTest) Attributes_ClobberedCheckFalse() {
-	attrs, err := t.in.Attributes(t.ctx, false)
+func TestBaseDir_Attributes_ClobberedCheckTrue(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		attrs, err := in.Attributes(ctx, true)
 
-	AssertEq(nil, err)
-	ExpectEq(uid, attrs.Uid)
-	ExpectEq(gid, attrs.Gid)
-	ExpectEq(dirMode|os.ModeDir, attrs.Mode)
+		require.NoError(t, err)
+		assert.Equal(t, uint32(uid), attrs.Uid)
+		assert.Equal(t, uint32(gid), attrs.Gid)
+		assert.Equal(t, dirMode|os.ModeDir, attrs.Mode)
+	})
 }
 
-func (t *BaseDirTest) LookUpChild_NonExistent() {
-	result, err := t.in.LookUpChild(t.ctx, "missing_bucket")
+func TestBaseDir_Attributes_ClobberedCheckFalse(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		attrs, err := in.Attributes(ctx, false)
 
-	ExpectNe(nil, err)
-	ExpectEq(nil, result)
-	ExpectEq(1, t.bm.SetUpTimes())
+		require.NoError(t, err)
+		assert.Equal(t, uint32(uid), attrs.Uid)
+		assert.Equal(t, uint32(gid), attrs.Gid)
+		assert.Equal(t, dirMode|os.ModeDir, attrs.Mode)
+	})
 }
 
-func (t *BaseDirTest) LookUpChild_BucketFound() {
-	result, err := t.in.LookUpChild(t.ctx, "bucketA")
+func TestBaseDir_LookUpChild_NonExistent(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		result, err := in.LookUpChild(ctx, "missing_bucket")
 
-	AssertEq(nil, err)
-	AssertNe(nil, result)
-
-	ExpectEq("bucketA", result.Bucket.Name())
-	ExpectTrue(result.FullName.IsBucketRoot())
-	ExpectEq("bucketA/", result.FullName.LocalName())
-	ExpectEq("", result.FullName.GcsObjectName())
-	ExpectEq(nil, result.MinObject)
-	ExpectEq(metadata.ImplicitDirType, result.Type())
-
-	result, err = t.in.LookUpChild(t.ctx, "bucketB")
-
-	AssertEq(nil, err)
-	AssertNe(nil, result)
-
-	ExpectEq("bucketB", result.Bucket.Name())
-	ExpectTrue(result.FullName.IsBucketRoot())
-	ExpectEq("bucketB/", result.FullName.LocalName())
-	ExpectEq("", result.FullName.GcsObjectName())
-	ExpectEq(nil, result.MinObject)
-	ExpectEq(metadata.ImplicitDirType, result.Type())
+		assert.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, 1, bm.SetUpTimes())
+	})
 }
 
-func (t *BaseDirTest) LookUpChild_BucketCached() {
-	_, _ = t.in.LookUpChild(t.ctx, "bucketA")
-	ExpectEq(1, t.bm.SetUpTimes())
-	_, _ = t.in.LookUpChild(t.ctx, "bucketA")
-	ExpectEq(1, t.bm.SetUpTimes())
-	_, _ = t.in.LookUpChild(t.ctx, "bucketB")
-	ExpectEq(2, t.bm.SetUpTimes())
-	_, _ = t.in.LookUpChild(t.ctx, "bucketB")
-	ExpectEq(2, t.bm.SetUpTimes())
-	_, _ = t.in.LookUpChild(t.ctx, "missing_bucket")
-	ExpectEq(3, t.bm.SetUpTimes())
+func TestBaseDir_LookUpChild_BucketFound(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		result, err := in.LookUpChild(ctx, "bucketA")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Equal(t, "bucketA", result.Bucket.Name())
+		assert.True(t, result.FullName.IsBucketRoot())
+		assert.Equal(t, "bucketA/", result.FullName.LocalName())
+		assert.Equal(t, "", result.FullName.GcsObjectName())
+		assert.Nil(t, result.MinObject)
+		assert.Equal(t, metadata.ImplicitDirType, result.Type())
+
+		result, err = in.LookUpChild(ctx, "bucketB")
+
+		require.NoError(t, err)
+		require.NotNil(t, result)
+
+		assert.Equal(t, "bucketB", result.Bucket.Name())
+		assert.True(t, result.FullName.IsBucketRoot())
+		assert.Equal(t, "bucketB/", result.FullName.LocalName())
+		assert.Equal(t, "", result.FullName.GcsObjectName())
+		assert.Nil(t, result.MinObject)
+		assert.Equal(t, metadata.ImplicitDirType, result.Type())
+	})
 }
 
-func (t *BaseDirTest) Test_ShouldInvalidateKernelListCache() {
-	ttl := time.Second
-	AssertEq(true, t.in.ShouldInvalidateKernelListCache(ttl))
+func TestBaseDir_LookUpChild_BucketCached(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		_, _ = in.LookUpChild(ctx, "bucketA")
+		assert.Equal(t, 1, bm.SetUpTimes())
+		_, _ = in.LookUpChild(ctx, "bucketA")
+		assert.Equal(t, 1, bm.SetUpTimes())
+		_, _ = in.LookUpChild(ctx, "bucketB")
+		assert.Equal(t, 2, bm.SetUpTimes())
+		_, _ = in.LookUpChild(ctx, "bucketB")
+		assert.Equal(t, 2, bm.SetUpTimes())
+		_, _ = in.LookUpChild(ctx, "missing_bucket")
+		assert.Equal(t, 3, bm.SetUpTimes())
+	})
 }
 
-func (t *BaseDirTest) Test_ShouldInvalidateKernelListCache_TtlExpired() {
-	ttl := time.Second
-	t.clock.AdvanceTime(10 * time.Second)
-
-	AssertEq(true, t.in.ShouldInvalidateKernelListCache(ttl))
+func TestBaseDir_ShouldInvalidateKernelListCache(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		ttl := time.Second
+		assert.True(t, in.ShouldInvalidateKernelListCache(ttl))
+	})
 }
 
-func (t *BaseDirTest) TestReadEntryCores() {
-	cores, unsupportedPaths, newTok, err := t.in.ReadEntryCores(t.ctx, "")
+func TestBaseDir_ShouldInvalidateKernelListCache_TtlExpired(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		ttl := time.Second
+		clock.AdvanceTime(10 * time.Second)
 
-	// Should return ENOTSUP because listing is unsupported.
-	ExpectEq(nil, cores)
-	ExpectEq(nil, unsupportedPaths)
-	ExpectEq("", newTok)
-	ExpectEq(syscall.ENOTSUP, err)
+		assert.True(t, in.ShouldInvalidateKernelListCache(ttl))
+	})
 }
 
-func (t *BaseDirTest) Test_IsTypeCacheDeprecated_false() {
+func TestBaseDir_ReadEntryCores(t *testing.T) {
+	runWithBaseDirInode(t, func(ctx context.Context, clock *timeutil.SimulatedClock, bm *fakeBucketManager, in DirInode) {
+		cores, unsupportedPaths, newTok, err := in.ReadEntryCores(ctx, "")
+
+		// Should return ENOTSUP because listing is unsupported.
+		assert.Nil(t, cores)
+		assert.Nil(t, unsupportedPaths)
+		assert.Equal(t, "", newTok)
+		assert.Equal(t, syscall.ENOTSUP, err)
+	})
+}
+
+func TestBaseDir_IsTypeCacheDeprecated_false(t *testing.T) {
+	bm := &fakeBucketManager{}
 	dInode := NewBaseDirInode(
 		dirInodeID,
 		NewRootName(""),
@@ -255,14 +258,16 @@ func (t *BaseDirTest) Test_IsTypeCacheDeprecated_false() {
 			Gid:  gid,
 			Mode: dirMode,
 		},
-		t.bm,
+		bm,
 		metrics.NewNoopMetrics(),
-		false)
+		false,
+	)
 
-	AssertFalse(dInode.IsTypeCacheDeprecated())
+	assert.False(t, dInode.IsTypeCacheDeprecated())
 }
 
-func (t *BaseDirTest) Test_IsTypeCacheDeprecated_true() {
+func TestBaseDir_IsTypeCacheDeprecated_true(t *testing.T) {
+	bm := &fakeBucketManager{}
 	dInode := NewBaseDirInode(
 		dirInodeID,
 		NewRootName(""),
@@ -271,9 +276,10 @@ func (t *BaseDirTest) Test_IsTypeCacheDeprecated_true() {
 			Gid:  gid,
 			Mode: dirMode,
 		},
-		t.bm,
+		bm,
 		metrics.NewNoopMetrics(),
-		true)
+		true,
+	)
 
-	AssertTrue(dInode.IsTypeCacheDeprecated())
+	assert.True(t, dInode.IsTypeCacheDeprecated())
 }

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -20,46 +20,29 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/jacobsa/fuse/fuseops"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSymlink(t *testing.T) { RunTests(t) }
-
-////////////////////////////////////////////////////////////////////////
-// Boilerplate
-////////////////////////////////////////////////////////////////////////
-
-type SymlinkTest struct {
-	bucket *gcsx.SyncerBucket
-}
-
-var _ SetUpInterface = &CoreTest{}
-var _ TearDownInterface = &CoreTest{}
-
-func init() { RegisterTestSuite(&SymlinkTest{}) }
-
-func (t *SymlinkTest) SetUp(ti *TestInfo) {
+func setupSymlinkTest(t *testing.T) *gcsx.SyncerBucket {
 	bucket := gcsx.NewSyncerBucket(
 		/*appendThreshold=*/ 1,
 		/*chunkRetryDeadlineSecs=*/ 120,
 		/*chunkTransferTimeoutSecs=*/ 10,
-		".gcsfuse_tmp/", fake.NewFakeBucket(timeutil.RealClock(), "some-bucket", gcs.BucketType{}))
-	t.bucket = &bucket
+		".gcsfuse_tmp/",
+		fake.NewFakeBucket(timeutil.RealClock(), "some-bucket", gcs.BucketType{}),
+	)
+	return &bucket
 }
 
-////////////////////////////////////////////////////////////////////////
-// Tests
-////////////////////////////////////////////////////////////////////////
-
-func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsPresent() {
+func TestIsSymlinkWhenMetadataKeyIsPresent(t *testing.T) {
 	metadata := map[string]string{
 		inode.SymlinkMetadataKey: "target",
 	}
@@ -68,18 +51,18 @@ func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsPresent() {
 		Metadata: metadata,
 	}
 
-	AssertEq(true, inode.IsSymlink(&m))
+	assert.True(t, inode.IsSymlink(&m))
 }
 
-func (t *SymlinkTest) TestIsSymLinkWhenMetadataKeyIsNotPresent() {
+func TestIsSymlinkWhenMetadataKeyIsNotPresent(t *testing.T) {
 	m := gcs.MinObject{
 		Name: "test",
 	}
 
-	AssertEq(false, inode.IsSymlink(&m))
+	assert.False(t, inode.IsSymlink(&m))
 }
 
-func (t *SymlinkTest) TestIsSymLinkWhenStandardMetadataKeyIsPresent() {
+func TestIsSymlinkWhenStandardMetadataKeyIsPresent(t *testing.T) {
 	metadata := map[string]string{
 		inode.StandardSymlinkMetadataKey: "true",
 	}
@@ -88,10 +71,10 @@ func (t *SymlinkTest) TestIsSymLinkWhenStandardMetadataKeyIsPresent() {
 		Metadata: metadata,
 	}
 
-	AssertEq(true, inode.IsSymlink(&m))
+	assert.True(t, inode.IsSymlink(&m))
 }
 
-func (t *SymlinkTest) TestIsSymLinkWhenStandardMetadataKeyIsFalse() {
+func TestIsSymlinkWhenStandardMetadataKeyIsFalse(t *testing.T) {
 	metadata := map[string]string{
 		inode.StandardSymlinkMetadataKey: "false",
 	}
@@ -100,14 +83,15 @@ func (t *SymlinkTest) TestIsSymLinkWhenStandardMetadataKeyIsFalse() {
 		Metadata: metadata,
 	}
 
-	AssertEq(false, inode.IsSymlink(&m))
+	assert.False(t, inode.IsSymlink(&m))
 }
 
-func (t *SymlinkTest) TestIsSymLinkForNilObject() {
-	AssertEq(false, inode.IsSymlink(nil))
+func TestIsSymlinkForNilObject(t *testing.T) {
+	assert.False(t, inode.IsSymlink(nil))
 }
 
-func (t *SymlinkTest) TestAttributes() {
+func TestAttributes(t *testing.T) {
+	bucket := setupSymlinkTest(t)
 	metadata := map[string]string{
 		inode.SymlinkMetadataKey: "target",
 	}
@@ -121,8 +105,9 @@ func (t *SymlinkTest) TestAttributes() {
 		Mode: 0777 | os.ModeSymlink,
 	}
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
-	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, t.bucket, m, attrs)
-	AssertEq(nil, err)
+	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m, attrs)
+	require.NoError(t, err)
+
 	tests := []struct {
 		name           string
 		clobberedCheck bool
@@ -132,19 +117,22 @@ func (t *SymlinkTest) TestAttributes() {
 	}
 
 	for _, tt := range tests {
-		// Call Attributes
-		extracted, err := s.Attributes(context.TODO(), tt.clobberedCheck)
+		t.Run(tt.name, func(t *testing.T) {
+			// Call Attributes
+			extracted, err := s.Attributes(context.TODO(), tt.clobberedCheck)
 
-		// Check expected values
-		AssertEq(nil, err)
-		ExpectEq(uint32(1), extracted.Nlink)
-		ExpectEq(attrs.Uid, extracted.Uid)
-		ExpectEq(attrs.Gid, extracted.Gid)
-		ExpectEq(attrs.Mode, extracted.Mode)
+			// Check expected values
+			require.NoError(t, err)
+			assert.Equal(t, uint32(1), extracted.Nlink)
+			assert.Equal(t, attrs.Uid, extracted.Uid)
+			assert.Equal(t, attrs.Gid, extracted.Gid)
+			assert.Equal(t, attrs.Mode, extracted.Mode)
+		})
 	}
 }
 
-func (t *SymlinkTest) TestUpdateSize() {
+func TestUpdateSize(t *testing.T) {
+	bucket := setupSymlinkTest(t)
 	m := &gcs.MinObject{
 		Name:           "test",
 		Generation:     1,
@@ -154,36 +142,37 @@ func (t *SymlinkTest) TestUpdateSize() {
 	}
 	attrs := fuseops.InodeAttributes{}
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
-	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, t.bucket, m, attrs)
-	AssertEq(nil, err)
+	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m, attrs)
+	require.NoError(t, err)
 
 	s.UpdateSize(200)
 
-	AssertEq(uint64(200), s.SourceGeneration().Size)
+	assert.Equal(t, uint64(200), s.SourceGeneration().Size)
 }
 
-func (t *SymlinkTest) TestSource() {
+func TestSource(t *testing.T) {
+	bucket := setupSymlinkTest(t)
 	obj, err := storageutil.CreateObject(
 		context.Background(),
-		t.bucket,
+		bucket,
 		"test", // The name of the object in GCS
 		[]byte("target_path"),
 	)
-	AssertEq(nil, err)
+	require.NoError(t, err)
 	m := storageutil.ConvertObjToMinObject(obj)
 	m.Metadata = map[string]string{inode.StandardSymlinkMetadataKey: "true"}
 	m.Updated = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // Explicitly set Updated time for consistent testing.
 	attrs := fuseops.InodeAttributes{}
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
-	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, t.bucket, m, attrs)
-	AssertEq(nil, err)
+	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m, attrs)
+	require.NoError(t, err)
 
 	source := s.Source()
 
-	AssertEq(m.Name, source.Name)
-	AssertEq(m.Generation, source.Generation)
-	AssertEq(m.MetaGeneration, source.MetaGeneration)
-	AssertEq(m.Size, source.Size)
-	AssertEq(m.Metadata, source.Metadata)
-	AssertEq(0, m.Updated.Compare(source.Updated))
+	assert.Equal(t, m.Name, source.Name)
+	assert.Equal(t, m.Generation, source.Generation)
+	assert.Equal(t, m.MetaGeneration, source.MetaGeneration)
+	assert.Equal(t, m.Size, source.Size)
+	assert.Equal(t, m.Metadata, source.Metadata)
+	assert.Equal(t, 0, m.Updated.Compare(source.Updated))
 }

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -15,6 +15,7 @@
 package caching_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	"github.com/jacobsa/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 type integrationTestDeps struct {

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -43,7 +43,7 @@ func setupIntegrationTest(t *testing.T) *integrationTestDeps {
 	bucketName := "some_bucket"
 
 	clock := &timeutil.SimulatedClock{}
-	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.UTC))
 
 	const cacheCapacity = 100
 	lruCache := lru.NewCache(cfg.AverageSizeOfPositiveStatCacheEntry * cacheCapacity)

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -25,275 +25,266 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
-	. "github.com/jacobsa/oglematchers"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"golang.org/x/net/context"
 )
 
-func TestIntegration(t *testing.T) { RunTests(t) }
-
-////////////////////////////////////////////////////////////////////////
-// Boilerplate
-////////////////////////////////////////////////////////////////////////
-
-type IntegrationTest struct {
-	ctx context.Context
-
-	clock   timeutil.SimulatedClock
+type integrationTestDeps struct {
+	ctx     context.Context
+	clock   *timeutil.SimulatedClock
 	wrapped gcs.Bucket
-
-	bucket gcs.Bucket
+	bucket  gcs.Bucket
 }
 
-func init() { RegisterTestSuite(&IntegrationTest{}) }
-
-func (t *IntegrationTest) SetUp(ti *TestInfo) {
-	t.ctx = context.Background()
+func setupIntegrationTest(t *testing.T) *integrationTestDeps {
+	ctx := context.Background()
 	bucketName := "some_bucket"
 
-	// Set up a fixed, non-zero time.
-	t.clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
+	clock := &timeutil.SimulatedClock{}
+	clock.SetTime(time.Date(2015, 4, 5, 2, 15, 0, 0, time.Local))
 
-	// Set up dependencies.
 	const cacheCapacity = 100
 	lruCache := lru.NewCache(cfg.AverageSizeOfPositiveStatCacheEntry * cacheCapacity)
 	cache := metadata.NewStatCacheBucketView(lruCache, "")
-	t.wrapped = fake.NewFakeBucket(&t.clock, bucketName, gcs.BucketType{})
+	wrapped := fake.NewFakeBucket(clock, bucketName, gcs.BucketType{})
 
-	t.bucket = caching.NewFastStatBucket(
+	bucket := caching.NewFastStatBucket(
 		primaryCacheTTL,
 		cache,
-		&t.clock,
-		t.wrapped,
+		clock,
+		wrapped,
 		negativeCacheTTL,
 		isTypeCacheDeprecated,
 		isImplicitDir,
 	)
+
+	return &integrationTestDeps{
+		ctx:     ctx,
+		clock:   clock,
+		wrapped: wrapped,
+		bucket:  bucket,
+	}
 }
 
-func (t *IntegrationTest) stat(name string) (o *gcs.Object, err error) {
+func statObject(ctx context.Context, bucket gcs.Bucket, name string) (*gcs.Object, error) {
 	req := &gcs.StatObjectRequest{
 		Name: name,
 	}
-
-	m, _, err := t.bucket.StatObject(t.ctx, req)
-	o = storageutil.ConvertMinObjectToObject(m)
-	return
+	m, _, err := bucket.StatObject(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+	return storageutil.ConvertMinObjectToObject(m), nil
 }
 
-////////////////////////////////////////////////////////////////////////
-// Test functions
-////////////////////////////////////////////////////////////////////////
-
-func (t *IntegrationTest) CreateInsertsIntoCache() {
+func TestIntegration_CreateInsertsIntoCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Create an object.
-	_, err = storageutil.CreateObject(t.ctx, t.bucket, name, []byte{})
-	AssertEq(nil, err)
+	_, err := storageutil.CreateObject(deps.ctx, deps.bucket, name, []byte{})
+	require.NoError(t, err)
 
 	// Delete it through the back door.
-	err = t.wrapped.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: name})
-	AssertEq(nil, err)
+	err = deps.wrapped.DeleteObject(deps.ctx, &gcs.DeleteObjectRequest{Name: name})
+	require.NoError(t, err)
 
 	// StatObject should still see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) StatInsertsIntoCache() {
+func TestIntegration_StatInsertsIntoCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "foo"
-	var err error
 
 	// Create an object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err := storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// Stat it so that it's in cache.
-	_, err = t.stat(name)
-	AssertEq(nil, err)
+	_, err = statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
 
 	// Delete it through the back door.
-	err = t.wrapped.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: name})
-	AssertEq(nil, err)
+	err = deps.wrapped.DeleteObject(deps.ctx, &gcs.DeleteObjectRequest{Name: name})
+	require.NoError(t, err)
 
 	// StatObject should still see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) ListInsertsIntoCache() {
+func TestIntegration_ListInsertsIntoCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Create an object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err := storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// List so that it's in cache.
-	_, err = t.bucket.ListObjects(t.ctx, &gcs.ListObjectsRequest{})
-	AssertEq(nil, err)
+	_, err = deps.bucket.ListObjects(deps.ctx, &gcs.ListObjectsRequest{})
+	require.NoError(t, err)
 
 	// Delete the object through the back door.
-	err = t.wrapped.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: name})
-	AssertEq(nil, err)
+	err = deps.wrapped.DeleteObject(deps.ctx, &gcs.DeleteObjectRequest{Name: name})
+	require.NoError(t, err)
 
 	// StatObject should still see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) UpdateUpdatesCache() {
+func TestIntegration_UpdateUpdatesCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Create an object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err := storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// Update it, putting the new version in cache.
 	updateReq := &gcs.UpdateObjectRequest{
 		Name: name,
 	}
-
-	_, err = t.bucket.UpdateObject(t.ctx, updateReq)
-	AssertEq(nil, err)
+	_, err = deps.bucket.UpdateObject(deps.ctx, updateReq)
+	require.NoError(t, err)
 
 	// Delete the object through the back door.
-	err = t.wrapped.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: name})
-	AssertEq(nil, err)
+	err = deps.wrapped.DeleteObject(deps.ctx, &gcs.DeleteObjectRequest{Name: name})
+	require.NoError(t, err)
 
 	// StatObject should still see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) PositiveCacheExpiration() {
+func TestIntegration_PositiveCacheExpiration(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Create an object.
-	_, err = storageutil.CreateObject(t.ctx, t.bucket, name, []byte{})
-	AssertEq(nil, err)
+	_, err := storageutil.CreateObject(deps.ctx, deps.bucket, name, []byte{})
+	require.NoError(t, err)
 
 	// Delete it through the back door.
-	err = t.wrapped.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: name})
-	AssertEq(nil, err)
+	err = deps.wrapped.DeleteObject(deps.ctx, &gcs.DeleteObjectRequest{Name: name})
+	require.NoError(t, err)
 
 	// Advance time.
-	t.clock.AdvanceTime(primaryCacheTTL + time.Millisecond)
+	deps.clock.AdvanceTime(primaryCacheTTL + time.Millisecond)
 
 	// StatObject should no longer see it.
-	_, err = t.stat(name)
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err = statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 }
 
-func (t *IntegrationTest) CreateInvalidatesNegativeCache() {
+func TestIntegration_CreateInvalidatesNegativeCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Stat an unknown object, getting it into the negative cache.
-	_, err = t.stat(name)
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err := statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 
 	// Create the object.
-	_, err = storageutil.CreateObject(t.ctx, t.bucket, name, []byte{})
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(deps.ctx, deps.bucket, name, []byte{})
+	require.NoError(t, err)
 
 	// Now StatObject should see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) StatAddsToNegativeCache() {
+func TestIntegration_StatAddsToNegativeCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Stat an unknown object, getting it into the negative cache.
-	_, err = t.stat(name)
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err := statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 
 	// Create the object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// StatObject should still not see it yet.
-	_, err = t.stat(name)
-	ExpectThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err = statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 }
 
-func (t *IntegrationTest) ListInvalidatesNegativeCache() {
+func TestIntegration_ListInvalidatesNegativeCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Stat an unknown object, getting it into the negative cache.
-	_, err = t.stat(name)
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err := statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 
 	// Create the object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// List the bucket.
-	_, err = t.bucket.ListObjects(t.ctx, &gcs.ListObjectsRequest{})
-	AssertEq(nil, err)
+	_, err = deps.bucket.ListObjects(deps.ctx, &gcs.ListObjectsRequest{})
+	require.NoError(t, err)
 
 	// Now StatObject should see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) UpdateInvalidatesNegativeCache() {
+func TestIntegration_UpdateInvalidatesNegativeCache(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Stat an unknown object, getting it into the negative cache.
-	_, err = t.stat(name)
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err := statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 
 	// Create the object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// Update the object.
 	updateReq := &gcs.UpdateObjectRequest{
 		Name: name,
 	}
-
-	_, err = t.bucket.UpdateObject(t.ctx, updateReq)
-	AssertEq(nil, err)
+	_, err = deps.bucket.UpdateObject(deps.ctx, updateReq)
+	require.NoError(t, err)
 
 	// Now StatObject should see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }
 
-func (t *IntegrationTest) NegativeCacheExpiration() {
+func TestIntegration_NegativeCacheExpiration(t *testing.T) {
+	deps := setupIntegrationTest(t)
 	const name = "taco"
-	var err error
 
 	// Stat an unknown object, getting it into the negative cache.
-	_, err = t.stat(name)
-	AssertThat(err, HasSameTypeAs(&gcs.NotFoundError{}))
+	_, err := statObject(deps.ctx, deps.bucket, name)
+	assert.IsType(t, &gcs.NotFoundError{}, err)
 
 	// Create the object through the back door.
-	_, err = storageutil.CreateObject(t.ctx, t.wrapped, name, []byte{})
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(deps.ctx, deps.wrapped, name, []byte{})
+	require.NoError(t, err)
 
 	// Advance time.
-	t.clock.AdvanceTime(negativeCacheTTL + time.Millisecond)
+	deps.clock.AdvanceTime(negativeCacheTTL + time.Millisecond)
 
 	// Now StatObject should see it.
-	o, err := t.stat(name)
-	AssertEq(nil, err)
-	ExpectNe(nil, o)
+	o, err := statObject(deps.ctx, deps.bucket, name)
+	require.NoError(t, err)
+	assert.NotNil(t, o)
 }


### PR DESCRIPTION
Migrates caching, base_dir, util, and symlink tests from legacy ogletest to testify.
b/529651390 

Improvements
IDE Integration: Standard go test support allows running individual tests instantly (<1s) from IDEs.
No Resource Leaks: Refactored util_test.go to use t.TempDir() instead of writing to the user's home directory, ensuring automatic cleanup.
Deadlock Prevention: Used a callback helper in base_dir_test.go to safely manage Lock/Unlock lifecycles and bypass linter embedding bugs.
Robustness: Removed obsolete dependencies, making tests thread-safe and ready for parallel execution (t.Parallel()).
