### PR TITLE
refactor: convert *lru.Cache struct to Cache interface

### DIFF
--- a/internal/cache/file/cache_handle.go
+++ b/internal/cache/file/cache_handle.go
@@ -38,7 +38,7 @@ type CacheHandle struct {
 	fileDownloadJob *downloader.Job
 
 	// fileInfoCache contains the reference to fileInfo cache.
-	fileInfoCache *lru.Cache
+	fileInfoCache lru.Cache
 
 	// cacheFileForRangeRead if true, async download job will start even for range
 	// reads.
@@ -54,7 +54,7 @@ type CacheHandle struct {
 }
 
 func NewCacheHandle(localFileHandle *os.File, fileDownloadJob *downloader.Job,
-	fileInfoCache *lru.Cache, cacheFileForRangeRead bool, initialOffset int64) *CacheHandle {
+	fileInfoCache lru.Cache, cacheFileForRangeRead bool, initialOffset int64) *CacheHandle {
 	fch := CacheHandle{
 		fileHandle:            localFileHandle,
 		fileDownloadJob:       fileDownloadJob,

--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -58,7 +58,7 @@ type cacheHandleTest struct {
 	bucket      gcs.Bucket
 	fakeStorage storage.FakeStorage
 	object      *gcs.MinObject
-	cache       *lru.Cache
+	cache       lru.Cache
 	cacheHandle *CacheHandle
 	cacheDir    string
 	fileSpec    data.FileSpec

--- a/internal/cache/file/cache_handler.go
+++ b/internal/cache/file/cache_handler.go
@@ -37,7 +37,7 @@ import (
 // directory.
 type CacheHandler struct {
 	// fileInfoCache contains the reference of fileInfo cache.
-	fileInfoCache *lru.Cache
+	fileInfoCache lru.Cache
 
 	// jobManager contains reference to a singleton jobManager.
 	jobManager *downloader.JobManager
@@ -67,7 +67,7 @@ type CacheHandler struct {
 	volumeBlockSize uint64
 }
 
-func NewCacheHandler(fileInfoCache *lru.Cache, jobManager *downloader.JobManager, cacheDir string, filePerm os.FileMode, dirPerm os.FileMode, excludeRegex string, includeRegex string, isSparse bool, volumeBlockSize uint64) *CacheHandler {
+func NewCacheHandler(fileInfoCache lru.Cache, jobManager *downloader.JobManager, cacheDir string, filePerm os.FileMode, dirPerm os.FileMode, excludeRegex string, includeRegex string, isSparse bool, volumeBlockSize uint64) *CacheHandler {
 	var compiledExcludeRegex *regexp.Regexp
 	var compiledIncludeRegex *regexp.Regexp
 

--- a/internal/cache/file/cache_handler_test.go
+++ b/internal/cache/file/cache_handler_test.go
@@ -53,7 +53,7 @@ type cacheHandlerTestArgs struct {
 	bucket          gcs.Bucket
 	fakeStorage     storage.FakeStorage
 	object          *gcs.MinObject
-	cache           *lru.Cache
+	cache           lru.Cache
 	cacheHandler    *CacheHandler
 	downloadPath    string
 	fileInfoKeyName string
@@ -138,7 +138,7 @@ func createObject(t *testing.T, bucket gcs.Bucket, objName string, objContent []
 	return minObject
 }
 
-func addTestFileInfoEntryInCache(t *testing.T, cache *lru.Cache, object *gcs.MinObject, bucketName string, cacheDirVolumeBlockSize uint64) string {
+func addTestFileInfoEntryInCache(t *testing.T, cache lru.Cache, object *gcs.MinObject, bucketName string, cacheDirVolumeBlockSize uint64) string {
 	t.Helper()
 	// Add an entry into
 	fileInfoKey := data.FileInfoKey{
@@ -163,7 +163,7 @@ func getDownloadJobForTestObject(t *testing.T, chTestArgs *cacheHandlerTestArgs)
 	return job
 }
 
-func isEntryInFileInfoCache(t *testing.T, cache *lru.Cache, objectName string, bucketName string) bool {
+func isEntryInFileInfoCache(t *testing.T, cache lru.Cache, objectName string, bucketName string) bool {
 	t.Helper()
 	fileInfoKey := data.FileInfoKey{
 		BucketName: bucketName,

--- a/internal/cache/file/downloader/downloader.go
+++ b/internal/cache/file/downloader/downloader.go
@@ -48,7 +48,7 @@ type JobManager struct {
 	// the size of GCS read requests by Job at the time of downloading object to
 	// file in cache.
 	sequentialReadSizeMb int32
-	fileInfoCache        *lru.Cache
+	fileInfoCache        lru.Cache
 	fileCacheConfig      *cfg.FileCacheConfig
 
 	/////////////////////////
@@ -67,7 +67,7 @@ type JobManager struct {
 	cacheDirVolumeBlockSize uint64
 }
 
-func NewJobManager(fileInfoCache *lru.Cache, filePerm os.FileMode, dirPerm os.FileMode,
+func NewJobManager(fileInfoCache lru.Cache, filePerm os.FileMode, dirPerm os.FileMode,
 	cacheDir string, sequentialReadSizeMb int32, c *cfg.FileCacheConfig,
 	metricHandle metrics.MetricHandle, traceHandle tracing.TraceHandle, cacheDirVolumeBlockSize uint64) (jm *JobManager) {
 	maxParallelDownloads := int64(math.MaxInt64)

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -47,7 +47,7 @@ type downloaderTest struct {
 	job                    *Job
 	bucket                 gcs.Bucket
 	object                 gcs.MinObject
-	cache                  *lru.Cache
+	cache                  lru.Cache
 	fakeStorage            storage.FakeStorage
 	fileSpec               data.FileSpec
 	jm                     *JobManager

--- a/internal/cache/file/downloader/jm_parallel_downloads_test.go
+++ b/internal/cache/file/downloader/jm_parallel_downloads_test.go
@@ -61,7 +61,7 @@ func configureFakeStorage(t *testing.T) storage.StorageHandle {
 	return fakeStorage.CreateStorageHandle()
 }
 
-func configureCache(t *testing.T, maxSize int64) (*lru.Cache, string) {
+func configureCache(t *testing.T, maxSize int64) (lru.Cache, string) {
 	t.Helper()
 	cache := lru.NewCache(uint64(maxSize))
 	cacheDir, err := os.MkdirTemp("", "gcsfuse_test")
@@ -72,7 +72,7 @@ func configureCache(t *testing.T, maxSize int64) (*lru.Cache, string) {
 	return cache, cacheDir
 }
 
-func createObjectInStoreAndInitCache(t *testing.T, cache *lru.Cache, bucket gcs.Bucket, objectName string, objectSize int64) (gcs.MinObject, []byte) {
+func createObjectInStoreAndInitCache(t *testing.T, cache lru.Cache, bucket gcs.Bucket, objectName string, objectSize int64) (gcs.MinObject, []byte) {
 	t.Helper()
 	content := createObjectInBucket(t, objectName, objectSize, bucket)
 	minObj := getMinObject(objectName, bucket)

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -59,7 +59,7 @@ type Job struct {
 
 	object                  *gcs.MinObject
 	bucket                  gcs.Bucket
-	fileInfoCache           *lru.Cache
+	fileInfoCache           lru.Cache
 	sequentialReadSizeMb    int32
 	fileSpec                data.FileSpec
 	fileCacheConfig         *cfg.FileCacheConfig
@@ -127,7 +127,7 @@ type jobSubscriber struct {
 func NewJob(
 	object *gcs.MinObject,
 	bucket gcs.Bucket,
-	fileInfoCache *lru.Cache,
+	fileInfoCache lru.Cache,
 	sequentialReadSizeMb int32,
 	fileSpec data.FileSpec,
 	removeJobCallback func(),

--- a/internal/cache/file/downloader/job_testify_test.go
+++ b/internal/cache/file/downloader/job_testify_test.go
@@ -48,7 +48,7 @@ type JobTestifyTest struct {
 	defaultFileCacheConfig *cfg.FileCacheConfig
 	job                    *Job
 	object                 gcs.MinObject
-	cache                  *lru.Cache
+	cache                  lru.Cache
 	fileSpec               data.FileSpec
 	mockBucket             *storage.TestifyMockBucket
 }

--- a/internal/cache/file/downloader/test_util.go
+++ b/internal/cache/file/downloader/test_util.go
@@ -66,7 +66,7 @@ func verifyCompleteFile(t *testing.T, spec data.FileSpec, content []byte) {
 	assert.True(t, reflect.DeepEqual(content, fileContent[:len(content)]))
 }
 
-func verifyFileInfoEntry(t *testing.T, mockBucket *storage.TestifyMockBucket, object gcs.MinObject, cache *lru.Cache, offset uint64) {
+func verifyFileInfoEntry(t *testing.T, mockBucket *storage.TestifyMockBucket, object gcs.MinObject, cache lru.Cache, offset uint64) {
 	fileInfo := getFileInfo(t, mockBucket, object, cache)
 	assert.True(t, fileInfo != nil)
 	assert.Equal(t, object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
@@ -74,7 +74,7 @@ func verifyFileInfoEntry(t *testing.T, mockBucket *storage.TestifyMockBucket, ob
 	assert.Equal(t, object.Size, fileInfo.(data.FileInfo).ContentSize())
 }
 
-func getFileInfo(t *testing.T, mockBucket *storage.TestifyMockBucket, object gcs.MinObject, cache *lru.Cache) lru.ValueType {
+func getFileInfo(t *testing.T, mockBucket *storage.TestifyMockBucket, object gcs.MinObject, cache lru.Cache) lru.ValueType {
 	fileInfoKey := data.FileInfoKey{BucketName: mockBucket.Name(), ObjectName: object.Name}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	assert.Equal(t, nil, err)

--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -32,9 +32,20 @@ var (
 	ErrEntryNotExist          = errors.New("entry with given key does not exist")
 )
 
-// Cache is a LRU cache for any lru.ValueType indexed by string keys.
+// Cache is an interface for a generic LRU cache.
+type Cache interface {
+	Insert(key string, value ValueType) ([]ValueType, error)
+	Erase(key string) (value ValueType)
+	LookUp(key string) (value ValueType)
+	LookUpWithoutChangingOrder(key string) (value ValueType)
+	UpdateWithoutChangingOrder(key string, value ValueType) error
+	UpdateSize(key string, sizeDelta uint64) error
+	EraseEntriesWithGivenPrefix(prefix string)
+}
+
+// mapCache is a map-based LRU cache for any lru.ValueType indexed by string keys.
 // That means entry's value should be a lru.ValueType.
-type Cache struct {
+type mapCache struct {
 	/////////////////////////
 	// Constant data
 	/////////////////////////
@@ -77,8 +88,8 @@ type entry struct {
 
 // NewCache returns the reference of cache object by initialising the cache with
 // the supplied maxSize, which must be greater than zero.
-func NewCache(maxSize uint64) *Cache {
-	c := &Cache{
+func NewCache(maxSize uint64) Cache {
+	c := &mapCache{
 		maxSize: maxSize,
 		index:   make(map[string]*list.Element),
 	}
@@ -89,7 +100,7 @@ func NewCache(maxSize uint64) *Cache {
 }
 
 // checkInvariants panic if any internal invariants have been violated.
-func (c *Cache) checkInvariants() {
+func (c *mapCache) checkInvariants() {
 	// INVARIANT: maxSize > 0
 	if !(c.maxSize > 0) {
 		panic(fmt.Sprintf("Invalid maxSize: %v", c.maxSize))
@@ -125,7 +136,7 @@ func (c *Cache) checkInvariants() {
 	}
 }
 
-func (c *Cache) evictOne() ValueType {
+func (c *mapCache) evictOne() ValueType {
 	e := c.entries.Back()
 	key := e.Value.(entry).Key
 
@@ -145,7 +156,7 @@ func (c *Cache) evictOne() ValueType {
 // Insert the supplied value into the cache, overwriting any previous entry for
 // the given key. The value must be non-nil.
 // Also returns a slice of ValueType evicted by the new inserted entry.
-func (c *Cache) Insert(
+func (c *mapCache) Insert(
 	key string,
 	value ValueType) ([]ValueType, error) {
 	if value == nil {
@@ -186,7 +197,7 @@ func (c *Cache) Insert(
 // eraseInternal removes any entry for the supplied key from the cache without acquiring locks.
 // It returns the value of the erased key, or nil if not present.
 // LOCKS_REQUIRED(c.mu)
-func (c *Cache) eraseInternal(key string) (value ValueType) {
+func (c *mapCache) eraseInternal(key string) (value ValueType) {
 	e, ok := c.index[key]
 	if !ok {
 		return
@@ -202,7 +213,7 @@ func (c *Cache) eraseInternal(key string) (value ValueType) {
 }
 
 // eraseKeys removes a list of keys from the cache.
-func (c *Cache) eraseKeys(keys []string) {
+func (c *mapCache) eraseKeys(keys []string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -212,7 +223,7 @@ func (c *Cache) eraseKeys(keys []string) {
 }
 
 // Erase any entry for the supplied key, also returns the value of erased key.
-func (c *Cache) Erase(key string) (value ValueType) {
+func (c *mapCache) Erase(key string) (value ValueType) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -221,7 +232,7 @@ func (c *Cache) Erase(key string) (value ValueType) {
 
 // LookUp a previously-inserted value for the given key. Return nil if no
 // value is present.
-func (c *Cache) LookUp(key string) (value ValueType) {
+func (c *mapCache) LookUp(key string) (value ValueType) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -243,7 +254,7 @@ func (c *Cache) LookUp(key string) (value ValueType) {
 //
 // Note: Because this look up doesn't change the order, it only acquires and
 // releases read lock.
-func (c *Cache) LookUpWithoutChangingOrder(key string) (value ValueType) {
+func (c *mapCache) LookUpWithoutChangingOrder(key string) (value ValueType) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -261,7 +272,7 @@ func (c *Cache) LookUpWithoutChangingOrder(key string) (value ValueType) {
 // given value without changing order of entries in cache, returning error if an
 // entry with given key doesn't exist. Also, the size of value for entry
 // shouldn't be updated with this method (use c.Insert for updating size).
-func (c *Cache) UpdateWithoutChangingOrder(
+func (c *mapCache) UpdateWithoutChangingOrder(
 	key string,
 	value ValueType) error {
 	if value == nil {
@@ -290,7 +301,7 @@ func (c *Cache) UpdateWithoutChangingOrder(
 // This is needed for entries whose size grows incrementally (e.g., sparse files).
 // Eviction is deferred until the next Insert() call.
 // The entry's order in the LRU is not changed.
-func (c *Cache) UpdateSize(key string, sizeDelta uint64) error {
+func (c *mapCache) UpdateSize(key string, sizeDelta uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -307,7 +318,7 @@ func (c *Cache) UpdateSize(key string, sizeDelta uint64) error {
 	return nil
 }
 
-func (c *Cache) EraseEntriesWithGivenPrefix(prefix string) {
+func (c *mapCache) EraseEntriesWithGivenPrefix(prefix string) {
 	c.mu.RLock()
 	var keysToDelete []string
 	for key := range c.index {

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -38,14 +38,14 @@ func (td testData) Size() uint64 {
 	return td.DataSize
 }
 
-func setupCacheTest(t *testing.T) *lru.Cache {
+func setupCacheTest(t *testing.T) lru.Cache {
 	locker.EnableInvariantsCheck()
 	return lru.NewCache(MaxSize)
 }
 
 // insertAndAssert inserts the given key,value in the cache and assert based on
 // the expected eviction and error.
-func insertAndAssert(t *testing.T, cache *lru.Cache, key string, val lru.ValueType, evictedValues []int64, expectedError error) {
+func insertAndAssert(t *testing.T, cache lru.Cache, key string, val lru.ValueType, evictedValues []int64, expectedError error) {
 	ret, err := cache.Insert(key, val)
 
 	require.ErrorIs(t, err, expectedError)

--- a/internal/cache/lru/lru_workload_benchmark_test.go
+++ b/internal/cache/lru/lru_workload_benchmark_test.go
@@ -53,7 +53,7 @@ func generateKeys(prefixCount, itemsPerPrefix, depth int) (keys []string, prefix
 	return keys, prefixMap, prefixes
 }
 
-func benchmarkInsert(b *testing.B, cache *lru.Cache, keys []string) {
+func benchmarkInsert(b *testing.B, cache lru.Cache, keys []string) {
 	data := testData{Value: 1, DataSize: 10}
 
 	i := 0
@@ -64,7 +64,7 @@ func benchmarkInsert(b *testing.B, cache *lru.Cache, keys []string) {
 	}
 }
 
-func benchmarkLookup(b *testing.B, cache *lru.Cache, keys []string) {
+func benchmarkLookup(b *testing.B, cache lru.Cache, keys []string) {
 	data := testData{Value: 1, DataSize: 10}
 	for _, key := range keys {
 		_, _ = cache.Insert(key, data)
@@ -78,7 +78,7 @@ func benchmarkLookup(b *testing.B, cache *lru.Cache, keys []string) {
 	}
 }
 
-func benchmarkErasePrefix(b *testing.B, cache *lru.Cache, prefixMap map[string][]string, prefixes []string) {
+func benchmarkErasePrefix(b *testing.B, cache lru.Cache, prefixMap map[string][]string, prefixes []string) {
 	data := testData{Value: 1, DataSize: 10}
 
 	for _, keysInPrefix := range prefixMap {

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -86,7 +86,7 @@ type StatCache interface {
 // Create a new bucket-view to the passed shared-cache object.
 // For dynamic-mount (mount for multiple buckets), pass bn as bucket-name.
 // For static-mout (mount for single bucket), pass bn as "".
-func NewStatCacheBucketView(sc *lru.Cache, bn string) StatCache {
+func NewStatCacheBucketView(sc lru.Cache, bn string) StatCache {
 	return &statCacheBucketView{
 		sharedCache: sc,
 		bucketName:  bn,
@@ -100,7 +100,7 @@ func NewStatCacheBucketView(sc *lru.Cache, bn string) StatCache {
 // bucket-name to its entry keys to make them unique
 // to it.
 type statCacheBucketView struct {
-	sharedCache *lru.Cache
+	sharedCache lru.Cache
 	// bucketName is the unique identifier for this
 	// statCache object among all statCache objects
 	// using the same shared lru.Cache object.

--- a/internal/cache/metadata/type_cache.go
+++ b/internal/cache/metadata/type_cache.go
@@ -126,7 +126,7 @@ type typeCache struct {
 	// A cache mapping names to the cache entry.
 	// INVARIANT: entries.CheckInvariants() does not panic
 	// INVARIANT: Each value is of type cacheEntry
-	entries *lru.Cache
+	entries lru.Cache
 }
 
 // NewTypeCache creates an LRU-policy-based cache with given parameters.

--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -47,7 +47,7 @@ var (
 	uncachedBucket gcs.Bucket
 )
 
-func newLruCache(capacity uint64) *lru.Cache {
+func newLruCache(capacity uint64) lru.Cache {
 	return lru.NewCache(capacity)
 }
 

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -675,7 +675,7 @@ type fileSystem struct {
 	globalMetadataPrefetchSem *semaphore.Weighted
 
 	// mrdCache manages the cache of inactive MultiRangeDownloaders.
-	mrdCache *lru.Cache
+	mrdCache lru.Cache
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -159,7 +159,7 @@ func NewFileInode(
 	localFile bool,
 	cfg *cfg.Config,
 	globalMaxBlocksSem *semaphore.Weighted,
-	mrdCache *lru.Cache,
+	mrdCache lru.Cache,
 	traceHandle tracing.TraceHandle,
 	metricHandle metrics.MetricHandle) (f *FileInode) {
 	// Set up the basic struct.

--- a/internal/gcsx/bucket_manager.go
+++ b/internal/gcsx/bucket_manager.go
@@ -93,7 +93,7 @@ type BucketManager interface {
 type bucketManager struct {
 	config          BucketConfig
 	storageHandle   storage.StorageHandle
-	sharedStatCache *lru.Cache
+	sharedStatCache lru.Cache
 
 	// Garbage collector
 	gcCtx                 context.Context
@@ -101,7 +101,7 @@ type bucketManager struct {
 }
 
 func NewBucketManager(config BucketConfig, storageHandle storage.StorageHandle) BucketManager {
-	var c *lru.Cache
+	var c lru.Cache
 	if config.StatCacheMaxSizeMB > 0 {
 		c = lru.NewCache(util.MiBsToBytes(config.StatCacheMaxSizeMB))
 	}

--- a/internal/gcsx/kernel_readers/kernel_mrd_reader_test.go
+++ b/internal/gcsx/kernel_readers/kernel_mrd_reader_test.go
@@ -43,7 +43,7 @@ type KernelMRDReaderTest struct {
 	suite.Suite
 	object      *gcs.MinObject
 	bucket      *storage.TestifyMockBucket
-	cache       *lru.Cache
+	cache       lru.Cache
 	inodeID     fuseops.InodeID
 	config      *cfg.Config
 	mrdInstance *gcsx.MrdInstance

--- a/internal/gcsx/mrd_instance.go
+++ b/internal/gcsx/mrd_instance.go
@@ -53,13 +53,13 @@ type MrdInstance struct {
 	// poolMu protects access to mrdPool.
 	poolMu sync.RWMutex
 	// mrdCache is a shared cache for inactive MrdInstance objects.
-	mrdCache *lru.Cache
+	mrdCache lru.Cache
 	// holds config specified by the user using config-file flag and CLI flags.
 	config *cfg.Config
 }
 
 // NewMrdInstance creates a new MrdInstance for a given GCS object.
-func NewMrdInstance(obj *gcs.MinObject, bucket gcs.Bucket, cache *lru.Cache, inodeId fuseops.InodeID, config *cfg.Config) *MrdInstance {
+func NewMrdInstance(obj *gcs.MinObject, bucket gcs.Bucket, cache lru.Cache, inodeId fuseops.InodeID, config *cfg.Config) *MrdInstance {
 	mrdInstance := MrdInstance{
 		bucket:   bucket,
 		mrdCache: cache,

--- a/internal/gcsx/mrd_instance_test.go
+++ b/internal/gcsx/mrd_instance_test.go
@@ -42,7 +42,7 @@ type MrdInstanceTest struct {
 	suite.Suite
 	object      *gcs.MinObject
 	bucket      *storage.TestifyMockBucket
-	cache       *lru.Cache
+	cache       lru.Cache
 	inodeID     fuseops.InodeID
 	config      *cfg.Config
 	mrdInstance *MrdInstance

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -33,7 +33,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject, config *cfg.Config, mrdCache *lru.Cache) (*MultiRangeDownloaderWrapper, error) {
+func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject, config *cfg.Config, mrdCache lru.Cache) (*MultiRangeDownloaderWrapper, error) {
 	if object == nil {
 		return nil, fmt.Errorf("NewMultiRangeDownloaderWrapper: Missing MinObject")
 	}
@@ -75,7 +75,7 @@ type MultiRangeDownloaderWrapper struct {
 	handle []byte
 
 	// MRD cache for LRU-based eviction of inactive MRD instances.
-	mrdCache *lru.Cache
+	mrdCache lru.Cache
 }
 
 // SetMinObject sets the gcs.MinObject stored in the wrapper to passed value, only if it's non nil.

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -404,7 +404,7 @@ func (t *mrdWrapperTest) Test_EnsureMultiRangeDownloader_FileClobbered() {
 // mrdWrapperCacheTest inherits from mrdWrapperTest and adds cache functionality.
 type mrdWrapperCacheTest struct {
 	mrdWrapperTest
-	cache *lru.Cache
+	cache lru.Cache
 }
 
 func TestMRDWrapperCacheTestSuite(t *testing.T) {


### PR DESCRIPTION
### Description
This PR decouples the GCSfuse file system from the concrete LRU cache implementation by introducing a generic `Cache` interface.

By converting `lru.Cache` into an interface, the rest of the GCSfuse file system will be able to seamlessly accept any future cache implementations without requiring any changes to the consumer logic.

#### Changes Made
* **Defined Cache Interface:** Extracted the public methods (`Insert`, `Erase`, `LookUp`, etc.) from the LRU cache into a generic `Cache` interface inside `internal/cache/lru/lru.go`.
* **Renamed Struct:** Renamed the existing `Cache` struct to `mapCache` (a private struct) and updated `NewCache(maxSize)` to return the new interface instead of a pointer.
* **Repository-Wide Refactor:** Safely refactored all occurrences of `*lru.Cache` to `lru.Cache` using `gofmt` across the entire repository (in `internal/fs`, `internal/gcsx`, `internal/cache/metadata`, etc.) so that the codebase operates entirely on the interface.
* **Verification:** All tests (`go test ./internal/cache/...`) and builds have been verified to pass successfully with the new interface.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA