### PR TITLE
fix(streaming writes): change log severity for streaming writes fallback from INFO to TRACE

### DIFF
--- a/docs/semantics.md
+++ b/docs/semantics.md
@@ -65,7 +65,7 @@ opened for streaming writes.
   writes to a new file only. Modifying existing files, or doing out-of-order
   writes (whether from the same file handle or concurrent writes from multiple
   file handles) will cause GCSFuse to automatically revert to the existing write
-  path of staging writes to a temporary file on disk. An informational log
+  path of staging writes to a temporary file on disk. A trace log
   message will be emitted when this fallback occurs.
 
 - **Concurrent Writes to the Same File:** While concurrent writes to the same

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -227,21 +227,21 @@ Starting with [version 3.0.0](https://github.com/GoogleCloudPlatform/gcsfuse/rel
 ### Writes still using legacy staged writes even though streaming writes are enabled.
 If you observe that GCSFuse is still utilizing staged writes despite streaming writes being enabled, several factors could be at play.
 
-- **Concurrent Streaming Write Limit Reached:** When the number of concurrent streaming writes exceeds the configured limit (`--write-global-max-blocks`), GCSFuse automatically uses legacy staged writes for concurrent file writes above this limit. You will see an warnining log message when this happens, similar to:
+- **Concurrent Streaming Write Limit Reached:** When the number of concurrent streaming writes exceeds the configured limit (`--write-global-max-blocks`), GCSFuse automatically uses legacy staged writes for concurrent file writes above this limit. When trace logging (`--log-severity=TRACE`) is enabled, you will see a log message similar to:
   > File <var>file_name</var> will use legacy staged writes because concurrent streaming write limit (set by --write-global-max-blocks) has been reached.
 
   This is not an error, but a fallback mechanism to manage memory usage. If your system has sufficient memory, you can increase the number of allowed concurrent streaming writes by adjusting the `--write-global-max-blocks` flag to prevent this warning. For memory usage refer [write semantics](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#writes) doc for more details.
 
 - **Unsupported Streaming Write Operations:** Streaming writes only work for sequential writes to new or empty files. GCSFuse will automatically revert to legacy staged writes for the following scenarios:
-    - **Modifying existing files (non-zero size):** Writing to a file that is not empty will cause that file to use legacy staged writes. You will see an informational log message similar to:
+    - **Modifying existing files (non-zero size):** Writing to a file that is not empty will cause that file to use legacy staged writes. When trace logging (`--log-severity=TRACE`) is enabled, you will see a log message similar to:
       > Existing file <var>file_name</var> of size <var>size</var> bytes (non-zero) will use legacy staged writes.
 
-    - **Performing out-of-order writes:** Streaming writes require data to be written sequentially. If a write occurs at an unexpected offset, GCSFuse will finalize the currently written sequential data and switch to legacy staged writes. You will see an informational log message similar to:
+    - **Performing out-of-order writes:** Streaming writes require data to be written sequentially. If a write occurs at an unexpected offset, GCSFuse will finalize the currently written sequential data and switch to legacy staged writes. When trace logging (`--log-severity=TRACE`) is enabled, you will see a log message similar to:
       > Out of order write detected. File <var>file_name</var> will now use legacy staged writes.
 
     - **Reading from a file while writes are in progress:** Performing a read on a file that is being actively written to using streaming writes will finalizes the object on GCS. Subsequent writes to that file will use the legacy staged writes.
 
-    - **Truncating a file downwards while streaming writes are in progress:** If a file is truncated to a smaller size while being written via streaming writes, the object is finalized on GCS, and subsequent writes will use the legacy staged writes. You will see an informational log message similar to:
+    - **Truncating a file downwards while streaming writes are in progress:** If a file is truncated to a smaller size while being written via streaming writes, the object is finalized on GCS, and subsequent writes will use the legacy staged writes. When trace logging (`--log-severity=TRACE`) is enabled, you will see a log message similar to:
       > Out of order write detected. File <var>file_name</var> will now use legacy staged writes.
 
 ### Issues related to the gcs-fuse-csi-driver

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -755,7 +755,7 @@ func (f *FileInode) writeUsingBufferedWrites(ctx context.Context, data []byte, o
 	}
 	// Fall back to temp file for Out-Of-Order Writes.
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
-		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
+		logger.Tracef("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
@@ -1116,7 +1116,7 @@ func (f *FileInode) truncateUsingBufferedWriteHandler(ctx context.Context, size 
 	err := f.bwh.Truncate(size)
 	// If truncate size is less than the total file size resulting in OutOfOrder write, finalize and fall back to temp file.
 	if errors.Is(err, bufferedwrites.ErrOutOfOrderWrite) {
-		logger.Infof("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
+		logger.Tracef("Out of order write detected. File %s will now use legacy staged writes. "+StreamingWritesSemantics, f.name.String())
 		// Finalize the object.
 		err = f.flushUsingBufferedWriteHandler(ctx)
 		if err != nil {
@@ -1237,7 +1237,7 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 			TraceHandle:              f.traceHandle,
 		})
 		if errors.Is(err, block.CantAllocateAnyBlockError) {
-			logger.Warnf("File %s will use legacy staged writes because concurrent streaming write "+
+			logger.Tracef("File %s will use legacy staged writes because concurrent streaming write "+
 				"limit (set by --write-global-max-blocks) has been reached. To allow more concurrent files "+
 				"to use streaming writes, consider increasing this limit if sufficient memory is available. "+
 				"For more details on memory usage, see: https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/docs/semantics.md#writes", f.name.String())
@@ -1262,7 +1262,7 @@ func (f *FileInode) areBufferedWritesSupported(openMode util.OpenMode, obj *gcs.
 	if f.config.Write.EnableRapidAppends && openMode.IsAppend() && f.bucket.BucketType().RapidWritesEnabled() && obj.Finalized.IsZero() {
 		return true
 	}
-	logger.Infof("Existing file %s of size %d bytes (non-zero) will use legacy staged writes. "+StreamingWritesSemantics, f.name.String(), obj.Size)
+	logger.Tracef("Existing file %s of size %d bytes (non-zero) will use legacy staged writes. "+StreamingWritesSemantics, f.name.String(), obj.Size)
 	recordStreamingWriteFallbackMetric(f.metricHandle, openMode, metrics.WriteFallbackReasonExistingFileAttr)
 	return false
 }


### PR DESCRIPTION
### Description
This PR addresses an issue where GCS Fuse was emitting excessive logs when falling back to legacy staged writes from streaming writes. The `INFO` and `WARN` level logs were spamming user logs (e.g., when writing to existing files, performing out-of-order writes, or reaching concurrent write limits). 

To prevent this log spam and improve the product experience, the severity of these fallback logs has been reduced to `TRACE` level. This ensures the information remains available for debugging purposes when explicitly requested, without polluting the default log output. Additionally, proper metrics are already in place that record the counts and the specific reasons for the fallback, ensuring that no observability information is lost despite the reduction in log verbosity. Documentation has also been updated accordingly. 


### Link to the issue in case of a bug fix.
[b/528701083](https://buganizer.corp.google.com/issues/528701083)
### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
None. Only logging severity is changed.