### PR TITLE
test(gke machine type): fix fusermount missing issue in gke machine type test

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
@@ -15,7 +15,7 @@
 
 set -e
 echo "Step 1: Container started. Updating apt and installing dependencies..."
-apt-get update && apt-get install -y wget git build-essential ca-certificates sudo
+apt-get update && apt-get install -y wget git build-essential ca-certificates fuse sudo
 
 echo "Step 2: Cloning GCSFuse repo..."
 git clone -b "$GCSFUSE_BRANCH" https://github.com/GoogleCloudPlatform/gcsfuse.git


### PR DESCRIPTION
### Description
This PR fixes a failure in the GKE machine type continuous test where GCSFuse fails to mount. The tests (`TestImplicitDirsEnabled`) were panicking with the error `exec: "fusermount": executable file not found in $PATH`. 

To resolve this, the `fuse` package has been added to the dependencies installed via `apt-get install` in `run_test.sh` so that the required `fusermount` binary is available in the test container's environment.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.