### PR TITLE
feat(cache): introduce the core radix trie structure 

### DIFF
--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -63,42 +63,21 @@ func (n *radixNode) getChild(b byte) *radixNode {
 // addChild adds a child node, maintaining sorted order by the first byte of the prefix.
 func (n *radixNode) addChild(newChild *radixNode) {
 	newChild.parent = n
-	newChild.sibling = nil
-
-	if n.child == nil {
-		n.child = newChild
-		return
+	pcurr := &n.child
+	for *pcurr != nil && (*pcurr).prefix[0] < newChild.prefix[0] {
+		pcurr = &(*pcurr).sibling
 	}
-
-	if newChild.prefix[0] < n.child.prefix[0] {
-		newChild.sibling = n.child
-		n.child = newChild
-		return
-	}
-
-	curr := n.child
-	for curr.sibling != nil && curr.sibling.prefix[0] < newChild.prefix[0] {
-		curr = curr.sibling
-	}
-
-	newChild.sibling = curr.sibling
-	curr.sibling = newChild
+	newChild.sibling = *pcurr
+	*pcurr = newChild
 }
 
 // removeChild directly removes a child node by reference from the sibling list.
 func (n *radixNode) removeChild(childToRemove *radixNode) {
-	if n.child == childToRemove {
-		n.child = childToRemove.sibling
-		return
-	}
-
-	curr := n.child
-	for curr != nil && curr.sibling != childToRemove {
-		curr = curr.sibling
-	}
-
-	if curr != nil {
-		curr.sibling = childToRemove.sibling
+	for pcurr := &n.child; *pcurr != nil; pcurr = &(*pcurr).sibling {
+		if *pcurr == childToRemove {
+			*pcurr = childToRemove.sibling
+			break
+		}
 	}
 }
 
@@ -141,17 +120,11 @@ func (t *radixTree) insertNode(key string, value ValueType) (*radixNode, bool) {
 			parent: node,
 		}
 
-		if node.child == child {
-			splitNode.sibling = child.sibling
-			node.child = splitNode
-		} else {
-			curr := node.child
-			for curr != nil && curr.sibling != child {
-				curr = curr.sibling
-			}
-			if curr != nil {
+		for pcurr := &node.child; *pcurr != nil; pcurr = &(*pcurr).sibling {
+			if *pcurr == child {
 				splitNode.sibling = child.sibling
-				curr.sibling = splitNode
+				*pcurr = splitNode
+				break
 			}
 		}
 
@@ -233,17 +206,11 @@ func (t *radixTree) compressPathUpwards(curr *radixNode) {
 			onlyChild.prefix = curr.prefix + onlyChild.prefix
 			onlyChild.parent = curr.parent
 
-			if curr.parent.child == curr {
-				onlyChild.sibling = curr.sibling
-				curr.parent.child = onlyChild
-			} else {
-				prev := curr.parent.child
-				for prev != nil && prev.sibling != curr {
-					prev = prev.sibling
-				}
-				if prev != nil {
+			for pcurr := &curr.parent.child; *pcurr != nil; pcurr = &(*pcurr).sibling {
+				if *pcurr == curr {
 					onlyChild.sibling = curr.sibling
-					prev.sibling = onlyChild
+					*pcurr = onlyChild
+					break
 				}
 			}
 			curr = curr.parent

--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -56,6 +56,10 @@ func (n *radixNode) getChild(b byte) *radixNode {
 		if curr.prefix[0] == b {
 			return curr
 		}
+		//as the siblings are arranged in lexicographical order we can exit early
+		if curr.prefix[0] > b {
+			break
+		}
 	}
 	return nil
 }
@@ -76,13 +80,17 @@ func (n *radixNode) removeChild(childToRemove *radixNode) {
 	for pcurr := &n.child; *pcurr != nil; pcurr = &(*pcurr).sibling {
 		if *pcurr == childToRemove {
 			*pcurr = childToRemove.sibling
-			break
+			return
 		}
 	}
 }
 
 // insertNode inserts a new key into the radix tree and returns the leaf node.
 func (t *radixTree) insertNode(key string, value ValueType) (*radixNode, bool) {
+	if value == nil {
+		return nil, false
+	}
+
 	node := t.root
 	search := key
 
@@ -98,6 +106,7 @@ func (t *radixTree) insertNode(key string, value ValueType) (*radixNode, bool) {
 
 		child := node.getChild(search[0])
 		if child == nil {
+			// clone the substring to prevent memory leaks otherwise, the slice pins the entire original string in memory
 			newLeaf := &radixNode{
 				prefix: strings.Clone(search),
 				value:  value,

--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -58,7 +58,7 @@ func (n *radixNode) getChild(b byte) *radixNode {
 		}
 		//as the siblings are arranged in lexicographical order we can exit early
 		if curr.prefix[0] > b {
-			break
+			return nil
 		}
 	}
 	return nil

--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -1,0 +1,254 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lru
+
+import (
+	"strings"
+)
+
+// radixNode represents a node in the custom radix tree.
+// It uses a Left-Child Right-Sibling (LCRS) representation to avoid slice allocations.
+type radixNode struct {
+	prefix  string
+	value   ValueType
+	parent  *radixNode
+	child   *radixNode
+	sibling *radixNode
+}
+
+// this radixTree struct will be replaced by a RadixCache struct afterwards with additional necessary fields
+// radixTree encapsulates the core tree structure (LRU logic to be added in next PR).
+type radixTree struct {
+	root *radixNode
+	size int
+}
+
+func newRadixTree() *radixTree {
+	return &radixTree{
+		root: &radixNode{},
+	}
+}
+
+// longestCommonPrefix finds the length of the longest common prefix of a and b.
+func longestCommonPrefix(a, b string) int {
+	i := 0
+	for i < len(a) && i < len(b) && a[i] == b[i] {
+		i++
+	}
+	return i
+}
+
+// getChild finds a child node whose prefix starts with the given byte.
+func (n *radixNode) getChild(b byte) *radixNode {
+	for curr := n.child; curr != nil; curr = curr.sibling {
+		if curr.prefix[0] == b {
+			return curr
+		}
+	}
+	return nil
+}
+
+// addChild adds a child node, maintaining sorted order by the first byte of the prefix.
+func (n *radixNode) addChild(newChild *radixNode) {
+	newChild.parent = n
+	newChild.sibling = nil
+
+	if n.child == nil {
+		n.child = newChild
+		return
+	}
+
+	if newChild.prefix[0] < n.child.prefix[0] {
+		newChild.sibling = n.child
+		n.child = newChild
+		return
+	}
+
+	curr := n.child
+	for curr.sibling != nil && curr.sibling.prefix[0] < newChild.prefix[0] {
+		curr = curr.sibling
+	}
+
+	newChild.sibling = curr.sibling
+	curr.sibling = newChild
+}
+
+// removeChild directly removes a child node by reference from the sibling list.
+func (n *radixNode) removeChild(childToRemove *radixNode) {
+	if n.child == childToRemove {
+		n.child = childToRemove.sibling
+		return
+	}
+
+	curr := n.child
+	for curr != nil && curr.sibling != childToRemove {
+		curr = curr.sibling
+	}
+
+	if curr != nil {
+		curr.sibling = childToRemove.sibling
+	}
+}
+
+// insertNode inserts a new key into the radix tree and returns the leaf node.
+func (t *radixTree) insertNode(key string, value ValueType) (*radixNode, bool) {
+	node := t.root
+	search := key
+
+	for {
+		if len(search) == 0 {
+			isNew := node.value == nil
+			if isNew {
+				t.size++
+			}
+			node.value = value
+			return node, isNew
+		}
+
+		child := node.getChild(search[0])
+		if child == nil {
+			newLeaf := &radixNode{
+				prefix: strings.Clone(search),
+				value:  value,
+			}
+			node.addChild(newLeaf)
+			t.size++
+			return newLeaf, true
+		}
+
+		lcp := longestCommonPrefix(search, child.prefix)
+
+		if lcp == len(child.prefix) {
+			search = search[lcp:]
+			node = child
+			continue
+		}
+
+		splitNode := &radixNode{
+			prefix: strings.Clone(child.prefix[:lcp]),
+			parent: node,
+		}
+
+		if node.child == child {
+			splitNode.sibling = child.sibling
+			node.child = splitNode
+		} else {
+			curr := node.child
+			for curr != nil && curr.sibling != child {
+				curr = curr.sibling
+			}
+			if curr != nil {
+				splitNode.sibling = child.sibling
+				curr.sibling = splitNode
+			}
+		}
+
+		child.prefix = strings.Clone(child.prefix[lcp:])
+		child.sibling = nil
+		splitNode.addChild(child)
+
+		if lcp == len(search) {
+			splitNode.value = value
+			t.size++
+			return splitNode, true
+		}
+
+		newLeaf := &radixNode{
+			prefix: strings.Clone(search[lcp:]),
+			value:  value,
+		}
+		splitNode.addChild(newLeaf)
+		t.size++
+		return newLeaf, true
+	}
+}
+
+// getNode finds a leaf node by key.
+func (t *radixTree) getNode(key string) (*radixNode, bool) {
+	node := t.root
+	search := key
+
+	for {
+		if len(search) == 0 {
+			if node.value != nil {
+				return node, true
+			}
+			return nil, false
+		}
+
+		child := node.getChild(search[0])
+		if child == nil {
+			return nil, false
+		}
+
+		if strings.HasPrefix(search, child.prefix) {
+			search = search[len(child.prefix):]
+			node = child
+			continue
+		}
+
+		return nil, false
+	}
+}
+
+// deleteNode removes a leaf node directly using its parent pointers.
+func (t *radixTree) deleteNode(node *radixNode) {
+	if node == nil || node.value == nil {
+		return
+	}
+
+	node.value = nil
+	t.size--
+	t.compressPathUpwards(node)
+}
+
+// compressPathUpwards walks up the tree, pruning empty leaves and compressing single-child routing nodes.
+func (t *radixTree) compressPathUpwards(curr *radixNode) {
+	for curr != nil && curr != t.root {
+		if curr.value != nil {
+			break
+		}
+
+		if curr.child == nil {
+			parent := curr.parent
+			parent.removeChild(curr)
+			curr = parent
+			continue
+		}
+
+		if curr.child.sibling == nil {
+			onlyChild := curr.child
+			onlyChild.prefix = curr.prefix + onlyChild.prefix
+			onlyChild.parent = curr.parent
+
+			if curr.parent.child == curr {
+				onlyChild.sibling = curr.sibling
+				curr.parent.child = onlyChild
+			} else {
+				prev := curr.parent.child
+				for prev != nil && prev.sibling != curr {
+					prev = prev.sibling
+				}
+				if prev != nil {
+					onlyChild.sibling = curr.sibling
+					prev.sibling = onlyChild
+				}
+			}
+			curr = curr.parent
+			continue
+		}
+		break
+	}
+}

--- a/internal/cache/lru/radix_test.go
+++ b/internal/cache/lru/radix_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lru
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// mockValue implements the ValueType interface for testing
+type mockValue struct{ size uint64 }
+
+func (m mockValue) Size() uint64 { return m.size }
+
+func TestRadixTree_InsertAndGet(t *testing.T) {
+	tree := newRadixTree()
+	val1 := mockValue{10}
+	val2 := mockValue{20}
+
+	// Test Insert
+	node1, isNew := tree.insertNode("foo/bar", val1)
+	assert.True(t, isNew)
+	assert.NotNil(t, node1)
+	assert.Equal(t, 1, tree.size)
+
+	// Test Get
+	gotNode, ok := tree.getNode("foo/bar")
+	assert.True(t, ok)
+	assert.Equal(t, val1, gotNode.value)
+
+	// Test Overwrite (should not increase size)
+	node2, isNew2 := tree.insertNode("foo/bar", val2)
+	assert.False(t, isNew2)
+	assert.Equal(t, val2, node2.value)
+	assert.Equal(t, 1, tree.size)
+
+	// Test non-existent get
+	_, ok = tree.getNode("foo/baz")
+	assert.False(t, ok)
+}
+
+func TestRadixTree_PrefixSplitting(t *testing.T) {
+	tree := newRadixTree()
+
+	tree.insertNode("foo/bar", mockValue{1})
+	tree.insertNode("foo/baz", mockValue{2}) // Splits "foo/ba" -> "r", "z"
+
+	assert.Equal(t, 2, tree.size)
+
+	n1, _ := tree.getNode("foo/bar")
+	n2, _ := tree.getNode("foo/baz")
+
+	// Both should share the same parent routing node "foo/ba"
+	assert.Equal(t, n1.parent, n2.parent)
+	assert.Equal(t, "foo/ba", n1.parent.prefix)
+	assert.Nil(t, n1.parent.value) // Parent is just a routing node
+}
+
+func TestRadixTree_DeleteAndCompress(t *testing.T) {
+	tree := newRadixTree()
+
+	tree.insertNode("foo/bar", mockValue{1})
+	tree.insertNode("foo/baz", mockValue{2})
+
+	n1, _ := tree.getNode("foo/bar")
+	tree.deleteNode(n1)
+
+	assert.Equal(t, 1, tree.size)
+	_, ok := tree.getNode("foo/bar")
+	assert.False(t, ok)
+
+	// After deleting "foo/bar", the routing node "foo/ba" should compress back
+	// into the surviving leaf "foo/baz", turning it back into "foo/baz".
+	n2, _ := tree.getNode("foo/baz")
+	assert.Equal(t, "foo/baz", n2.prefix)
+	assert.Equal(t, tree.root, n2.parent) // Path compressed all the way up to the root!
+}

--- a/internal/cache/lru/radix_test.go
+++ b/internal/cache/lru/radix_test.go
@@ -25,66 +25,106 @@ type mockValue struct{ size uint64 }
 
 func (m mockValue) Size() uint64 { return m.size }
 
-func TestRadixTree_InsertAndGet(t *testing.T) {
+func TestRadixTree_Insert(t *testing.T) {
+	// Arrange
 	tree := newRadixTree()
 	val1 := mockValue{10}
-	val2 := mockValue{20}
 
-	// Test Insert
+	// Act
 	node1, isNew := tree.insertNode("foo/bar", val1)
+
+	// Assert
 	assert.True(t, isNew)
 	assert.NotNil(t, node1)
 	assert.Equal(t, 1, tree.size)
+}
 
-	// Test Get
+func TestRadixTree_InsertNil(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+
+	// Act
+	node, isNew := tree.insertNode("foo/bar", nil)
+
+	// Assert
+	assert.False(t, isNew)
+	assert.Nil(t, node)
+	assert.Equal(t, 0, tree.size)
+}
+
+func TestRadixTree_Get(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	val1 := mockValue{10}
+	tree.insertNode("foo/bar", val1)
+
+	// Act
 	gotNode, ok := tree.getNode("foo/bar")
+
+	// Assert
 	assert.True(t, ok)
 	assert.Equal(t, val1, gotNode.value)
+}
 
-	// Test Overwrite (should not increase size)
+func TestRadixTree_Overwrite(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	tree.insertNode("foo/bar", mockValue{10})
+	val2 := mockValue{20}
+
+	// Act
 	node2, isNew2 := tree.insertNode("foo/bar", val2)
+
+	// Assert
 	assert.False(t, isNew2)
 	assert.Equal(t, val2, node2.value)
 	assert.Equal(t, 1, tree.size)
+}
 
-	// Test non-existent get
-	_, ok = tree.getNode("foo/baz")
+func TestRadixTree_GetNonExistent(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	tree.insertNode("foo/bar", mockValue{10})
+
+	// Act
+	_, ok := tree.getNode("foo/baz")
+
+	// Assert
 	assert.False(t, ok)
 }
 
 func TestRadixTree_PrefixSplitting(t *testing.T) {
+	// Arrange
 	tree := newRadixTree()
-
 	tree.insertNode("foo/bar", mockValue{1})
+
+	// Act
 	tree.insertNode("foo/baz", mockValue{2}) // Splits "foo/ba" -> "r", "z"
-
-	assert.Equal(t, 2, tree.size)
-
 	n1, _ := tree.getNode("foo/bar")
 	n2, _ := tree.getNode("foo/baz")
 
-	// Both should share the same parent routing node "foo/ba"
+	// Assert
+	assert.Equal(t, 2, tree.size)
 	assert.Equal(t, n1.parent, n2.parent)
 	assert.Equal(t, "foo/ba", n1.parent.prefix)
 	assert.Nil(t, n1.parent.value) // Parent is just a routing node
 }
 
 func TestRadixTree_DeleteAndCompress(t *testing.T) {
+	// Arrange
 	tree := newRadixTree()
-
 	tree.insertNode("foo/bar", mockValue{1})
 	tree.insertNode("foo/baz", mockValue{2})
-
 	n1, _ := tree.getNode("foo/bar")
+
+	// Act
 	tree.deleteNode(n1)
-
-	assert.Equal(t, 1, tree.size)
 	_, ok := tree.getNode("foo/bar")
-	assert.False(t, ok)
-
-	// After deleting "foo/bar", the routing node "foo/ba" should compress back
-	// into the surviving leaf "foo/baz", turning it back into "foo/baz".
 	n2, _ := tree.getNode("foo/baz")
+
+	// Assert
+	assert.Equal(t, 1, tree.size)
+	assert.False(t, ok)
 	assert.Equal(t, "foo/baz", n2.prefix)
 	assert.Equal(t, tree.root, n2.parent) // Path compressed all the way up to the root!
 }


### PR DESCRIPTION
### Description
This PR introduces only the core, internal tree structure (radixTree and radixNode) along with the core operations: `insertNode`, `getNode`, `deleteNode`, and `compressPathUpwards`. It does not yet include LRU eviction logic or the lru.Cache wrapper.

Design Overview  : A Radix Tree (or compressed trie) is a space-optimized tree where nodes with only a single child are merged with their parents. By storing directory paths as string prefixes across nodes, we can instantly locate or sever entire directory trees just by walking the prefix.

To map this multi-way tree efficiently in Go memory, we use the Left-Child Right-Sibling (LCRS) design pattern. Instead of storing a slice of children ` []*radixNode`, each node only points to its first child, and that child points to its sibling.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Added `radix_test.go` to thoroughly test string prefix splitting, path compression, and exact-match leaf lookup.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.