### PR TITLE
feat(kernel range reader): Add thread-safe LIFO BufferPool with mmap allocation and sync.Pool fallback

### DIFF
--- a/internal/fs/buffer_pool.go
+++ b/internal/fs/buffer_pool.go
@@ -1,0 +1,176 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"unsafe"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+)
+
+// BufferPool manages a pool of bufferSize buffers.
+// It allocates static buffers via mmap on-demand up to maxStatic.
+// If mmap allocation fails or more buffers are needed concurrently, it falls back
+// to a sync.Pool of Go-allocated buffers.
+type BufferPool struct {
+	mu            sync.Mutex
+	staticBuffers [][]byte // LIFO stack of static buffers
+	staticMap     sync.Map // map[uintptr][]byte for routing
+	fallbackPool  sync.Pool
+	bufferSize    int
+	maxStatic     int
+	allocated     int32 // atomic count of allocated static buffers
+}
+
+// NewBufferPool creates and initializes a BufferPool.
+func NewBufferPool(maxStatic int, bufferSize int) *BufferPool {
+	return &BufferPool{
+		staticBuffers: make([][]byte, 0, maxStatic),
+		bufferSize:    bufferSize,
+		maxStatic:     maxStatic,
+		fallbackPool: sync.Pool{
+			New: func() interface{} {
+				return make([]byte, bufferSize)
+			},
+		},
+	}
+}
+
+// allocateAndRegisterStatic allocates a single static buffer via mmap
+// and registers it in the staticMap.
+func (bp *BufferPool) allocateAndRegisterStatic() ([]byte, error) {
+	buf, err := allocateMmap(bp.bufferSize)
+	if err != nil {
+		return nil, err
+	}
+
+	bp.staticMap.Store(uintptr(unsafe.Pointer(&buf[0])), buf)
+	return buf, nil
+}
+
+// Get retrieves a buffer of bufferSize from the pool.
+// It attempts to get a static buffer first (either from the pre-allocated stack
+// or by allocating a new one on-demand if the limit is not reached),
+// falling back to the sync.Pool.
+func (bp *BufferPool) Get() []byte {
+	if buf := bp.pop(); buf != nil {
+		return buf
+	}
+
+	// Try to allocate a new static buffer on-demand if we haven't reached maxStatic.
+	if bp.tryAllocate() {
+		buf, err := bp.allocateAndRegisterStatic()
+		if err == nil {
+			return buf
+		}
+		logger.Warnf("Failed to allocate static buffer via mmap: %v. Falling back to sync.Pool.", err)
+		atomic.AddInt32(&bp.allocated, -1)
+	}
+
+	// Fallback to sync.Pool.
+	return bp.fallbackPool.Get().([]byte)
+}
+
+// Put returns a buffer to the pool.
+// It routes the buffer back to the static pool if it was one of the mmap'ed static buffers,
+// otherwise it returns it to the fallback sync.Pool.
+func (bp *BufferPool) Put(buf []byte) {
+	if len(buf) == 0 {
+		return
+	}
+
+	// Restore the slice to its full capacity before checking and returning.
+	buf = buf[:cap(buf)]
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+
+	if val, ok := bp.staticMap.Load(ptr); ok {
+		bp.push(val.([]byte))
+	} else {
+		bp.fallbackPool.Put(buf)
+	}
+}
+
+// pop retrieves a buffer from the static stack in a thread-safe manner.
+func (bp *BufferPool) pop() []byte {
+	bp.mu.Lock()
+	n := len(bp.staticBuffers)
+	if n == 0 {
+		bp.mu.Unlock()
+		return nil
+	}
+	buf := bp.staticBuffers[n-1]
+	bp.staticBuffers = bp.staticBuffers[:n-1]
+	bp.mu.Unlock()
+	return buf
+}
+
+// push adds a buffer back to the static stack in a thread-safe manner.
+func (bp *BufferPool) push(buf []byte) {
+	bp.mu.Lock()
+	bp.staticBuffers = append(bp.staticBuffers, buf)
+	bp.mu.Unlock()
+}
+
+// tryAllocate atomically attempts to reserve a slot for a new static buffer.
+// It returns true if a slot was successfully reserved, or false if the limit has been reached.
+func (bp *BufferPool) tryAllocate() bool {
+	for {
+		curr := atomic.LoadInt32(&bp.allocated)
+		if curr >= int32(bp.maxStatic) {
+			return false
+		}
+		if atomic.CompareAndSwapInt32(&bp.allocated, curr, curr+1) {
+			return true
+		}
+	}
+}
+
+// Close deallocates all static buffers that were allocated via mmap.
+func (bp *BufferPool) Close() error {
+	var errs []error
+	bp.staticMap.Range(func(key, value interface{}) bool {
+		buf := value.([]byte)
+		if err := deallocateMmap(buf); err != nil {
+			errs = append(errs, err)
+		}
+		return true
+	})
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("errors closing buffer pool: %w", err)
+	}
+	return nil
+}
+
+func allocateMmap(size int) ([]byte, error) {
+	prot := syscall.PROT_READ | syscall.PROT_WRITE
+	flags := syscall.MAP_ANON | syscall.MAP_PRIVATE
+	addr, err := syscall.Mmap(-1, 0, size, prot, flags)
+	if err != nil {
+		return nil, err
+	}
+	return addr, nil
+}
+
+func deallocateMmap(buf []byte) error {
+	if buf == nil {
+		return nil
+	}
+	return syscall.Munmap(buf)
+}

