### PR TITLE
chore(cleanup): e2e test packages cleanup (Part 1)

### DIFF
--- a/tools/integration_tests/benchmarking/setup_test.go
+++ b/tools/integration_tests/benchmarking/setup_test.go
@@ -79,20 +79,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.Benchmarking) == 0 {
-		log.Println("No configuration found for benchmarking tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.Benchmarking = make([]test_suite.TestConfig, 1)
-		cfg.Benchmarking[0].TestBucket = setup.TestBucket()
-		cfg.Benchmarking[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.Benchmarking[0].LogFile = setup.LogFile()
-		// Manually add configs for each benchmark test.
-		cfg.Benchmarking[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.Benchmarking[0].Configs[0].Flags = []string{"--stat-cache-ttl=0", "--stat-cache-ttl=0 --client-protocol=grpc"}
-		cfg.Benchmarking[0].Configs[0].Run = "Benchmark_Stat"
-		cfg.Benchmarking[0].Configs[1].Flags = []string{"--stat-cache-ttl=0 --enable-atomic-rename-object=true", "--stat-cache-ttl=0 --enable-atomic-rename-object=true --client-protocol=grpc"}
-		cfg.Benchmarking[0].Configs[1].Run = "Benchmark_Rename"
-		cfg.Benchmarking[0].Configs[2].Flags = []string{"--stat-cache-ttl=0", "--client-protocol=grpc --stat-cache-ttl=0"}
-		cfg.Benchmarking[0].Configs[2].Run = "Benchmark_Delete"
+		log.Fatal("No configuration found for Benchmarking in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/buffered_read/setup_test.go
+++ b/tools/integration_tests/buffered_read/setup_test.go
@@ -64,33 +64,7 @@ func TestMain(m *testing.M) {
 
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.BufferedRead) == 0 {
-		log.Println("No configuration found for buffered_read tests in config. Using flags instead.")
-		cfg.BufferedRead = make([]test_suite.TestConfig, 1)
-		cfg.BufferedRead[0].TestBucket = setup.TestBucket()
-		cfg.BufferedRead[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.BufferedRead[0].LogFile = setup.LogFile()
-		cfg.BufferedRead[0].Configs = make([]test_suite.ConfigItem, 3)
-
-		cfg.BufferedRead[0].Configs[0].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestBufferedReadSuite.log --log-severity=TRACE",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=1 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestBufferedReadSuite.log --log-severity=TRACE",
-		}
-		cfg.BufferedRead[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.BufferedRead[0].Configs[0].Run = "TestSequentialReadSuite"
-
-		cfg.BufferedRead[0].Configs[1].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log --log-severity=TRACE",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-min-blocks-per-handle=2 --read-global-max-blocks=1 --read-max-blocks-per-handle=10 --read-start-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log --log-severity=TRACE",
-		}
-		cfg.BufferedRead[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.BufferedRead[0].Configs[1].Run = "TestInsufficientPoolCreationSuite"
-
-		cfg.BufferedRead[0].Configs[2].Flags = []string{
-			"--enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log --log-severity=TRACE",
-			"--client-protocol=grpc --enable-buffered-read --read-block-size-mb=8 --read-max-blocks-per-handle=20 --read-start-blocks-per-handle=2 --read-min-blocks-per-handle=2 --enable-kernel-reader=false --log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log --log-severity=TRACE",
-		}
-		cfg.BufferedRead[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.BufferedRead[0].Configs[2].Run = "TestRandomReadFallbackSuite"
+		log.Fatal("No configuration found for BufferedRead in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/dentry_cache/setup_test.go
+++ b/tools/integration_tests/dentry_cache/setup_test.go
@@ -64,28 +64,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.DentryCache) == 0 {
-		log.Println("No configuration found for dentry_cache tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.DentryCache = make([]test_suite.TestConfig, 1)
-		cfg.DentryCache[0].TestBucket = setup.TestBucket()
-		cfg.DentryCache[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.DentryCache[0].LogFile = setup.LogFile()
-		cfg.DentryCache[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.DentryCache[0].Configs[0].Flags = []string{
-			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=2",
-		}
-		cfg.DentryCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.DentryCache[0].Configs[0].Run = "TestStatWithDentryCacheEnabledTest"
-		cfg.DentryCache[0].Configs[1].Flags = []string{
-			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000",
-		}
-		cfg.DentryCache[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.DentryCache[0].Configs[1].Run = "TestDeleteOperationTest"
-		cfg.DentryCache[0].Configs[2].Flags = []string{
-			"--implicit-dirs --experimental-enable-dentry-cache --metadata-cache-ttl-secs=1000",
-		}
-		cfg.DentryCache[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.DentryCache[0].Configs[2].Run = "TestNotifierTest"
+		log.Fatal("No configuration found for DentryCache in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/explicit_dir/explicit_dir_test.go
+++ b/tools/integration_tests/explicit_dir/explicit_dir_test.go
@@ -47,14 +47,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ExplicitDir) == 0 {
-		log.Println("No configuration found for explicit_dir tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.ExplicitDir = make([]test_suite.TestConfig, 1)
-		cfg.ExplicitDir[0].TestBucket = setup.TestBucket()
-		cfg.ExplicitDir[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.ExplicitDir[0].Configs = make([]test_suite.ConfigItem, 1)
-		cfg.ExplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs=false", "--implicit-dirs=false --client-protocol=grpc"}
-		cfg.ExplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
+		log.Fatal("No configuration found for ExplicitDir in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/gzip/gzip_test.go
+++ b/tools/integration_tests/gzip/gzip_test.go
@@ -197,17 +197,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.Gzip) == 0 {
-		log.Println("No configuration found for gzip tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.Gzip = make([]test_suite.TestConfig, 1)
-		cfg.Gzip[0].TestBucket = setup.TestBucket()
-		cfg.Gzip[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.Gzip[0].Configs = make([]test_suite.ConfigItem, 1)
-		cfg.Gzip[0].Configs[0].Flags = []string{
-			"--sequential-read-size-mb=1 --implicit-dirs",
-			"--sequential-read-size-mb=1 --implicit-dirs --client-protocol=grpc",
-		}
-		cfg.Gzip[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		log.Fatal("No configuration found for Gzip in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -66,16 +66,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ImplicitDir) == 0 {
-		log.Println("No configuration found for implicit_dir tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.ImplicitDir = make([]test_suite.TestConfig, 1)
-		cfg.ImplicitDir[0].TestBucket = setup.TestBucket()
-		cfg.ImplicitDir[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.ImplicitDir[0].Configs = make([]test_suite.ConfigItem, 2)
-		cfg.ImplicitDir[0].Configs[0].Flags = []string{"--implicit-dirs"}
-		cfg.ImplicitDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ImplicitDir[0].Configs[1].Flags = []string{"--implicit-dirs --client-protocol=grpc"}
-		cfg.ImplicitDir[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+		log.Fatal("No configuration found for ImplicitDir in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/inactive_stream_timeout/setup_test.go
+++ b/tools/integration_tests/inactive_stream_timeout/setup_test.go
@@ -132,26 +132,7 @@ func TestMain(m *testing.M) {
 	// 1. read config file
 	configFile := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(configFile.InactiveStreamTimeout) == 0 {
-		log.Println("No configuration found for inactive_stream_timeout tests in config. Using default flags.")
-		configFile.InactiveStreamTimeout = make([]test_suite.TestConfig, 1)
-		testEnv.cfg = &configFile.InactiveStreamTimeout[0]
-		testEnv.cfg.TestBucket = setup.TestBucket()
-		testEnv.cfg.LogFile = setup.LogFile()
-		testEnv.cfg.GKEMountedDirectory = setup.MountedDirectory()
-
-		testEnv.cfg.Configs = make([]test_suite.ConfigItem, 2)
-		testEnv.cfg.Configs[0].Flags = []string{
-			"--read-inactive-stream-timeout=1s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log",
-			"--read-inactive-stream-timeout=1s --client-protocol=grpc --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log",
-		}
-		testEnv.cfg.Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		testEnv.cfg.Configs[0].Run = "TestTimeoutEnabledSuite"
-
-		testEnv.cfg.Configs[1].Flags = []string{
-			"--read-inactive-stream-timeout=0s --client-protocol=http1 --log-format=json --log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log",
-		}
-		testEnv.cfg.Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		testEnv.cfg.Configs[1].Run = "TestTimeoutDisabledSuite"
+		log.Fatal("No configuration found for InactiveStreamTimeout in config file.")
 	}
 	testEnv.cfg = &configFile.InactiveStreamTimeout[0]
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/interrupt/interrupt_test.go
+++ b/tools/integration_tests/interrupt/interrupt_test.go
@@ -47,22 +47,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.Interrupt) == 0 {
-		log.Println("No configuration found for interrupt tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.Interrupt = make([]test_suite.TestConfig, 1)
-		cfg.Interrupt[0].TestBucket = setup.TestBucket()
-		cfg.Interrupt[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.Interrupt[0].Configs = make([]test_suite.ConfigItem, 2)
-		cfg.Interrupt[0].Configs[0].Flags = []string{
-			"--implicit-dirs=true --enable-streaming-writes=false",
-			"--ignore-interrupts=true --enable-streaming-writes=false",
-			"--ignore-interrupts=false --enable-streaming-writes=false",
-		}
-		cfg.Interrupt[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.Interrupt[0].Configs[1].Flags = []string{
-			"--enable-streaming-writes=true",
-		}
-		cfg.Interrupt[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+		log.Fatal("No configuration found for Interrupt in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/list_large_dir/list_large_dir_test.go
+++ b/tools/integration_tests/list_large_dir/list_large_dir_test.go
@@ -57,24 +57,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ListLargeDir) == 0 {
-		log.Println("No configuration found for list large dir tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.ListLargeDir = make([]test_suite.TestConfig, 1)
-		cfg.ListLargeDir[0].TestBucket = setup.TestBucket()
-		cfg.ListLargeDir[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.ListLargeDir[0].Configs = make([]test_suite.ConfigItem, 2)
-		cfg.ListLargeDir[0].Configs[0].Flags = []string{
-			"--implicit-dirs=true,--stat-cache-ttl=0,--kernel-list-cache-ttl-secs=-1",
-			"--client-protocol=grpc,--implicit-dirs=true,--stat-cache-ttl=0,--kernel-list-cache-ttl-secs=-1",
-		}
-		cfg.ListLargeDir[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ListLargeDir[0].Configs[0].Run = "TestListLargeDirWithKernelListCache"
-		cfg.ListLargeDir[0].Configs[1].Flags = []string{
-			"--enable-metadata-prefetch --implicit-dirs=true",
-			"--client-protocol=grpc --enable-metadata-prefetch --implicit-dirs=true",
-		}
-		cfg.ListLargeDir[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ListLargeDir[0].Configs[1].Run = "TestListLargeDirWithoutKernelListCache"
+		log.Fatal("No configuration found for ListLargeDir in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/local_file/setup_test.go
+++ b/tools/integration_tests/local_file/setup_test.go
@@ -44,23 +44,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.LocalFile) == 0 {
-		log.Println("No configuration found for LocalFile tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.LocalFile = make([]test_suite.TestConfig, 1)
-		cfg.LocalFile[0].TestBucket = setup.TestBucket()
-		cfg.LocalFile[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.LocalFile[0].Configs = make([]test_suite.ConfigItem, 2)
-		cfg.LocalFile[0].Configs[0].Flags = []string{
-			"--implicit-dirs=true --rename-dir-limit=3 --enable-streaming-writes=false",
-			"--implicit-dirs=false --rename-dir-limit=3 --enable-streaming-writes=false --client-protocol=grpc",
-			"--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --write-global-max-blocks=0",
-		}
-		cfg.LocalFile[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.LocalFile[0].Configs[1].Flags = []string{
-			"--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --write-global-max-blocks=-1 --client-protocol=grpc",
-			"--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --write-global-max-blocks=-1",
-		}
-		cfg.LocalFile[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+		log.Fatal("No configuration found for LocalFile in config file.")
 	}
 
 	// 2. Create storage client before running tests.

--- a/tools/integration_tests/managed_folders/managed_folders_test.go
+++ b/tools/integration_tests/managed_folders/managed_folders_test.go
@@ -68,23 +68,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ManagedFolders) == 0 {
-		log.Println("No configuration found for managed_folders tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.ManagedFolders = make([]test_suite.TestConfig, 1)
-		cfg.ManagedFolders[0].TestBucket = setup.TestBucket()
-		cfg.ManagedFolders[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.ManagedFolders[0].LogFile = setup.LogFile()
-		// Initialize the slice to hold 15 specific test configurations
-		cfg.ManagedFolders[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.ManagedFolders[0].Configs[0].Flags = []string{"--implicit-dirs --key-file=${KEY_FILE} --rename-dir-limit=3"}
-		cfg.ManagedFolders[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ManagedFolders[0].Configs[0].Run = "TestManagedFolders_FolderViewPermission"
-		cfg.ManagedFolders[0].Configs[1].Flags = []string{"--implicit-dirs --enable-empty-managed-folders"}
-		cfg.ManagedFolders[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ManagedFolders[0].Configs[1].Run = "TestEnableEmptyManagedFoldersTrue"
-		cfg.ManagedFolders[0].Configs[2].Flags = []string{"--implicit-dirs --key-file=${KEY_FILE} --rename-dir-limit=5 --stat-cache-ttl=0"}
-		cfg.ManagedFolders[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ManagedFolders[0].Configs[2].Run = "TestManagedFolders_FolderAdminPermission"
+		log.Fatal("No configuration found for ManagedFolders in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -145,10 +145,7 @@ func TestMain(m *testing.M) {
 	// Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.MountTimeout) == 0 {
-		log.Println("No configuration found for mount_timeout tests in config. Using flags instead.")
-		cfg.MountTimeout = make([]test_suite.TestConfig, 1)
-		cfg.MountTimeout[0].TestBucket = setup.TestBucket()
-		cfg.MountTimeout[0].GKEMountedDirectory = setup.MountedDirectory()
+		log.Fatal("No configuration found for MountTimeout in config file.")
 	}
 
 	// Skip for GKE or mounted directory tests.

--- a/tools/integration_tests/negative_stat_cache/setup_test.go
+++ b/tools/integration_tests/negative_stat_cache/setup_test.go
@@ -66,23 +66,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.NegativeStatCache) == 0 {
-		log.Println("No configuration found for negative_stat_cache tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.NegativeStatCache = make([]test_suite.TestConfig, 1)
-		cfg.NegativeStatCache[0].TestBucket = setup.TestBucket()
-		cfg.NegativeStatCache[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.NegativeStatCache[0].LogFile = setup.LogFile()
-		// Initialize the slice to hold specific test configurations
-		cfg.NegativeStatCache[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.NegativeStatCache[0].Configs[0].Flags = []string{"--metadata-cache-negative-ttl-secs=0"}
-		cfg.NegativeStatCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.NegativeStatCache[0].Configs[0].Run = "TestDisabledNegativeStatCacheTest"
-		cfg.NegativeStatCache[0].Configs[1].Flags = []string{"--metadata-cache-negative-ttl-secs=5"}
-		cfg.NegativeStatCache[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.NegativeStatCache[0].Configs[1].Run = "TestFiniteNegativeStatCacheTest"
-		cfg.NegativeStatCache[0].Configs[2].Flags = []string{"--metadata-cache-negative-ttl-secs=-1"}
-		cfg.NegativeStatCache[0].Configs[2].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.NegativeStatCache[0].Configs[2].Run = "TestInfiniteNegativeStatCacheTest"
+		log.Fatal("No configuration found for NegativeStatCache in config file.")
 	}
 
 	testEnv.ctx = context.Background()


### PR DESCRIPTION
### Description
Cleanup of legacy manual configuration setups for 13 e2e test packages. 

The flag configurations for these tests are now defined and executed via `test_config.yaml`, rendering the hardcoded configurations inside the `setup_test.go` and `*_test.go` files obsolete. Removing this unused code ensures that `test_config.yaml` acts as the single source of truth for all e2e test configurations.

The packages cleaned up include:
- `benchmarking`
- `buffered_read`
- `dentry_cache`
- `explicit_dir`
- `gzip`
- `implicit_dir`
- `inactive_stream_timeout`
- `interrupt`
- `list_large_dir`
- `local_file`
- `managed_folders`
- `mount_timeout`
- `negative_stat_cache`

### Link to the issue in case of a bug fix.
[b/438068132](https://buganizer.corp.google.com/issues/438068132)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Kokoro

### Any backward incompatible change? If so, please explain.
None