### PR TITLE
feat(native-retries): wire Control Plane mount retry predicate (ShouldRetryOnMount)

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -151,6 +151,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		MaxRetrySleep:                           newConfig.GcsRetries.MaxRetrySleep,
 		MaxRetryAttempts:                        int(newConfig.GcsRetries.MaxRetryAttempts),
 		RetryMultiplier:                         newConfig.GcsRetries.Multiplier,
+		EnableMountRetries:                      newConfig.GcsRetries.EnableMountRetries,
 		UserAgent:                               userAgent,
 		CustomEndpoint:                          newConfig.GcsConnection.CustomEndpoint,
 		KeyFile:                                 string(newConfig.GcsAuth.KeyFile),

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -100,6 +100,8 @@ type storageControlClientWithRetry struct {
 	enableRetriesOnStorageLayoutAPI bool
 	// Whether or not to enable retries for folder APIs.
 	enableRetriesOnFolderAPIs bool
+	// Whether or not to enable mount retries for GetStorageLayout call.
+	enableRetriesOnMount bool
 }
 
 func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Context,
@@ -113,6 +115,9 @@ func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Conte
 		return sccwros.raw.GetStorageLayout(attemptCtx, req, opts...)
 	}
 
+	if sccwros.enableRetriesOnMount {
+		return storageutil.ExecuteWithCustomShouldRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, storageutil.ShouldRetryOnMount, logger.LevelInfo)
+	}
 	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, logger.LevelInfo)
 }
 
@@ -180,7 +185,7 @@ func (sccwros *storageControlClientWithRetry) CreateFolder(ctx context.Context,
 // It accepts various parameters to configure the retry behavior.
 // The returned control client retries storage-layout.
 // It also retries folder-related APIs if `retryFolderAPIs` is true.
-func newRetryWrapper(controlClient StorageControlClient, clientConfig *storageutil.StorageClientConfig, retryDeadline, totalRetryBudget, initialBackoff time.Duration, retryFolderAPIs bool) StorageControlClient {
+func newRetryWrapper(controlClient StorageControlClient, clientConfig *storageutil.StorageClientConfig, retryDeadline, totalRetryBudget, initialBackoff time.Duration, retryFolderAPIs, enableRetriesOnMount bool) StorageControlClient {
 	// Avoid creating a nested wrapper.
 	raw := controlClient
 	if sccwros, ok := controlClient.(*storageControlClientWithRetry); ok {
@@ -193,20 +198,30 @@ func newRetryWrapper(controlClient StorageControlClient, clientConfig *storageut
 		retryConfig:                     retryConfig,
 		enableRetriesOnStorageLayoutAPI: true,
 		enableRetriesOnFolderAPIs:       retryFolderAPIs,
+		enableRetriesOnMount:            enableRetriesOnMount,
 	}
 }
 
 // withRetryOnAllAPIs wraps a StorageControlClient to do a time-bound retry approach for retryable errors for all API calls through it.
 func withRetryOnAllAPIs(controlClient StorageControlClient,
 	clientConfig *storageutil.StorageClientConfig) StorageControlClient {
-	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, true)
+	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, true, false)
 }
 
 // withRetryOnStorageLayout wraps a StorageControlClient to do a time-bound retry approach for retryable errors for the GetStorageLayout call through it.
 func withRetryOnStorageLayout(controlClient StorageControlClient,
 	clientConfig *storageutil.StorageClientConfig) StorageControlClient {
-	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, false)
+	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, false, false)
+}
 
+// withRetryOnMount wraps a StorageControlClient to do a time-bound retry approach for retryable errors and mount errors (404/403) for the GetStorageLayout call during mount initialization.
+func withRetryOnMount(controlClient StorageControlClient,
+	clientConfig *storageutil.StorageClientConfig) StorageControlClient {
+	enableRetriesOnMount := false
+	if clientConfig != nil {
+		enableRetriesOnMount = clientConfig.EnableMountRetries
+	}
+	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, false, enableRetriesOnMount)
 }
 
 func storageControlClientGaxRetryOptions(clientConfig *storageutil.StorageClientConfig) []gax.CallOption {

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -218,6 +218,59 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut(
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_Retry404ThenSuccess() {
+	// Arrange
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr).Times(2)
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedLayout, layout)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesDisabled_404FailsImmediately() {
+	// Arrange
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, false)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr).Once()
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), layout)
+	assert.Contains(t.T(), err.Error(), "failed:")
+	assert.Contains(t.T(), err.Error(), mountErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_AllAttemptsTimeOut() {
+	// Arrange
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr)
+
+	// Act
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	// Assert
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), layout)
+	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
 func (t *StorageLayoutRetryWrapperTest) TestGetFolder_IsNotRetried() {
 	// Arrange
 	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
@@ -295,7 +348,17 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 		MaxRetrySleep:   maxRetrySleep,
 		RetryMultiplier: backoffMultiplier,
 	}
