### PR TITLE
test(ci): install fuse3 to fix gke machine type test failures

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
@@ -15,7 +15,7 @@
 
 set -e
 echo "Step 1: Container started. Updating apt and installing dependencies..."
-apt-get update && apt-get install -y wget git build-essential ca-certificates fuse sudo
+apt-get update && apt-get install -y wget git build-essential ca-certificates fuse3 sudo
 
 echo "Step 2: Cloning GCSFuse repo..."
 git clone -b "$GCSFUSE_BRANCH" https://github.com/GoogleCloudPlatform/gcsfuse.git


### PR DESCRIPTION
### Description
This PR fixes the failing GKE machine type continuous tests where GCSFuse was unable to mount the test buckets. 

**Background & Why the previous approach failed:**
Initially, the `TestImplicitDirsEnabled` test was panicking with `exec: "fusermount": executable file not found in $PATH`. 

An initial attempt was made to fix this by adding the legacy `fuse` package to the container. While this provided the missing binary, the test then crashed at the actual mount step with `running /usr/bin/fusermount: exit status 1`. This occurred because the test environment runs on Ubuntu 24.04 (Noble Numbat), and the older FUSE 2 (`fuse`) package is incompatible with this modern OS environment. 

**The Fix:**
This PR updates `run_test.sh` to install `fuse3` instead. Installing `fuse3` provides the required compatibility for Ubuntu 24.04 while still properly satisfying the underlying Go library's mount command expectations, allowing the integration tests to run successfully.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - Verified locally by simulating the Ubuntu 24.04 CI container environment.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.