--- a/internal/fs/buffer_pool_test.go
+++ b/internal/fs/buffer_pool_test.go
@@ -1,0 +1,219 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewBufferPool_StartupState(t *testing.T) {
+	// Arrange
+	maxStatic := 5
+	bufferSize := 1024
+
+	// Act
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+
+	// Assert
+	assert.Equal(t, int32(0), bp.allocated)
+	bp.mu.Lock()
+	stackLen := len(bp.staticBuffers)
+	bp.mu.Unlock()
+	assert.Equal(t, 0, stackLen)
+}
+
+func TestBufferPool_Get_OnDemandAllocation(t *testing.T) {
+	// Arrange
+	maxStatic := 5
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+
+	// Act
+	buf := bp.Get()
+
+	// Assert
+	require.Len(t, buf, bufferSize)
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+	_, registered := bp.staticMap.Load(ptr)
+	assert.True(t, registered)
+	assert.Equal(t, int32(1), bp.allocated)
+}
+
+func TestBufferPool_Get_ReuseFromStack(t *testing.T) {
+	// Arrange
+	maxStatic := 5
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+	originalBuf := bp.Get()
+	originalPtr := uintptr(unsafe.Pointer(&originalBuf[0]))
+	bp.Put(originalBuf) // Put it back to stack
+
+	// Act
+	reusedBuf := bp.Get()
+
+	// Assert
+	reusedPtr := uintptr(unsafe.Pointer(&reusedBuf[0]))
+	assert.Equal(t, originalPtr, reusedPtr)
+	assert.Equal(t, int32(1), bp.allocated)
+}
+
+func TestBufferPool_Get_FallbackToSyncPool(t *testing.T) {
+	// Arrange
+	maxStatic := 2
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+	// Exhaust static pool
+	_ = bp.Get()
+	_ = bp.Get()
+
+	// Act
+	fallbackBuf := bp.Get()
+
+	// Assert
+	require.Len(t, fallbackBuf, bufferSize)
+	fbPtr := uintptr(unsafe.Pointer(&fallbackBuf[0]))
+	_, registered := bp.staticMap.Load(fbPtr)
+	assert.False(t, registered)
+	assert.Equal(t, int32(2), bp.allocated)
+}
+
+func TestBufferPool_Put_RestoresCapacityOfSlicedBuffer(t *testing.T) {
+	// Arrange
+	maxStatic := 2
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+	originalBuf := bp.Get()
+	originalPtr := uintptr(unsafe.Pointer(&originalBuf[0]))
+
+	// Act
+	slicedBuf := originalBuf[:100]
+	bp.Put(slicedBuf)
+	reusedBuf := bp.Get()
+
+	// Assert
+	reusedPtr := uintptr(unsafe.Pointer(&reusedBuf[0]))
+	assert.Equal(t, originalPtr, reusedPtr)
+	assert.Len(t, reusedBuf, bufferSize)
+}
+
+func TestBufferPool_Put_StaticBuffer(t *testing.T) {
+	// Arrange
+	maxStatic := 2
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+	buf := bp.Get()
+	ptr := uintptr(unsafe.Pointer(&buf[0]))
+
+	// Act
+	bp.Put(buf)
+
+	// Assert
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	require.Len(t, bp.staticBuffers, 1)
+	returnedPtr := uintptr(unsafe.Pointer(&bp.staticBuffers[0][0]))
+	assert.Equal(t, ptr, returnedPtr)
+}
+
+func TestBufferPool_Put_FallbackToSyncPool(t *testing.T) {
+	// Arrange
+	maxStatic := 1
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	defer bp.Close()
+	_ = bp.Get()            // Exhaust static pool
+	fallbackBuf := bp.Get() // Get fallback buffer from sync.Pool
+
+	// Act
+	bp.Put(fallbackBuf)
+
+	// Assert
+	bp.mu.Lock()
+	stackLen := len(bp.staticBuffers)
+	bp.mu.Unlock()
+	assert.Equal(t, 0, stackLen)
+	assert.Equal(t, int32(1), bp.allocated)
+}
+
+func TestBufferPool_Close_Success(t *testing.T) {
+	// Arrange
+	maxStatic := 3
+	bufferSize := 1024
+	bp := NewBufferPool(maxStatic, bufferSize)
+	// Allocate buffers to ensure they are registered in the static map
+	_ = bp.Get()
+	_ = bp.Get()
+
+	// Act
+	err := bp.Close()
+
+	// Assert
+	assert.NoError(t, err)
+}
+
+func BenchmarkBufferPool_Contention_Warmed(b *testing.B) {
+	staticCount := 50
+	bufferSize := 1024 * 1024 // 1MB
+	bp := NewBufferPool(staticCount, bufferSize)
+	defer bp.Close()
+
+	// Warm up the pool so all static buffers are allocated.
+	var bufs [][]byte
+	for i := 0; i < staticCount; i++ {
+		bufs = append(bufs, bp.Get())
+	}
+	for _, buf := range bufs {
+		bp.Put(buf)
+	}
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := bp.Get()
+			if len(buf) != bufferSize {
+				b.Fatalf("unexpected buffer size: %d", len(buf))
+			}
+			bp.Put(buf)
+		}
+	})
+}
+
+func BenchmarkBufferPool_Contention_Cold(b *testing.B) {
+	staticCount := 50
+	bufferSize := 1024 * 1024 // 1MB
+	bp := NewBufferPool(staticCount, bufferSize)
+	defer bp.Close()
+
+	b.ResetTimer()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			buf := bp.Get()
+			if len(buf) != bufferSize {
+				b.Fatalf("unexpected buffer size: %d", len(buf))
+			}
+			bp.Put(buf)
+		}
+	})
+}


