### PR TITLE
style(test_config): comma separated flags in test_config.yaml

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -215,7 +215,7 @@ read_large_files:
           zonal: true
         run_on_gke: true
       - flags:
-          - "--implicit-dirs --enable-kernel-reader=false,--client-protocol=http1"
+          - "--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
         compatible:
           flat: false
           hns: false
@@ -979,7 +979,7 @@ benchmarking:
     configs:
       - flags:
           - "--stat-cache-ttl=0,--client-protocol=http1"
-          - "--stat-cache-ttl=0 --client-protocol=grpc"
+          - "--stat-cache-ttl=0,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
@@ -2003,7 +2003,7 @@ symlink_handling:
       - run: TestStandardSymlinksTestSuite
         flags:
           - "--enable-standard-symlinks=true,--client-protocol=http1"
-          - "--enable-standard-symlinks=true --client-protocol=grpc"
+          - "--enable-standard-symlinks=true,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
@@ -2023,7 +2023,7 @@ symlink_handling:
       - run: TestLegacySymlinksTestSuite
         flags:
           - "--enable-standard-symlinks=false,--client-protocol=http1"
-          - "--enable-standard-symlinks=false --client-protocol=grpc"
+          - "--enable-standard-symlinks=false,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -15,8 +15,10 @@
 package test_suite
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
@@ -60,6 +62,27 @@ type ConfigItem struct {
 	Run            string           `yaml:"run,omitempty"`
 	RunOnGKE       bool             `yaml:"run_on_gke"`
 	RunOnPirlo     RunOnPirloConfig `yaml:"run_on_pirlo"`
+}
+
+// UnmarshalYAML validates flags during YAML unmarshaling without needing reflection.
+func (c *ConfigItem) UnmarshalYAML(value *yaml.Node) error {
+	type alias ConfigItem
+	var item alias
+	if err := value.Decode(&item); err != nil {
+		return err
+	}
+	for _, flagString := range item.Flags {
+		if strings.Contains(flagString, " ") {
+			return fmt.Errorf("invalid flag string %q in test_config.yaml: flags must not contain spaces. Separate flags using commas without spaces", flagString)
+		}
+	}
+	for _, flagString := range item.SecondaryFlags {
+		if strings.Contains(flagString, " ") {
+			return fmt.Errorf("invalid secondary flag string %q in test_config.yaml: flags must not contain spaces. Separate flags using commas without spaces", flagString)
+		}
+	}
+	*c = ConfigItem(item)
+	return nil
 }
 
 // Config holds all test configurations parsed from the YAML file.


### PR DESCRIPTION
### Description
Keep the flags in test_config.yaml comma separated.
Force the flags to remain comma separated.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Kokoro

### Any backward incompatible change? If so, please explain.
