### PR TITLE
feat(cache): add LRU mechanics to Radix Trie

### DIFF
--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -26,6 +26,9 @@ type radixNode struct {
 	parent  *radixNode
 	child   *radixNode
 	sibling *radixNode
+	// LRU Linked List pointers
+	prev *radixNode
+	next *radixNode
 }
 
 // this radixTree struct will be replaced by a RadixCache struct afterwards with additional necessary fields
@@ -33,6 +36,10 @@ type radixNode struct {
 type radixTree struct {
 	root *radixNode
 	size int
+	// Head and tail of the LRU Doubly Linked List
+	head *radixNode
+	tail *radixNode
+	len  int
 }
 
 func newRadixTree() *radixTree {
@@ -190,6 +197,7 @@ func (t *radixTree) deleteNode(node *radixNode) {
 	if node == nil || node.value == nil {
 		return
 	}
+	t.remove(node) // Unlink from LRU list
 
 	node.value = nil
 	t.size--
@@ -227,4 +235,73 @@ func (t *radixTree) compressPathUpwards(curr *radixNode) {
 		}
 		break
 	}
+}
+
+// --- LRU Logic ---
+func (t *radixTree) moveToFront(node *radixNode) {
+	if t.head == node {
+		return
+	}
+	if node.prev != nil {
+		node.prev.next = node.next
+	}
+	if node.next != nil {
+		node.next.prev = node.prev
+	}
+	if t.tail == node {
+		t.tail = node.prev
+	}
+	node.prev = nil
+	node.next = t.head
+	if t.head != nil {
+		t.head.prev = node
+	}
+	t.head = node
+	if t.tail == nil {
+		t.tail = node
+	}
+}
+
+func (t *radixTree) pushFront(node *radixNode) {
+	node.prev = nil
+	node.next = t.head
+	if t.head != nil {
+		t.head.prev = node
+	}
+	t.head = node
+	if t.tail == nil {
+		t.tail = node
+	}
+	t.len++
+}
+
+func (t *radixTree) remove(node *radixNode) {
+	if t.head != node && node.prev == nil {
+		return
+	}
+	if node.prev != nil {
+		node.prev.next = node.next
+	} else {
+		t.head = node.next
+	}
+	if node.next != nil {
+		node.next.prev = node.prev
+	} else {
+		t.tail = node.prev
+	}
+	node.prev = nil
+	node.next = nil
+	t.len--
+}
+
+func (t *radixTree) evictOne() ValueType {
+	node := t.tail
+	if node == nil {
+		return nil
+	}
+	evictedEntry := node.value
+	// Remove from LRU list and then fully delete from the tree
+	t.remove(node)
+	t.deleteNode(node)
+	return evictedEntry
 }

--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -35,11 +35,17 @@ type radixNode struct {
 // radixTree encapsulates the core tree structure (LRU logic to be added in next PR).
 type radixTree struct {
 	root *radixNode
+
+	// size is the number of active, value-bearing entries in the radix tree.
 	size int
+
 	// Head and tail of the LRU Doubly Linked List
 	head *radixNode
 	tail *radixNode
-	len  int
+
+	// len is the number of nodes currently linked in the LRU list.
+	// In a properly functioning cache, size and len must always be equal.
+	len int
 }
 
 func newRadixTree() *radixTree {
@@ -197,7 +203,6 @@ func (t *radixTree) deleteNode(node *radixNode) {
 	if node == nil || node.value == nil {
 		return
 	}
-	t.remove(node) // Unlink from LRU list
 
 	node.value = nil
 	t.size--
@@ -257,9 +262,6 @@ func (t *radixTree) moveToFront(node *radixNode) {
 		t.head.prev = node
 	}
 	t.head = node
-	if t.tail == nil {
-		t.tail = node
-	}
 }
 
 func (t *radixTree) pushFront(node *radixNode) {

--- a/internal/cache/lru/radix_test.go
+++ b/internal/cache/lru/radix_test.go
@@ -128,3 +128,72 @@ func TestRadixTree_DeleteAndCompress(t *testing.T) {
 	assert.Equal(t, "foo/baz", n2.prefix)
 	assert.Equal(t, tree.root, n2.parent) // Path compressed all the way up to the root!
 }
+
+func TestRadixTree_LRU_PushFront(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	val1 := mockValue{10}
+	val2 := mockValue{20}
+	node1, _ := tree.insertNode("foo/1", val1)
+	node2, _ := tree.insertNode("foo/2", val2)
+
+	// Act
+	tree.pushFront(node1)
+	tree.pushFront(node2)
+
+	// Assert
+	assert.Equal(t, 2, tree.len)
+	assert.Equal(t, node2, tree.head)
+	assert.Equal(t, node1, tree.tail)
+	assert.Equal(t, node1, node2.next)
+	assert.Equal(t, node2, node1.prev)
+}
+
+func TestRadixTree_LRU_MoveToFront(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	node1, _ := tree.insertNode("foo/1", mockValue{10})
+	node2, _ := tree.insertNode("foo/2", mockValue{20})
+	tree.pushFront(node1)
+	tree.pushFront(node2)
+
+	// Act
+	tree.moveToFront(node1) // Move tail to head
+
+	// Assert
+	assert.Equal(t, node1, tree.head)
+	assert.Equal(t, node2, tree.tail)
+}
+
+func TestRadixTree_LRU_Remove(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	node1, _ := tree.insertNode("foo/1", mockValue{10})
+	tree.pushFront(node1)
+
+	// Act
+	tree.remove(node1)
+
+	// Assert
+	assert.Equal(t, 0, tree.len)
+	assert.Nil(t, tree.head)
+	assert.Nil(t, tree.tail)
+}
+
+func TestRadixTree_LRU_EvictOne(t *testing.T) {
+	// Arrange
+	tree := newRadixTree()
+	node1, _ := tree.insertNode("foo/1", mockValue{10})
+	node2, _ := tree.insertNode("foo/2", mockValue{20})
+	tree.pushFront(node1)
+	tree.pushFront(node2)
+
+	// Act
+	evictedValue := tree.evictOne()
+
+	// Assert
+	assert.Equal(t, 1, tree.len)
+	assert.Equal(t, mockValue{10}, evictedValue) // node1 was tail (least recently used)
+	assert.Equal(t, node2, tree.head)
+	assert.Equal(t, node2, tree.tail)
+}

--- a/internal/cache/lru/radix_test.go
+++ b/internal/cache/lru/radix_test.go
@@ -26,84 +26,66 @@ type mockValue struct{ size uint64 }
 func (m mockValue) Size() uint64 { return m.size }
 
 func TestRadixTree_Insert(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	val1 := mockValue{10}
 
-	// Act
 	node1, isNew := tree.insertNode("foo/bar", val1)
 
-	// Assert
 	assert.True(t, isNew)
 	assert.NotNil(t, node1)
 	assert.Equal(t, 1, tree.size)
 }
 
 func TestRadixTree_InsertNil(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 
-	// Act
 	node, isNew := tree.insertNode("foo/bar", nil)
 
-	// Assert
 	assert.False(t, isNew)
 	assert.Nil(t, node)
 	assert.Equal(t, 0, tree.size)
 }
 
 func TestRadixTree_Get(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	val1 := mockValue{10}
 	tree.insertNode("foo/bar", val1)
 
-	// Act
 	gotNode, ok := tree.getNode("foo/bar")
 
-	// Assert
 	assert.True(t, ok)
 	assert.Equal(t, val1, gotNode.value)
 }
 
 func TestRadixTree_Overwrite(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	tree.insertNode("foo/bar", mockValue{10})
 	val2 := mockValue{20}
 
-	// Act
 	node2, isNew2 := tree.insertNode("foo/bar", val2)
 
-	// Assert
 	assert.False(t, isNew2)
 	assert.Equal(t, val2, node2.value)
 	assert.Equal(t, 1, tree.size)
 }
 
 func TestRadixTree_GetNonExistent(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	tree.insertNode("foo/bar", mockValue{10})
 
-	// Act
 	_, ok := tree.getNode("foo/baz")
 
-	// Assert
 	assert.False(t, ok)
 }
 
 func TestRadixTree_PrefixSplitting(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	tree.insertNode("foo/bar", mockValue{1})
 
-	// Act
 	tree.insertNode("foo/baz", mockValue{2}) // Splits "foo/ba" -> "r", "z"
 	n1, _ := tree.getNode("foo/bar")
 	n2, _ := tree.getNode("foo/baz")
 
-	// Assert
 	assert.Equal(t, 2, tree.size)
 	assert.Equal(t, n1.parent, n2.parent)
 	assert.Equal(t, "foo/ba", n1.parent.prefix)
@@ -111,18 +93,15 @@ func TestRadixTree_PrefixSplitting(t *testing.T) {
 }
 
 func TestRadixTree_DeleteAndCompress(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	tree.insertNode("foo/bar", mockValue{1})
 	tree.insertNode("foo/baz", mockValue{2})
 	n1, _ := tree.getNode("foo/bar")
 
-	// Act
 	tree.deleteNode(n1)
 	_, ok := tree.getNode("foo/bar")
 	n2, _ := tree.getNode("foo/baz")
 
-	// Assert
 	assert.Equal(t, 1, tree.size)
 	assert.False(t, ok)
 	assert.Equal(t, "foo/baz", n2.prefix)
@@ -130,18 +109,15 @@ func TestRadixTree_DeleteAndCompress(t *testing.T) {
 }
 
 func TestRadixTree_LRU_PushFront(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	val1 := mockValue{10}
 	val2 := mockValue{20}
 	node1, _ := tree.insertNode("foo/1", val1)
 	node2, _ := tree.insertNode("foo/2", val2)
 
-	// Act
 	tree.pushFront(node1)
 	tree.pushFront(node2)
 
-	// Assert
 	assert.Equal(t, 2, tree.len)
 	assert.Equal(t, node2, tree.head)
 	assert.Equal(t, node1, tree.tail)
@@ -150,48 +126,111 @@ func TestRadixTree_LRU_PushFront(t *testing.T) {
 }
 
 func TestRadixTree_LRU_MoveToFront(t *testing.T) {
-	// Arrange
-	tree := newRadixTree()
-	node1, _ := tree.insertNode("foo/1", mockValue{10})
-	node2, _ := tree.insertNode("foo/2", mockValue{20})
-	tree.pushFront(node1)
-	tree.pushFront(node2)
+	t.Run("move tail to front", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		node2, _ := tree.insertNode("foo/2", mockValue{20})
+		tree.pushFront(node1)
+		tree.pushFront(node2)
 
-	// Act
-	tree.moveToFront(node1) // Move tail to head
+		tree.moveToFront(node1)
 
-	// Assert
-	assert.Equal(t, node1, tree.head)
-	assert.Equal(t, node2, tree.tail)
+		assert.Equal(t, node1, tree.head)
+		assert.Equal(t, node2, tree.tail)
+		assert.Nil(t, node1.prev)
+		assert.Equal(t, node2, node1.next)
+		assert.Equal(t, node1, node2.prev)
+		assert.Nil(t, node2.next)
+	})
+
+	t.Run("move middle to front", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		node2, _ := tree.insertNode("foo/2", mockValue{20})
+		node3, _ := tree.insertNode("foo/3", mockValue{30})
+		tree.pushFront(node1)
+		tree.pushFront(node2)
+		tree.pushFront(node3)
+
+		tree.moveToFront(node2)
+
+		assert.Equal(t, node2, tree.head)
+		assert.Equal(t, node1, tree.tail)
+		assert.Nil(t, node2.prev)
+		assert.Equal(t, node3, node2.next)
+		assert.Equal(t, node2, node3.prev)
+		assert.Equal(t, node1, node3.next)
+		assert.Equal(t, node3, node1.prev)
+	})
+
+	t.Run("move head to front", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		node2, _ := tree.insertNode("foo/2", mockValue{20})
+		tree.pushFront(node1)
+		tree.pushFront(node2)
+
+		tree.moveToFront(node2)
+
+		assert.Equal(t, node2, tree.head)
+		assert.Equal(t, node1, tree.tail)
+	})
 }
 
 func TestRadixTree_LRU_Remove(t *testing.T) {
-	// Arrange
-	tree := newRadixTree()
-	node1, _ := tree.insertNode("foo/1", mockValue{10})
-	tree.pushFront(node1)
+	t.Run("remove only node", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		tree.pushFront(node1)
 
-	// Act
-	tree.remove(node1)
+		tree.remove(node1)
 
-	// Assert
-	assert.Equal(t, 0, tree.len)
-	assert.Nil(t, tree.head)
-	assert.Nil(t, tree.tail)
+		assert.Equal(t, 0, tree.len)
+		assert.Nil(t, tree.head)
+		assert.Nil(t, tree.tail)
+	})
+
+	t.Run("remove middle node", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		node2, _ := tree.insertNode("foo/2", mockValue{20})
+		node3, _ := tree.insertNode("foo/3", mockValue{30})
+		tree.pushFront(node1)
+		tree.pushFront(node2)
+		tree.pushFront(node3)
+
+		tree.remove(node2)
+
+		assert.Equal(t, 2, tree.len)
+		assert.Equal(t, node3, tree.head)
+		assert.Equal(t, node1, tree.tail)
+		assert.Equal(t, node1, node3.next)
+		assert.Equal(t, node3, node1.prev)
+	})
+
+	t.Run("remove node not in list", func(t *testing.T) {
+		tree := newRadixTree()
+		node1, _ := tree.insertNode("foo/1", mockValue{10})
+		node2, _ := tree.insertNode("foo/2", mockValue{20})
+		tree.pushFront(node1)
+
+		tree.remove(node2)
+
+		assert.Equal(t, 1, tree.len)
+		assert.Equal(t, node1, tree.head)
+		assert.Equal(t, node1, tree.tail)
+	})
 }
 
 func TestRadixTree_LRU_EvictOne(t *testing.T) {
-	// Arrange
 	tree := newRadixTree()
 	node1, _ := tree.insertNode("foo/1", mockValue{10})
 	node2, _ := tree.insertNode("foo/2", mockValue{20})
 	tree.pushFront(node1)
 	tree.pushFront(node2)
 
-	// Act
 	evictedValue := tree.evictOne()
 
-	// Assert
 	assert.Equal(t, 1, tree.len)
 	assert.Equal(t, mockValue{10}, evictedValue) // node1 was tail (least recently used)
 	assert.Equal(t, node2, tree.head)


### PR DESCRIPTION
### Description
This PR embeds a doubly-linked list directly into the `radixNode` structure and introduces the core LRU management functions: `pushFront`, `moveToFront`, `remove`, and `evictOne`.

Instead of maintaining a separate list data structure (like the standard `container/list`) , the `prev`and `next` pointers are incorporated directly into the `radixNode` struct. This "intrusive" design completely eliminates the need for separate list-element allocations when tracking cache eviction order, saving memory and GC pressure.

`evictOne()` performs `O(1)` removal of the tail node from both the linked list and the core tree structure in constant time.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Appended unit tests to `radix_test.go` to test `pushFront`, `moveToFront`, `remove`, and `evictOne` pointer mutations.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.