-	return newRetryWrapper(t.stallingClient, clientConfig, retryDeadline, totalRetryBudget, initialBackoff, retryFolderAPIs)
+	return newRetryWrapper(t.stallingClient, clientConfig, retryDeadline, totalRetryBudget, initialBackoff, retryFolderAPIs, false)
+}
+
+func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(controlClient StorageControlClient, retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool, enableRetriesOnMount bool) StorageControlClient {
+	t.T().Helper()
+	clientConfig := &storageutil.StorageClientConfig{
+		MaxRetrySleep:      maxRetrySleep,
+		RetryMultiplier:    backoffMultiplier,
+		EnableMountRetries: enableRetriesOnMount,
+	}
+	return newRetryWrapper(t.stallingClient, clientConfig, retryDeadline, totalRetryBudget, initialBackoff, retryFolderAPIs, enableRetriesOnMount)
 }
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -413,9 +413,9 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		}
 		// special handling for mounts created with custom billing projects.
 		controlClientWithBillingProject := withBillingProject(rawStorageControlClientWithoutGaxRetries, billingProject)
-		// Wrap the control client with retry-on-stall logic.
-		// This will retry on only on GetStorageLayout call for all buckets.
-		controlClient = withRetryOnStorageLayout(controlClientWithBillingProject, &clientConfig)
+		// Wrap the control client with retry-on-stall and mount retry logic.
+		// This will retry only on GetStorageLayout call during mount initialization.
+		controlClient = withRetryOnMount(controlClientWithBillingProject, &clientConfig)
 	} else {
 		logger.Infof("Skipping storage control client creation because custom-endpoint %q was passed, which is assumed to be a storage testbench server because of 'localhost' in it.", clientConfig.CustomEndpoint)
 	}

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -61,6 +61,7 @@ type StorageClientConfig struct {
 	ExperimentalNonrapidFolderApiStallRetry bool
 	MaxRetrySleep                           time.Duration
 	RetryMultiplier                         float64
+	EnableMountRetries                      bool
 	LocalSocketAddress                      string
 
 	/** HTTP client parameters. */


### PR DESCRIPTION
### Description
- Added `EnableMountRetries bool` field to `storageutil.StorageClientConfig` to transport the `--enable-mount-retries` flag from the CLI configuration layer into the storage layer.
- Mapped `newConfig.GcsRetries.EnableMountRetries` to `storageClientConfig.EnableMountRetries` in `createStorageHandle()` inside `cmd/legacy_main.go`.
- Added a `withRetryOnMount` client wrapper function to configure the Control Plane storage client to handle retries during mount initialization.
- Wrapped the control client with `withRetryOnMount` instead of `withRetryOnStorageLayout` inside `NewStorageHandle()` of `internal/storage/storage_handle.go`.
- Updated `storageControlClientWithRetry.GetStorageLayout()` in `internal/storage/control_client_wrapper.go` to use `storageutil.ShouldRetryOnMount` when `enableRetriesOnMount` is active, enabling autonomous self-healing for `404 NotFound` (missing bucket) and `403 PermissionDenied` errors during mount initialization.
- Restricted mount retries strictly to the Control Plane (`GetStorageLayout`) during mount setup, leaving Data Plane runtime I/O completely untouched and safe from infinite retry loops.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Verified that Data Plane runtime operations remain unchanged and fail fast on 404/non-retryable errors.
2. Unit tests - Added unit tests in `internal/storage/control_client_wrapper_test.go`:
   - `TestGetStorageLayout_MountRetriesEnabled_Retry404ThenSuccess`: Verifies that `GetStorageLayout` successfully retries transient 404 errors during initialization and succeeds.
   - `TestGetStorageLayout_MountRetriesDisabled_404FailsImmediately`: Verifies that `GetStorageLayout` fails immediately on 404 errors when the feature is disabled.
   - `TestGetStorageLayout_MountRetriesEnabled_AllAttemptsTimeOut`: Verifies correct propagation of deadline exceeded errors when all retry attempts time out.
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
No
