### PR TITLE
test(gke_machine_type): pass test_config.yaml to flag_optimizations in GKE machine_type_test

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
@@ -36,6 +36,6 @@ echo "Step 4: Running tests ..."
 # These tests are chosen to verify that machine-type is correctly passed by
 # CSI Driver to GCSFuse and GCSFuse is correctly accepting it and triggering optimization flags
 # like implicit-dirs and rename-dir-limit for high-performance machine-type as expected.
-go test -v ./tools/integration_tests/flag_optimizations/... --integrationTest --mountedDirectory=/data_mnt --testbucket="$BUCKET_NAME" -run "TestImplicitDirsEnabled|TestRenameDirLimitSet"
+go test -v ./tools/integration_tests/flag_optimizations/... --integrationTest --config-file="$(pwd)/tools/integration_tests/test_config.yaml" --mountedDirectory=/data_mnt --testbucket="$BUCKET_NAME" -run "TestImplicitDirsEnabled|TestRenameDirLimitSet"
 
 echo "Step 5: Test finished successfully."


### PR DESCRIPTION
### Description
Resolves fatal errors caused by missing `FlagOptimizations` configurations after the removal of hardcoded test fallback configs in a recent commit. Previously, `setup_test.go` would fall back to manual configs, but it now strictly requires `test_config.yaml` to be passed.
### Link to the issue in case of a bug fix.
[b/532193472](b/532193472)
### Testing details
1. Manual - Yes.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
