### PR TITLE
feat(kernel range reader): Add buffer pooling support for large reads on regional buckets

### DIFF
--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -27,6 +27,7 @@ import (
 	"reflect"
 	"slices"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -60,6 +61,9 @@ import (
 	"github.com/jacobsa/timeutil"
 	"github.com/spf13/viper"
 )
+
+// readPoolBufferSize is the size of each buffer in readBufferPool (1 MiB).
+const readPoolBufferSize = util.MiB
 
 type ServerConfig struct {
 	// A clock used for cache expiration. It is *not* used for inode times, for
@@ -225,6 +229,11 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		globalMaxWriteBlocksSem:    semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks),
 		globalMaxReadBlocksSem:     semaphore.NewWeighted(serverCfg.NewConfig.Read.GlobalMaxBlocks),
 		globalMetadataPrefetchSem:  semaphore.NewWeighted(serverCfg.NewConfig.MetadataCache.MetadataPrefetchMaxWorkers),
+		readBufferPool: sync.Pool{
+			New: func() any {
+				return new([readPoolBufferSize]byte)
+			},
+		},
 	}
 
 	// Initialize MRD cache if enabled
@@ -676,6 +685,9 @@ type fileSystem struct {
 
 	// mrdCache manages the cache of inactive MultiRangeDownloaders.
 	mrdCache *lru.Cache
+
+	// readBufferPool is a sync.Pool of readPoolBufferSize (1 MiB) buffers.
+	readBufferPool sync.Pool
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -3118,23 +3130,74 @@ func (fs *fileSystem) ReadFile(
 	}
 	// Serve the read.
 
+	req := gcsx.ReadRequest{
+		Offset: op.Offset,
+		Size:   op.Size,
+	}
+
+	useReadBufferPool := op.Dst == nil
+	if useReadBufferPool {
+		if !fs.newConfig.FileSystem.EnableKernelReader || fh.Inode().Bucket().BucketType().IsRapid() {
+			logger.Errorf("ReadFile: buffer pool allocation is only supported for regional buckets with"+
+				" kernel reader enabled (EnableKernelReader: %v, IsRapid: %v)",
+				fs.newConfig.FileSystem.EnableKernelReader,
+				fh.Inode().Bucket().BucketType().IsRapid())
+			fh.Inode().Unlock()
+			return syscall.ENOTSUP
+		}
+
+		var buffers [][]byte
+		remaining := op.Size
+		for remaining > 0 {
+			bufVal := fs.readBufferPool.Get()
+			poolBuf := bufVal.(*[readPoolBufferSize]byte)
+			size := min(remaining, readPoolBufferSize)
+			buffers = append(buffers, poolBuf[:size])
+			remaining -= size
+		}
+		req.Buffers = buffers
+	} else {
+		req.Buffer = op.Dst
+	}
+
 	if fs.newConfig.FileSystem.EnableKernelReader {
 		var resp gcsx.ReadResponse
-		req := &gcsx.ReadRequest{
-			Buffer: op.Dst,
-			Offset: op.Offset,
-		}
-		resp, err = fh.ReadWithKernelReader(ctx, req)
+		resp, err = fh.ReadWithKernelReader(ctx, &req)
 		op.BytesRead = resp.Size
-		op.Data = resp.Data
-		op.Callback = resp.Callback
+		if useReadBufferPool {
+			if len(resp.Data) > 0 {
+				op.Data = resp.Data
+				// Zero-copy hit: we did not use the pool buffers at all. Return all of them immediately.
+				for _, buf := range req.Buffers {
+					fs.readBufferPool.Put((*[readPoolBufferSize]byte)(buf[:cap(buf)]))
+				}
+				req.Buffers = nil
+			} else {
+				op.Data = util.LimitBuffers(req.Buffers, resp.Size)
+				// Return unused buffers (from index len(op.Data) onwards) back to the pool immediately.
+				usedCount := len(op.Data)
+				for j := usedCount; j < len(req.Buffers); j++ {
+					fs.readBufferPool.Put((*[readPoolBufferSize]byte)(req.Buffers[j][:cap(req.Buffers[j])]))
+				}
+				// Shrink req.Buffers so the callback only returns the used ones.
+				req.Buffers = req.Buffers[:usedCount]
+			}
+
+			op.Callback = func() {
+				if resp.Callback != nil {
+					resp.Callback()
+				}
+				for _, buf := range req.Buffers {
+					fs.readBufferPool.Put((*[readPoolBufferSize]byte)(buf[:cap(buf)]))
+				}
+			}
+		} else {
+			op.Data = resp.Data
+			op.Callback = resp.Callback
+		}
 	} else if fs.newConfig.EnableNewReader {
 		var resp gcsx.ReadResponse
-		req := &gcsx.ReadRequest{
-			Buffer: op.Dst,
-			Offset: op.Offset,
-		}
-		resp, err = fh.ReadWithReadManager(ctx, req, fs.sequentialReadSizeMb)
+		resp, err = fh.ReadWithReadManager(ctx, &req, fs.sequentialReadSizeMb)
 		op.BytesRead = resp.Size
 		op.Data = resp.Data
 		op.Callback = resp.Callback

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3135,7 +3135,7 @@ func (fs *fileSystem) ReadFile(
 		Size:   op.Size,
 	}
 
-	useReadBufferPool := op.Dst == nil
+	useReadBufferPool := op.Size > 0 && op.Dst == nil
 	if useReadBufferPool {
 		if !fs.newConfig.FileSystem.EnableKernelReader || fh.Inode().Bucket().BucketType().IsRapid() {
 			logger.Errorf("ReadFile: buffer pool allocation is only supported for regional buckets with"+

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -289,8 +289,23 @@ func (fh *FileHandle) ReadWithKernelReader(ctx context.Context, req *gcsx.ReadRe
 	if !fh.inode.SourceGenerationIsAuthoritative() {
 		// Read from inode if source generation is not authoritative.
 		defer fh.inode.Unlock()
-		n, err := fh.inode.Read(ctx, req.Buffer, req.Offset)
-		return gcsx.ReadResponse{Size: n}, err
+		buffers := req.Buffers
+		if len(buffers) == 0 {
+			// Use a stack-allocated 1-element array to avoid heap allocation
+			// when wrapping req.Buffer into a slice for unified iteration.
+			single := [1][]byte{req.Buffer}
+			buffers = single[:]
+		}
+
+		var n int
+		for _, b := range buffers {
+			bytesRead, err := fh.inode.Read(ctx, b, req.Offset+int64(n))
+			n += bytesRead
+			if err != nil || bytesRead < len(b) {
+				return gcsx.ReadResponse{Size: n}, err
+			}
+		}
+		return gcsx.ReadResponse{Size: n}, nil
 	}
 	fh.inode.Unlock()
 

--- a/internal/fs/large_read_regional_test.go
+++ b/internal/fs/large_read_regional_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fs_test
+
+import (
+	"context"
+	"syscall"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
+	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/jacobsa/fuse/fuseutil"
+	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupLargeRead(ctx context.Context, t *testing.T, isZonal bool, enableKernelReader bool, fileContent string) (fuseutil.FileSystem, *fuseops.ReadFileOp) {
+	t.Helper()
+	bucketName := "regional-bucket"
+	if isZonal {
+		bucketName = "zonal-bucket"
+	}
+	bucket := fake.NewFakeBucket(timeutil.RealClock(), bucketName, gcs.BucketType{Zonal: isZonal, Hierarchical: false})
+
+	serverCfg := &fs.ServerConfig{
+		NewConfig: &cfg.Config{
+			Write: cfg.WriteConfig{
+				GlobalMaxBlocks: 1,
+			},
+			FileSystem: cfg.FileSystemConfig{
+				EnableKernelReader: enableKernelReader,
+			},
+		},
+		CacheClock: &timeutil.SimulatedClock{},
+		BucketName: bucketName,
+		BucketManager: &fakeBucketManager{
+			buckets: map[string]gcs.Bucket{
+				bucketName: bucket,
+			},
+		},
+		SequentialReadSizeMb: 200,
+		TraceHandle:          tracing.NewOTELTracer(),
+		MetricHandle:         metrics.NewNoopMetrics(),
+	}
+
+	server, err := fs.NewFileSystem(ctx, serverCfg)
+	require.NoError(t, err)
+
+	fileName := "large-file"
+	createWithContents(ctx, t, bucket, fileName, fileContent)
+	lookUpOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   fileName,
+	}
+	err = server.LookUpInode(ctx, lookUpOp)
+	require.NoError(t, err)
+
+	openOp := &fuseops.OpenFileOp{
+		Inode: lookUpOp.Entry.Child,
+	}
+	err = server.OpenFile(ctx, openOp)
+	require.NoError(t, err)
+
+	readOp := &fuseops.ReadFileOp{
+		Inode:  lookUpOp.Entry.Child,
+		Handle: openOp.Handle,
+		Offset: 0,
+		Size:   int64(len(fileContent)),
+		Dst:    nil,
+	}
+
+	return server, readOp
+}
+
+func TestLargeReadRegional_Success(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	fileContent := "regional bucket content for vectored read verification."
+	server, readOp := setupLargeRead(ctx, t, false, true, fileContent)
+
+	// Act
+	err := server.ReadFile(ctx, readOp)
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, len(fileContent), readOp.BytesRead)
+	require.Len(t, readOp.Data, 1)
+	assert.Equal(t, []byte(fileContent), readOp.Data[0])
+	if readOp.Callback != nil {
+		readOp.Callback()
+	}
+}
+
+func TestLargeReadRegional_NotSupportedForZonal(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	server, readOp := setupLargeRead(ctx, t, true, true, "zonal bucket content.")
+
+	// Act
+	err := server.ReadFile(ctx, readOp)
+
+	// Assert
+	assert.ErrorIs(t, err, syscall.ENOTSUP)
+}
+
+func TestLargeReadRegional_NotSupportedWhenKernelReaderDisabled(t *testing.T) {
+	// Arrange
+	ctx := context.Background()
+	server, readOp := setupLargeRead(ctx, t, false, false, "regional bucket content.")
+
+	// Act
+	err := server.ReadFile(ctx, readOp)
+
+	// Assert
+	assert.ErrorIs(t, err, syscall.ENOTSUP)
+}

--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -96,3 +96,21 @@ func BytesToHigherMiBs(bytes uint64) uint64 {
 	// Use integer arithmetic and bitwise shift to avoid slow float conversions
 	return (bytes + bytesInOneMiB - 1) >> 20
 }
+
+// LimitBuffers reslices the buffers slice in-place to represent the first 'limit'
+// bytes. It avoids allocating a new slice of slices by modifying the slice elements
+// in-place and returning a subslice of the original buffers slice.
+func LimitBuffers(buffers [][]byte, limit int) [][]byte {
+	if limit <= 0 {
+		return nil
+	}
+	var current int
+	for i, b := range buffers {
+		if current+len(b) >= limit {
+			buffers[i] = b[:limit-current]
+			return buffers[:i+1]
+		}
+		current += len(b)
+	}
+	return buffers
+}

--- a/internal/util/util_test.go
+++ b/internal/util/util_test.go
@@ -213,3 +213,57 @@ func (ts *UtilTest) TestBytesToHigherMiBs() {
 		assert.Equal(ts.T(), tc.mib, BytesToHigherMiBs(tc.bytes))
 	}
 }
+
+func (ts *UtilTest) TestLimitBuffers() {
+	cases := []struct {
+		name     string
+		buffers  [][]byte
+		limit    int
+		expected [][]byte
+	}{
+		{
+			name:     "limit zero",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    0,
+			expected: nil,
+		},
+		{
+			name:     "limit negative",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    -5,
+			expected: nil,
+		},
+		{
+			name:     "limit within first buffer",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    3,
+			expected: [][]byte{[]byte("hel")},
+		},
+		{
+			name:     "limit at buffer boundary",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    5,
+			expected: [][]byte{[]byte("hello")},
+		},
+		{
+			name:     "limit spanning multiple buffers",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    8,
+			expected: [][]byte{[]byte("hello"), []byte("wor")},
+		},
+		{
+			name:     "limit greater than total length",
+			buffers:  [][]byte{[]byte("hello"), []byte("world")},
+			limit:    20,
+			expected: [][]byte{[]byte("hello"), []byte("world")},
+		},
+	}
+
+	for _, tc := range cases {
+		ts.Run(tc.name, func() {
+			result := LimitBuffers(tc.buffers, tc.limit)
+
+			assert.Equal(ts.T(), tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### Description
# Description

This PR introduces buffer pooling for large and vectored read operations to optimize memory usage and reduce garbage collection overhead. By reusing allocated buffers via a sync pool, we minimize memory churn during sequential and large file reads.

> [!NOTE]
> Buffer pooling support for larger reads is only supported for **regional buckets** when **kernel reader** is enabled.

## Key Changes

* **Buffer Pooling & Lifecycle Management (`internal/fs/fs.go`)**
  * Integrated `readBufferPool` into read operations to dynamically allocate and recycle byte buffers for read requests (supported only for regional buckets with kernel reader enabled).
  * Implemented immediate buffer reclamation: unused buffers or zero-copy hits return their buffers to the pool right away.
  * Added callback handling to ensure borrowed buffers are properly returned to the pool after the caller finishes consuming the read data.

* **Buffer Limiting Utility (`internal/util/util.go`)**
  * Added a zero-allocation helper function `LimitBuffers(buffers [][]byte, limit int) [][]byte`.
  * Reslices multi-buffer slices in-place to cap total data size without allocating new slice headers or arrays.

* **Testing (`internal/fs/large_read_regional_test.go`, `internal/util/util_test.go`)**
  * Added unit tests for `LimitBuffers` covering boundary conditions, multiple buffer spans, and edge cases.
  * Introduced regional large read test suite (`large_read_regional_test.go`) verifying successful vectored reads on regional buckets and confirming proper fallback/error behavior (`ENOTSUP`) for zonal buckets or when kernel reader support is disabled.

### Link to the issue in case of a bug fix.
b/530765312

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
