### PR TITLE
test(TPC): Ensure TPC setup works properly with integration test client

### DIFF
--- a/tools/integration_tests/util/client/control_client.go
+++ b/tools/integration_tests/util/client/control_client.go
@@ -32,6 +32,7 @@ import (
 	"github.com/googleapis/gax-go/v2"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"google.golang.org/api/option"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -57,14 +58,22 @@ func storageControlClientRetryOptions() []gax.CallOption {
 }
 
 func CreateControlClient(ctx context.Context) (client *control.StorageControlClient, err error) {
-	client, err = control.NewStorageControlClient(ctx)
+	var opts []option.ClientOption
+	if setup.TestOnTPCEndPoint() {
+		ts, err := getTokenSrc("/tmp/sa.key.json")
+		if err != nil {
+			return nil, fmt.Errorf("unable to fetch token-source for TPC: %w", err)
+		}
+		opts = append(opts, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithTokenSource(ts))
+	}
+	client, err = control.NewStorageControlClient(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("control.NewStorageControlClient: %w", err)
+	}
 
 	client.CallOptions.CreateManagedFolder = storageControlClientRetryOptions()
 	client.CallOptions.DeleteManagedFolder = storageControlClientRetryOptions()
 
-	if err != nil {
-		return nil, fmt.Errorf("control.NewStorageControlClient: #{err}")
-	}
 	return client, nil
 }
 


### PR DESCRIPTION
### Description
The test: TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT is failing for TPC environment for hns buckets.
The RCA is as follows:
In an HNS (Hierarchical Namespace) bucket, explicit directory operations (creating and deleting folders) are backed by GCS Folder resources via the Storage Control gRPC API.

During TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT:
1. The test creates a directory oob_deleted_explicit_dir on the GCSFuse mount.
2. It attempts an out-of-band (OOB) deletion on GCS via client.DeleteDirOnGCS(ctx, storageClient, ...).
3. Inside DeleteDirOnGCS (control_client.go), it calls CreateControlClient(ctx) and then DeleteFolderInBucket(ctx, controlClient, relativeDirPath).
The Bug: CreateControlClient in 
tools/integration_tests/util/client/control_client.go was calling control.NewStorageControlClient(ctx) with default options—without passing the TPC endpoint (storage.apis-tpczero.goog:443) or the TPC authentication token source (/tmp/sa.key.json) when setup.TestOnTPCEndPoint() was enabled.

As a result:
* In TPC test runs, CreateControlClient failed or targeted commercial GCP endpoints (storagecontrol.googleapis.com), causing DeleteFolderInBucket to fail.
* DeleteDirOnGCS ignored the error (_ = DeleteFolderInBucket(...)), so the folder was never actually deleted on GCS.
* When the test subsequently called os.Remove(dirPath), GCSFuse (which was properly initialized with TPC endpoints) deleted the still-existing folder on GCS and returned nil (Success).
* The test asserted if !os.IsNotExist(err) and failed because it expected ENOENT (os.ErrNotExist).

### Link to the issue in case of a bug fix.
b/530389977
b/530757458

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Tested by running tests using tpc_build.sh with the fix and without fix and verified fix works.

### Any backward incompatible change? If so, please explain.
N/A 