### PR TITLE
fix(bufferedread): release inflight prefetch blocks on non-EOF read errors

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -320,8 +320,12 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (res
 			resp.Data = dataSlices
 			resp.Callback = func() { p.callback(entriesToCallback) }
 			resp.Size = bytesRead
-		} else if errors.Is(err, gcsx.FallbackToAnotherReader) {
-			// When falling back, we must immediately release the blocks we've acquired references to.
+		} else {
+			// On ANY error (fallback, or a mid-read block download failure /
+			// ctx cancellation), immediately release the blocks we IncRef'd.
+			// Otherwise their pool memory and the shared read-global-max-blocks
+			// permits leak, and inflightCallbackWg never reaches 0 (Destroy then
+			// blocks on its 10s timeout and leaks the blocks permanently).
 			p.releaseInflightBlocks(entriesToCallback)
 			resp = gcsx.ReadResponse{}
 		}

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -149,6 +149,61 @@ func (t *BufferedReaderTest) TearDownTest() {
 	t.workerPool.Stop()
 }
 
+// Regression test for the buffered-read block leak on non-EOF read errors.
+// block1 (offset == blockSize) download fails; block0 succeeds. A single ReadAt
+// straddling the block0/block1 boundary consumes the tail of block0 (IncRef'd)
+// and then hits the failed block1 -> non-EOF error after an earlier block was
+// already referenced. Before the fix the IncRef'd block0 leaks and
+// inflightCallbackWg never reaches 0, so Destroy() blocks on its 10s timeout.
+// After the fix releaseInflightBlocks() runs and Destroy() returns promptly.
+func (t *BufferedReaderTest) TestReadAtReleasesInflightBlocksOnMidReadDownloadFailure() {
+	reader, err := NewBufferedReader(&BufferedReaderOptions{
+		Object:             t.object,
+		Bucket:             t.bucket,
+		Config:             t.config,
+		GlobalMaxBlocksSem: t.globalMaxBlocksSem,
+		WorkerPool:         t.workerPool,
+		MetricHandle:       t.metricHandle,
+		ReadTypeClassifier: t.readTypeClassifier})
+	require.NoError(t.T(), err)
+
+	t.bucket.On("Name").Return("test-bucket").Maybe() // Bucket name used for logging.
+
+	blockSize := testPrefetchBlockSizeBytes // 1024 in tests
+
+	// block0 (Start == 0) downloads successfully.
+	t.bucket.On("NewReaderWithReadHandle",
+		mock.Anything,
+		mock.MatchedBy(func(r *gcs.ReadObjectRequest) bool { return r.Range.Start == 0 }),
+	).Return(createFakeReaderWithOffset(t.T(), int(blockSize), 0), nil).Maybe()
+	// block1 (Start == blockSize) download fails.
+	t.bucket.On("NewReaderWithReadHandle",
+		mock.Anything,
+		mock.MatchedBy(func(r *gcs.ReadObjectRequest) bool { return r.Range.Start == uint64(blockSize) }),
+	).Return(nil, errors.New("injected download failure")).Maybe()
+	// Safety net for any other prefetched offset: fail harmlessly (no reader reuse -> no race).
+	t.bucket.On("NewReaderWithReadHandle",
+		mock.Anything,
+		mock.Anything,
+	).Return(nil, errors.New("unexpected prefetch offset in test")).Maybe()
+
+	// Straddle the block0/block1 boundary: read [blockSize/2, blockSize/2 + blockSize).
+	buf := make([]byte, blockSize)
+	_, err = reader.ReadAt(t.ctx, &gcsx.ReadRequest{Buffer: buf, Offset: blockSize / 2})
+	require.Error(t.T(), err)
+	require.NotErrorIs(t.T(), err, io.EOF)
+
+	// The IncRef'd block0 must have been released, so inflightCallbackWg is
+	// balanced and Destroy() returns promptly.
+	done := make(chan struct{})
+	go func() { reader.Destroy(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.T().Fatal("Destroy() blocked: an in-flight prefetch block leaked on the mid-read error path")
+	}
+}
+
 func (t *BufferedReaderTest) TestNewBufferedReader() {
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,


### PR DESCRIPTION
### Description

`BufferedReader.ReadAt` returns zero-copy slices out of prefetch blocks and, for each slice, does
`blk.IncRef()` + `inflightCallbackWg.Add(1)`, deferring the block's release to the FUSE `resp.Callback`.
The `ReadAt` defer only wires that callback on success/EOF, and only eagerly releases blocks for
`gcsx.FallbackToAnotherReader`. For **any other non-EOF error** raised after an earlier block in the
same read was already consumed — a later block's `BlockStateDownloadFailed`, or a ctx cancellation
while awaiting a later block — neither branch runs: `resp` is returned zero-valued, so the callback
never fires and the IncRef'd blocks are never released.

Impact: the leaked `PrefetchBlock` is never returned to the pool (never munmap'd) and its permit on the
per-mount, shared `read-global-max-blocks` semaphore is never released. Because that semaphore is shared
across all file handles, repeated transient read errors permanently shrink the global block budget →
buffered read silently degrades to the fallback reader mount-wide (`insufficient_memory`), RSS grows, and
each affected handle's `Destroy()` blocks on its 10s timeout. `Destroy()` already notes that this timeout
leaks blocks and assumes the condition is rare — but an ordinary mid-read transient error makes it routine.

Fix: in the `ReadAt` defer, collapse the fallback branch and the (previously missing) general-error
branch into a single `else` that calls the existing `releaseInflightBlocks(entriesToCallback)` and clears
`resp`, so every `IncRef` / `inflightCallbackWg.Add` is balanced on all exit paths. Behavior on
success/EOF and on `FallbackToAnotherReader` is unchanged.

### Link to the issue in case of a bug fix.

Fixes #4839

### Testing details
1. Manual - NA
2. Unit tests - Added `TestReadAtReleasesInflightBlocksOnMidReadDownloadFailure` in
   `internal/bufferedread/buffered_reader_test.go`: block0 downloads, block1's download fails, and a
   single boundary-straddling `ReadAt` errors after consuming block0; the test asserts `Destroy()`
   returns promptly (i.e. the earlier block was released and `inflightCallbackWg` reached 0).
   - On the **pre-fix** code the test FAILS: `Destroy()` blocks on its 10s timeout (the test's own 3s
     guard trips first and reports the leaked in-flight block).
   - With the **fix** it PASSES, and is clean under `-race`.
   - The full `internal/bufferedread` package suite passes (`go test ./internal/bufferedread/...`).
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.

