### PR TITLE
chore(cleanup): e2e test packages cleanup (Part 2)

### DIFF
--- a/tools/integration_tests/release_version/setup_test.go
+++ b/tools/integration_tests/release_version/setup_test.go
@@ -29,10 +29,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.ReleaseVersion) == 0 {
-		log.Println("No configuration found for release_version tests in config. Using flags instead.")
-		cfg.ReleaseVersion = make([]test_suite.TestConfig, 1)
-		cfg.ReleaseVersion[0].TestBucket = setup.TestBucket()
-		cfg.ReleaseVersion[0].GKEMountedDirectory = setup.MountedDirectory()
+		log.Fatal("No configuration found for ReleaseVersion in config file.")
 	}
 
 	// 2. Not running mounted directory tests.

--- a/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
+++ b/tools/integration_tests/rename_dir_limit/rename_dir_limit_test.go
@@ -55,22 +55,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.RenameDirLimit) == 0 {
-		log.Println("No configuration found for rename dir limit tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.RenameDirLimit = make([]test_suite.TestConfig, 1)
-		cfg.RenameDirLimit[0].TestBucket = setup.TestBucket()
-		cfg.RenameDirLimit[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.RenameDirLimit[0].Configs = make([]test_suite.ConfigItem, 2)
-		cfg.RenameDirLimit[0].Configs[0].Flags = []string{
-			"--rename-dir-limit=3 --implicit-dirs --client-protocol=grpc",
-			"--rename-dir-limit=3",
-			"--rename-dir-limit=3 --client-protocol=grpc",
-		}
-		cfg.RenameDirLimit[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": false, "zonal": false}
-		cfg.RenameDirLimit[0].Configs[1].Flags = []string{
-			"",
-		}
-		cfg.RenameDirLimit[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": true, "zonal": true}
+		log.Fatal("No configuration found for RenameDirLimit in config file.")
 	}
 
 	ctx = context.Background()

--- a/tools/integration_tests/requester_pays_bucket/setup_test.go
+++ b/tools/integration_tests/requester_pays_bucket/setup_test.go
@@ -81,18 +81,7 @@ func TestMain(m *testing.M) {
 	// Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.RequesterPaysBucket) == 0 {
-		log.Println("No configuration found for requester pays bucket tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.RequesterPaysBucket = make([]test_suite.TestConfig, 1)
-		cfg.RequesterPaysBucket[0].TestBucket = setup.TestBucket()
-		cfg.RequesterPaysBucket[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.RequesterPaysBucket[0].Configs = make([]test_suite.ConfigItem, 1)
-		cfg.RequesterPaysBucket[0].Configs[0].Flags = []string{
-			"--billing-project=${BILLING_PROJECT} --key-file=${KEY_FILE}",
-			"--billing-project=${BILLING_PROJECT} --client-protocol=grpc --key-file=${KEY_FILE}",
-			"--billing-project=${BILLING_PROJECT} --client-protocol=grpc --grpc-path-strategy=direct-path-only --key-file=${KEY_FILE}",
-		}
-		cfg.RequesterPaysBucket[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": false}
+		log.Fatal("No configuration found for RequesterPaysBucket in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/shared_chunk_cache/setup_test.go
+++ b/tools/integration_tests/shared_chunk_cache/setup_test.go
@@ -49,23 +49,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.SharedChunkCache) == 0 {
-		log.Println("No configuration found for shared_chunk_cache tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.SharedChunkCache = make([]test_suite.TestConfig, 1)
-		cfg.SharedChunkCache[0].TestBucket = setup.TestBucket()
-		cfg.SharedChunkCache[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.SharedChunkCache[0].LogFile = setup.LogFile()
-		cfg.SharedChunkCache[0].Configs = make([]test_suite.ConfigItem, 1)
-
-		// TestSharedChunkCacheTestSuite - dual mount with shared cache
-		cfg.SharedChunkCache[0].Configs[0].Flags = []string{
-			"--enable-experimental-shared-chunk-cache --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/shared-cache",
-		}
-		cfg.SharedChunkCache[0].Configs[0].SecondaryFlags = []string{
-			"--enable-experimental-shared-chunk-cache --file-cache-max-size-mb=-1 --cache-dir=/gcsfuse-tmp/shared-cache",
-		}
-		cfg.SharedChunkCache[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.SharedChunkCache[0].Configs[0].Run = "TestSharedChunkCacheTestSuite"
+		log.Fatal("No configuration found for SharedChunkCache in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/stale_handle/setup_test.go
+++ b/tools/integration_tests/stale_handle/setup_test.go
@@ -56,30 +56,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.StaleHandle) == 0 {
-		log.Println("No configuration found for stale_handle tests in config. Using flags instead.")
-		if setup.MountedDirectory() != "" {
-			log.Println("Skip mounted directory tests if no config file has been passed.")
-			os.Exit(0)
-		}
-		// Populate the config manually.
-		cfg.StaleHandle = make([]test_suite.TestConfig, 1)
-		cfg.StaleHandle[0].TestBucket = setup.TestBucket()
-		cfg.StaleHandle[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.StaleHandle[0].LogFile = setup.LogFile()
-		cfg.StaleHandle[0].Configs = make([]test_suite.ConfigItem, 4)
-		cfg.StaleHandle[0].Configs[0].Flags = []string{
-			"--metadata-cache-ttl-secs=0 --write-block-size-mb=1 --write-max-blocks-per-file=1",
-			"--metadata-cache-ttl-secs=0 --write-block-size-mb=1 --write-max-blocks-per-file=1 --client-protocol=grpc",
-		}
-		cfg.StaleHandle[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.StaleHandle[0].Configs[0].Run = "TestStaleHandleStreamingWritesEnabled"
-
-		cfg.StaleHandle[0].Configs[1].Flags = []string{
-			"--metadata-cache-ttl-secs=0 --enable-streaming-writes=false",
-			"--metadata-cache-ttl-secs=0 --enable-streaming-writes=false --client-protocol=grpc",
-		}
-		cfg.StaleHandle[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.StaleHandle[0].Configs[1].Run = "TestStaleHandleStreamingWritesDisabled"
+		log.Fatal("No configuration found for StaleHandle in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/streaming_writes/setup_test.go
+++ b/tools/integration_tests/streaming_writes/setup_test.go
@@ -46,18 +46,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.StreamingWrites) == 0 {
-		log.Println("No configuration found for streaming_writes tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.StreamingWrites = make([]test_suite.TestConfig, 1)
-		cfg.StreamingWrites[0].TestBucket = setup.TestBucket()
-		cfg.StreamingWrites[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.StreamingWrites[0].LogFile = setup.LogFile()
-		cfg.StreamingWrites[0].Configs = make([]test_suite.ConfigItem, 1)
-		cfg.StreamingWrites[0].Configs[0].Flags = []string{
-			"--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --client-protocol=grpc --write-global-max-blocks=-1",
-			"--rename-dir-limit=3 --write-block-size-mb=1 --write-max-blocks-per-file=2 --write-global-max-blocks=-1",
-		}
-		cfg.StreamingWrites[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
+		log.Fatal("No configuration found for StreamingWrites in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/symlink_handling/symlink_handling_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_handling_test.go
@@ -50,23 +50,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.SymlinkHandling) == 0 {
-		log.Println("No configuration found for symlink handling tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.SymlinkHandling = make([]test_suite.TestConfig, 1)
-		cfg.SymlinkHandling[0].TestBucket = setup.TestBucket()
-		cfg.SymlinkHandling[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.SymlinkHandling[0].LogFile = setup.LogFile()
-		cfg.SymlinkHandling[0].Configs = make([]test_suite.ConfigItem, 2)
-
-		// 1. TestStandardSymlinksTestSuite
-		cfg.SymlinkHandling[0].Configs[0].Flags = []string{"--enable-standard-symlinks=true"}
-		cfg.SymlinkHandling[0].Configs[0].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.SymlinkHandling[0].Configs[0].Run = "TestStandardSymlinksTestSuite"
-
-		// 2. TestLegacySymlinksTestSuite
-		cfg.SymlinkHandling[0].Configs[1].Flags = []string{"--enable-standard-symlinks=false"}
-		cfg.SymlinkHandling[0].Configs[1].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.SymlinkHandling[0].Configs[1].Run = "TestLegacySymlinksTestSuite"
+		log.Fatal("No configuration found for SymlinkHandling in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/unfinalized_object/setup_test.go
+++ b/tools/integration_tests/unfinalized_object/setup_test.go
@@ -53,31 +53,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.UnfinalizedObject) == 0 {
-		log.Println("No configuration found for unfinalized_object tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.UnfinalizedObject = make([]test_suite.TestConfig, 1)
-		cfg.UnfinalizedObject[0].TestBucket = setup.TestBucket()
-		cfg.UnfinalizedObject[0].GKEMountedDirectory = setup.MountedDirectory()
-		cfg.UnfinalizedObject[0].LogFile = setup.LogFile()
-		cfg.UnfinalizedObject[0].Configs = make([]test_suite.ConfigItem, 3)
-		cfg.UnfinalizedObject[0].Configs[0].Flags = []string{
-			"--metadata-cache-ttl-secs=-1",
-			"--metadata-cache-ttl-secs=-1 --enable-kernel-reader=false",
-		}
-		cfg.UnfinalizedObject[0].Configs[0].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
-		cfg.UnfinalizedObject[0].Configs[0].Run = "TestUnfinalizedObjectReadTest"
-		cfg.UnfinalizedObject[0].Configs[1].Flags = []string{
-			"--metadata-cache-ttl-secs=0",
-			"--metadata-cache-ttl-secs=0 --enable-kernel-reader=false",
-		}
-		cfg.UnfinalizedObject[0].Configs[1].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
-		cfg.UnfinalizedObject[0].Configs[1].Run = "TestUnfinalizedObjectOperationTest"
-		cfg.UnfinalizedObject[0].Configs[2].Flags = []string{
-			"--metadata-cache-ttl-secs=2",
-			"--metadata-cache-ttl-secs=2 --enable-kernel-reader=false",
-		}
-		cfg.UnfinalizedObject[0].Configs[2].Compatible = map[string]bool{"flat": false, "hns": false, "zonal": true}
-		cfg.UnfinalizedObject[0].Configs[2].Run = "TestUnfinalizedObjectTailingReadTest"
+		log.Fatal("No configuration found for UnfinalizedObject in config file.")
 	}
 
 	testEnv.ctx = context.Background()

--- a/tools/integration_tests/unsupported_path/setup_test.go
+++ b/tools/integration_tests/unsupported_path/setup_test.go
@@ -40,28 +40,7 @@ func TestMain(m *testing.M) {
 	// 1. Load and parse the common configuration.
 	cfg := test_suite.ReadConfigFile(setup.ConfigFile())
 	if len(cfg.UnsupportedPath) == 0 {
-		log.Println("No configuration found for unsupported path tests in config. Using flags instead.")
-		// Populate the config manually.
-		cfg.UnsupportedPath = []test_suite.TestConfig{
-			{
-				TestBucket:          setup.TestBucket(),
-				GKEMountedDirectory: setup.MountedDirectory(),
-				Configs: []test_suite.ConfigItem{
-					{
-						Flags: []string{
-							"--implicit-dirs --client-protocol=grpc --enable-unsupported-path-support=true --rename-dir-limit=200 --metadata-cache-negative-ttl-secs=0",
-						},
-						Compatible: map[string]bool{"flat": true, "hns": true, "zonal": false},
-					},
-					{
-						Flags: []string{
-							"--implicit-dirs --enable-unsupported-path-support=true --rename-dir-limit=200 --metadata-cache-negative-ttl-secs=0",
-						},
-						Compatible: map[string]bool{"flat": true, "hns": true, "zonal": true},
-					},
-				},
-			},
-		}
+		log.Fatal("No configuration found for UnsupportedPath in config file.")
 	}
 
 	ctx = context.Background()

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -15,13 +15,11 @@
 package dynamic_mounting
 
 import (
-	"context"
 	"fmt"
 	"log"
 	"path"
 	"testing"
 
-	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
@@ -92,18 +90,6 @@ func executeTestsForDynamicMounting(config *test_suite.TestConfig, flagsSet [][]
 	setup.SetDynamicBucketMounted("")
 
 	return
-}
-
-// Deprecated: Use RunTestsWithConfigFile instead.
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func RunTests(ctx context.Context, client *storage.Client, flags [][]string, m *testing.M) (successCode int) {
-	config := &test_suite.TestConfig{
-		TestBucket:              setup.TestBucket(),
-		GKEMountedDirectory:     setup.MountedDirectory(),
-		GCSFuseMountedDirectory: setup.MntDir(),
-		LogFile:                 setup.LogFile(),
-	}
-	return RunTestsWithConfigFile(config, flags, m)
 }
 
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -26,18 +26,6 @@ import (
 	"golang.org/x/net/context"
 )
 
-// Deprecated: Use MountGcsfuseWithOnlyDirMountingWithConfigFile instead.
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func MountGcsfuseWithOnlyDir(flags []string) (err error) {
-	config := &test_suite.TestConfig{
-		TestBucket:              setup.TestBucket(),
-		GKEMountedDirectory:     setup.MountedDirectory(),
-		GCSFuseMountedDirectory: setup.MntDir(),
-		LogFile:                 setup.LogFile(),
-	}
-	return MountGcsfuseWithOnlyDirWithConfigFile(config, flags)
-}
-
 func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{"--only-dir",
 		setup.OnlyDirMounted(),
@@ -102,18 +90,6 @@ func executeTestsForOnlyDirMounting(config *test_suite.TestConfig, flags [][]str
 	// Reset onlyDirMounted value to empty string after only dir mount tests are done.
 	setup.SetOnlyDirMounted("")
 	return
-}
-
-// Deprecated: Use RunTestsWithConfigFile instead.
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func RunTests(flags [][]string, dirName string, m *testing.M) (successCode int) {
-	config := &test_suite.TestConfig{
-		TestBucket:              setup.TestBucket(),
-		GKEMountedDirectory:     setup.MountedDirectory(),
-		GCSFuseMountedDirectory: setup.MntDir(),
-		LogFile:                 setup.LogFile(),
-	}
-	return RunTestsWithConfigFile(config, flags, dirName, m)
 }
 
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, dirName string, m *testing.M) (successCode int) {

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -79,18 +79,6 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 	return
 }
 
-// Deprecated: Use RunTestsWithConfigFile instead.
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
-	config := &test_suite.TestConfig{
-		TestBucket:              setup.TestBucket(),
-		GKEMountedDirectory:     setup.MountedDirectory(),
-		GCSFuseMountedDirectory: setup.MntDir(),
-		LogFile:                 setup.LogFile(),
-	}
-	return RunTestsWithConfigFile(config, flagsSet, m)
-}
-
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running persistent mounting tests...")
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -71,18 +71,6 @@ func executeTestsForStaticMounting(config *test_suite.TestConfig, flagsSet [][]s
 	return
 }
 
-// Deprecated: Use RunTestsWithConfigFile instead.
-// TODO(b/438068132): cleanup deprecated methods after migration is complete.
-func RunTests(flagsSet [][]string, m *testing.M) (successCode int) {
-	config := &test_suite.TestConfig{
-		TestBucket:              setup.TestBucket(),
-		GKEMountedDirectory:     setup.MountedDirectory(),
-		GCSFuseMountedDirectory: setup.MntDir(),
-		LogFile:                 setup.LogFile(),
-	}
-	return RunTestsWithConfigFile(config, flagsSet, m)
-}
-
 func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, m *testing.M) (successCode int) {
 	log.Println("Running static mounting tests...")
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)


### PR DESCRIPTION
### Description
Cleanup of legacy e2e test configuration code (Part 2). 
Since the tests are currently run using `test_config.yaml`, the manual fallback configuration blocks in these packages are no longer required. Removing this code enforces `test_config.yaml` as the single source of truth for test configurations and reduces maintenance overhead.

Specifically, this branch `remove-unused-e2e-test-code-2` accomplishes the following:

* Removes unused manual test configurations and replaces them with a fatal log in 9 test packages (`release_version`, `rename_dir_limit`, `requester_pays_bucket`, `shared_chunk_cache`, `stale_handle`, `streaming_writes`, `symlink_handling`, `unfinalized_object`, `unsupported_path`).
* Removes the deprecated `RunTests` and `MountGcsfuseWithOnlyDir` methods from the `util/mounting` packages (`dynamic_mounting`, `only_dir_mounting`, `persistent_mounting`, `static_mounting`) as they have been fully migrated to use the config file equivalents.

### Link to the issue in case of a bug fix.
[b/438068132](https://buganizer.corp.google.com/issues/438068132)

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Kokoro

### Any backward incompatible change? If so, please explain.
No backward incompatible changes.
