### PR TITLE
test(lru): demonstrate TOCTOU race in lru implementation

### DIFF
--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -413,7 +413,7 @@ func (m *mutableTestData) setSize(newSize uint64) {
 // when an entry's size is mutated in memory concurrently with eviction or erasure before UpdateSize finishes.
 func TestMapCache_UpdateSize_TOCTOU_Underflow(t *testing.T) {
 	locker.EnableInvariantsCheck()
-	cache := lru.NewCache(100)
+	cache := lru.NewCache(20000)
 	key := "test-key"
 	val := &mutableTestData{dataSize: 20}
 	_, err := cache.Insert(key, val)

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -391,3 +391,54 @@ func Test_EraseEntriesWithGivenPrefix_Concurrent(t *testing.T) {
 
 	wg.Wait()
 }
+
+type mutableTestData struct {
+	mu       sync.Mutex
+	dataSize uint64
+}
+
+func (m *mutableTestData) Size() uint64 {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.dataSize
+}
+
+func (m *mutableTestData) setSize(newSize uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dataSize = newSize
+}
+
+// TestMapCache_UpdateSize_TOCTOU_Underflow exhibits the TOCTOU race and size accounting underflow
+// when an entry's size is mutated in memory concurrently with eviction or erasure before UpdateSize finishes.
+func TestMapCache_UpdateSize_TOCTOU_Underflow(t *testing.T) {
+	locker.EnableInvariantsCheck()
+	cache := lru.NewCache(100)
+	key := "test-key"
+	val := &mutableTestData{dataSize: 20}
+	_, err := cache.Insert(key, val)
+	require.NoError(t, err)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Goroutine 1: mutate the size in memory and call UpdateSize with strictly positive delta (+30)
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			val.setSize(50)               // Simulate chunk download adding 30 bytes
+			_ = cache.UpdateSize(key, 30) // Strictly positive +30 delta!
+		}
+	}()
+
+	// Goroutine 2: concurrently Erase and Re-insert with initial size 20
+	go func() {
+		defer wg.Done()
+		for range 50 {
+			cache.Erase(key)
+			val.setSize(20) // Reset in-memory size for new insertion
+			_, _ = cache.Insert(key, val)
+		}
+	}()
+
+	wg.Wait()
+}


### PR DESCRIPTION
### Description
When downloading **sparse files**, cached objects grow incrementally from 0 bytes as chunks arrive. Callers invoke `cache.UpdateSize(key, delta)` to dynamically update LRU size accounting (`currentSize`). *(Note: Normal sequential file-cache is immune to this issue because its full file size is allocated upfront at insertion time).*
* **The Race:** If a sparse object is concurrently evicted or erased via `Erase(key)` after its in-memory size changes but *before* `UpdateSize` finishes, `Erase` subtracts the new size instead of the size known to the cache.
* **The Impact:** This causes `currentSize` underflows (wrapping around unsigned `uint64`), leading to invariant check panics or aggressive, endless cache eviction. Additionally, if the same key is rapidly re-inserted, stale deltas from the old object can corrupt the new entry's accounting.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Analyzed TOCTOU race condition and verified sparse-file vs normal file-cache accounting differences.
2. Unit tests - Executed `go test -v ./internal/cache/lru/...` on `TestMapCache_UpdateSize_TOCTOU_Underflow` with `maxSize=2000` which successfully reproduced and demonstrated the underflow (`CurrentSize 18446744073709551586 over maxSize 2000`).
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A