### PR DESCRIPTION
### Description
# Description

This PR introduces a thread-safe **`BufferPool`** in GCSFuse to manage a pool of buffers. These buffers are used to optimize large read paths (such as the kernel reader path). 

The pool dynamically allocates static buffers via `mmap` on-demand up to a configured limit (`maxStatic`). When the static pool is exhausted, or if an allocation fails, it transparently falls back to a `sync.Pool` of Go-allocated buffers. This design prevents goroutines from blocking and ensures high throughput under heavy concurrent read workloads.

---

# Why Stack-Based (LIFO) Approach?

We chose a **LIFO (Last-In, First-Out) stack** (`staticBuffers [][]byte`) for managing the static buffers for the following reasons:

1. **Cache Locality:** The buffer most recently returned to the pool is the most likely to still reside in the CPU's cache hierarchy (L1/L2/L3). Reusing it immediately (LIFO) maximizes cache hits and reduces memory access latency compared to a FIFO queue.
2. **Low Overhead:** Slice append and pop operations on a LIFO stack are extremely fast ($O(1)$) and avoid complex index bookkeeping.
3. **Reduced Lock Contention:**
   * **Lock-free Slot Reservation:** The pool uses an atomic Compare-And-Swap (CAS) counter (`allocated`) to reserve slots up to `maxStatic` without holding any locks.
   * **Short Critical Section:** The mutex (`bp.mu`) is only held for the duration of pushing to or popping from the slice, which takes only a few nanoseconds.
   * This ensures the pool scales exceptionally well under high contention

---

# Benchmarking Results

We ran parallel benchmarks on an `Intel(R) Xeon(R) CPU @ 2.20GHz` (Linux/amd64) simulating concurrent workers (1 to 50 goroutines) requesting and releasing `1MiB` buffers.

### 1. Steady State (Warmed Cache)
*Static buffers are pre-allocated/warmed-up before the benchmark begins.*

| Concurrency (CPU Threads) | Throughput (ns/op) | Memory Allocation (B/op) | Allocs/op |
| :--- | :--- | :--- | :--- |
| **1** (No Contention) | **64.19 ns/op** | 0 B/op | 0 allocs/op |
| **2** | **83.64 ns/op** | 0 B/op | 0 allocs/op |
| **4** | **207.40 ns/op** | 0 B/op | 0 allocs/op |
| **8** | **295.70 ns/op** | 0 B/op | 0 allocs/op |
| **16** | **308.40 ns/op** | 0 B/op | 0 allocs/op |
| **32** | **242.20 ns/op** | 0 B/op | 0 allocs/op |
| **50** (High Contention) | **201.10 ns/op** | 0 B/op | 0 allocs/op |

### 2. On-Demand Allocation (Cold Cache)
*Static buffers are allocated on-demand via `mmap` during the benchmark.*

| Concurrency (CPU Threads) | Throughput (ns/op) | Memory Allocation (B/op) | Allocs/op |
| :--- | :--- | :--- | :--- |
| **1** (No Contention) | **61.62 ns/op** | 0 B/op | 0 allocs/op |
| **2** | **86.26 ns/op** | 0 B/op | 0 allocs/op |
| **4** | **202.40 ns/op** | 0 B/op | 0 allocs/op |
| **8** | **296.50 ns/op** | 0 B/op | 0 allocs/op |
| **16** | **306.70 ns/op** | 0 B/op | 0 allocs/op |
| **32** | **229.00 ns/op** | 0 B/op | 0 allocs/op |
| **50** (High Contention) | **211.70 ns/op** | 0 B/op | 0 allocs/op |

### Key Takeaways
* **Negligible Cold Start Overhead:** Over a typical benchmark run, the cost of the initial `mmap` allocations on a cold cache is negligible, performing virtually identically to the warmed cache.
* **Excellent Scalability:** Even under high contention (50 concurrent goroutines), the time per operation remains low (~200ns).

### Link to the issue in case of a bug fix.
b/530541554

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
