### PR TITLE
fix(bucket type optimization): Add support for multiple bucket types in bucket type flag optimization

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -28,7 +28,7 @@ import (
 var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.congestion-threshold": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"zonal",
 				"pirlo",
 			},
@@ -38,7 +38,7 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "file-system.enable-kernel-reader": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"zonal",
 				"pirlo",
 			},
@@ -59,13 +59,13 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "write.finalize-file-for-rapid": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"zonal",
 			},
 			Value: bool(false),
 		},
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"pirlo",
 			},
 			Value: bool(true),
@@ -102,7 +102,7 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "file-system.max-background": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"zonal",
 				"pirlo",
 			},
@@ -112,7 +112,7 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "file-system.max-read-ahead-kb": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: shared.BucketTypeList{
+			BucketTypes: shared.BucketTypeList{
 				"zonal",
 				"pirlo",
 			},

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -28,23 +28,21 @@ import (
 var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.congestion-threshold": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: "zonal",
-			Value:      int64(DefaultCongestionThreshold()),
-		},
-		{
-			BucketType: "pirlo",
-			Value:      int64(DefaultCongestionThreshold()),
+			BucketType: shared.BucketTypeList{
+				"zonal",
+				"pirlo",
+			},
+			Value: int64(DefaultCongestionThreshold()),
 		},
 	},
 }, "file-system.enable-kernel-reader": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: "zonal",
-			Value:      bool(true),
-		},
-		{
-			BucketType: "pirlo",
-			Value:      bool(true),
+			BucketType: shared.BucketTypeList{
+				"zonal",
+				"pirlo",
+			},
+			Value: bool(true),
 		},
 	},
 }, "file-cache.cache-file-for-range-read": {
@@ -61,12 +59,16 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "write.finalize-file-for-rapid": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: "zonal",
-			Value:      bool(false),
+			BucketType: shared.BucketTypeList{
+				"zonal",
+			},
+			Value: bool(false),
 		},
 		{
-			BucketType: "pirlo",
-			Value:      bool(true),
+			BucketType: shared.BucketTypeList{
+				"pirlo",
+			},
+			Value: bool(true),
 		},
 	},
 }, "implicit-dirs": {
@@ -100,23 +102,21 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 }, "file-system.max-background": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: "zonal",
-			Value:      int64(DefaultMaxBackground()),
-		},
-		{
-			BucketType: "pirlo",
-			Value:      int64(DefaultMaxBackground()),
+			BucketType: shared.BucketTypeList{
+				"zonal",
+				"pirlo",
+			},
+			Value: int64(DefaultMaxBackground()),
 		},
 	},
 }, "file-system.max-read-ahead-kb": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{
-			BucketType: "zonal",
-			Value:      int64(16384),
-		},
-		{
-			BucketType: "pirlo",
-			Value:      int64(16384),
+			BucketType: shared.BucketTypeList{
+				"zonal",
+				"pirlo",
+			},
+			Value: int64(16384),
 		},
 	},
 }, "metadata-cache.negative-ttl-secs": {

--- a/cfg/optimize.go
+++ b/cfg/optimize.go
@@ -163,11 +163,13 @@ func getOptimizedValue(
 	// 3. If no profile is set, and no machine-type optimization applies, then check for bucket-type optimization.
 	if input != nil && input.BucketType.IsValid() {
 		for _, bto := range rules.BucketTypeOptimization {
-			if BucketType(bto.BucketType) == input.BucketType {
-				return OptimizationResult{
-					FinalValue:         bto.Value,
-					OptimizationReason: fmt.Sprintf("bucket-type %q", input.BucketType),
-					Optimized:          true,
+			for _, bt := range bto.BucketType {
+				if BucketType(bt) == input.BucketType {
+					return OptimizationResult{
+						FinalValue:         bto.Value,
+						OptimizationReason: fmt.Sprintf("bucket-type %q", input.BucketType),
+						Optimized:          true,
+					}
 				}
 			}
 		}

--- a/cfg/optimize.go
+++ b/cfg/optimize.go
@@ -163,7 +163,7 @@ func getOptimizedValue(
 	// 3. If no profile is set, and no machine-type optimization applies, then check for bucket-type optimization.
 	if input != nil && input.BucketType.IsValid() {
 		for _, bto := range rules.BucketTypeOptimization {
-			for _, bt := range bto.BucketType {
+			for _, bt := range bto.BucketTypes {
 				if BucketType(bt) == input.BucketType {
 					return OptimizationResult{
 						FinalValue:         bto.Value,

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -377,9 +377,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: "zonal"
-          value: "DefaultCongestionThreshold()"
-        - bucket-type: "pirlo"
+        - bucket-type: ["zonal", "pirlo"]
           value: "DefaultCongestionThreshold()"
 
   - config-path: "file-system.dir-mode"
@@ -403,9 +401,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: "zonal"
-          value: true
-        - bucket-type: "pirlo"
+        - bucket-type: ["zonal", "pirlo"]
           value: true
 
   - config-path: "file-system.experimental-enable-dentry-cache"
@@ -523,9 +519,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: "zonal"
-          value: "DefaultMaxBackground()"
-        - bucket-type: "pirlo"
+        - bucket-type: ["zonal", "pirlo"]
           value: "DefaultMaxBackground()"
 
   - config-path: "file-system.max-read-ahead-kb"
@@ -539,9 +533,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: "zonal"
-          value: 16384 # 16 MiB
-        - bucket-type: "pirlo"
+        - bucket-type: ["zonal", "pirlo"]
           value: 16384 # 16 MiB
 
   - config-path: "file-system.rename-dir-limit"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -377,7 +377,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: ["zonal", "pirlo"]
+        - bucket-type: "zonal, pirlo"
           value: "DefaultCongestionThreshold()"
 
   - config-path: "file-system.dir-mode"
@@ -401,7 +401,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: ["zonal", "pirlo"]
+        - bucket-type: "zonal, pirlo"
           value: true
 
   - config-path: "file-system.experimental-enable-dentry-cache"
@@ -519,7 +519,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: ["zonal", "pirlo"]
+        - bucket-type: "zonal, pirlo"
           value: "DefaultMaxBackground()"
 
   - config-path: "file-system.max-read-ahead-kb"
@@ -533,7 +533,7 @@ params:
     hide-flag: true
     optimizations:
       bucket-type-optimization:
-        - bucket-type: ["zonal", "pirlo"]
+        - bucket-type: "zonal, pirlo"
           value: 16384 # 16 MiB
 
   - config-path: "file-system.rename-dir-limit"

--- a/cfg/shared/types.go
+++ b/cfg/shared/types.go
@@ -27,13 +27,14 @@ type BucketTypeList []string
 
 func (b *BucketTypeList) UnmarshalYAML(value *yaml.Node) error {
 	var rawStrings []string
-	if value.Kind == yaml.ScalarNode {
+	switch value.Kind {
+	case yaml.ScalarNode:
 		rawStrings = []string{value.Value}
-	} else if value.Kind == yaml.SequenceNode {
+	case yaml.SequenceNode:
 		if err := value.Decode(&rawStrings); err != nil {
 			return err
 		}
-	} else {
+	default:
 		return fmt.Errorf("bucket-type must be a string or list of strings, got %v", value.Kind)
 	}
 

--- a/cfg/shared/types.go
+++ b/cfg/shared/types.go
@@ -16,28 +16,38 @@ package shared
 
 import (
 	"fmt"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// BucketTypeList represents a list of bucket types, supporting both scalar string (e.g. "zonal")
-// and YAML sequence (e.g. ["zonal", "pirlo"]) in params.yaml.
+// BucketTypeList represents a list of bucket types, supporting scalar strings (e.g. "zonal" or "zonal, pirlo")
+// and YAML sequences (e.g. ["zonal", "pirlo"]) in params.yaml.
 type BucketTypeList []string
 
 func (b *BucketTypeList) UnmarshalYAML(value *yaml.Node) error {
+	var rawStrings []string
 	if value.Kind == yaml.ScalarNode {
-		*b = []string{value.Value}
-		return nil
-	}
-	if value.Kind == yaml.SequenceNode {
-		var slice []string
-		if err := value.Decode(&slice); err != nil {
+		rawStrings = []string{value.Value}
+	} else if value.Kind == yaml.SequenceNode {
+		if err := value.Decode(&rawStrings); err != nil {
 			return err
 		}
-		*b = slice
-		return nil
+	} else {
+		return fmt.Errorf("bucket-type must be a string or list of strings, got %v", value.Kind)
 	}
-	return fmt.Errorf("bucket-type must be a string or list of strings, got %v", value.Kind)
+
+	var parsed []string
+	for _, raw := range rawStrings {
+		for _, part := range strings.Split(raw, ",") {
+			trimmed := strings.TrimSpace(part)
+			if trimmed != "" {
+				parsed = append(parsed, trimmed)
+			}
+		}
+	}
+	*b = parsed
+	return nil
 }
 
 // ProfileOptimization holds the rules for a single performance profile.
@@ -54,8 +64,8 @@ type MachineBasedOptimization struct {
 
 // BucketTypeOptimization defines a bucket-type-based optimization.
 type BucketTypeOptimization struct {
-	BucketType BucketTypeList `yaml:"bucket-type"`
-	Value      any            `yaml:"value"`
+	BucketTypes BucketTypeList `yaml:"bucket-type"`
+	Value       any            `yaml:"value"`
 }
 
 // OptimizationRules holds all defined optimizations for a single flag.

--- a/cfg/shared/types.go
+++ b/cfg/shared/types.go
@@ -14,6 +14,32 @@
 
 package shared
 
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// BucketTypeList represents a list of bucket types, supporting both scalar string (e.g. "zonal")
+// and YAML sequence (e.g. ["zonal", "pirlo"]) in params.yaml.
+type BucketTypeList []string
+
+func (b *BucketTypeList) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode {
+		*b = []string{value.Value}
+		return nil
+	}
+	if value.Kind == yaml.SequenceNode {
+		var slice []string
+		if err := value.Decode(&slice); err != nil {
+			return err
+		}
+		*b = slice
+		return nil
+	}
+	return fmt.Errorf("bucket-type must be a string or list of strings, got %v", value.Kind)
+}
+
 // ProfileOptimization holds the rules for a single performance profile.
 type ProfileOptimization struct {
 	Name  string `yaml:"name"`
@@ -28,8 +54,8 @@ type MachineBasedOptimization struct {
 
 // BucketTypeOptimization defines a bucket-type-based optimization.
 type BucketTypeOptimization struct {
-	BucketType string `yaml:"bucket-type"`
-	Value      any    `yaml:"value"`
+	BucketType BucketTypeList `yaml:"bucket-type"`
+	Value      any            `yaml:"value"`
 }
 
 // OptimizationRules holds all defined optimizations for a single flag.

--- a/cfg/shared/types.go
+++ b/cfg/shared/types.go
@@ -21,30 +21,19 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// BucketTypeList represents a list of bucket types, supporting scalar strings (e.g. "zonal" or "zonal, pirlo")
-// and YAML sequences (e.g. ["zonal", "pirlo"]) in params.yaml.
+// BucketTypeList represents a list of bucket types parsed from a comma-separated string (e.g. "zonal" or "zonal, pirlo") in params.yaml.
 type BucketTypeList []string
 
 func (b *BucketTypeList) UnmarshalYAML(value *yaml.Node) error {
-	var rawStrings []string
-	switch value.Kind {
-	case yaml.ScalarNode:
-		rawStrings = []string{value.Value}
-	case yaml.SequenceNode:
-		if err := value.Decode(&rawStrings); err != nil {
-			return err
-		}
-	default:
-		return fmt.Errorf("bucket-type must be a string or list of strings, got %v", value.Kind)
+	if value.Kind != yaml.ScalarNode {
+		return fmt.Errorf("bucket-type must be a string (e.g. \"zonal\" or \"zonal, pirlo\"), got %v", value.Kind)
 	}
 
 	var parsed []string
-	for _, raw := range rawStrings {
-		for _, part := range strings.Split(raw, ",") {
-			trimmed := strings.TrimSpace(part)
-			if trimmed != "" {
-				parsed = append(parsed, trimmed)
-			}
+	for _, part := range strings.Split(value.Value, ",") {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			parsed = append(parsed, trimmed)
 		}
 	}
 	*b = parsed

--- a/cfg/shared/types_test.go
+++ b/cfg/shared/types_test.go
@@ -43,16 +43,6 @@ func TestBucketTypeListUnmarshalYAML(t *testing.T) {
 			yaml:     `bucket-type: " zonal , pirlo , flat "`,
 			expected: BucketTypeList{"zonal", "pirlo", "flat"},
 		},
-		{
-			name:     "Sequence of strings",
-			yaml:     `bucket-type: ["zonal", "pirlo"]`,
-			expected: BucketTypeList{"zonal", "pirlo"},
-		},
-		{
-			name:     "Sequence with CSV string inside",
-			yaml:     `bucket-type: ["zonal, pirlo", "hierarchical"]`,
-			expected: BucketTypeList{"zonal", "pirlo", "hierarchical"},
-		},
 	}
 
 	for _, tc := range testCases {
@@ -61,6 +51,34 @@ func TestBucketTypeListUnmarshalYAML(t *testing.T) {
 			err := yaml.Unmarshal([]byte(tc.yaml), &bto)
 			require.NoError(t, err)
 			assert.Equal(t, tc.expected, bto.BucketTypes)
+		})
+	}
+}
+
+func TestBucketTypeListUnmarshalYAMLErrors(t *testing.T) {
+	testCases := []struct {
+		name                   string
+		yaml                   string
+		expectedErrorSubstring string
+	}{
+		{
+			name:                   "Sequence of strings not allowed",
+			yaml:                   `bucket-type: ["zonal", "pirlo"]`,
+			expectedErrorSubstring: "bucket-type must be a string",
+		},
+		{
+			name:                   "Mapping not allowed",
+			yaml:                   `bucket-type: { key: value }`,
+			expectedErrorSubstring: "bucket-type must be a string",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bto BucketTypeOptimization
+			err := yaml.Unmarshal([]byte(tc.yaml), &bto)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedErrorSubstring)
 		})
 	}
 }

--- a/cfg/shared/types_test.go
+++ b/cfg/shared/types_test.go
@@ -1,0 +1,66 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shared
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestBucketTypeListUnmarshalYAML(t *testing.T) {
+	testCases := []struct {
+		name     string
+		yaml     string
+		expected BucketTypeList
+	}{
+		{
+			name:     "Scalar string single",
+			yaml:     `bucket-type: "zonal"`,
+			expected: BucketTypeList{"zonal"},
+		},
+		{
+			name:     "Scalar string CSV",
+			yaml:     `bucket-type: "zonal, pirlo"`,
+			expected: BucketTypeList{"zonal", "pirlo"},
+		},
+		{
+			name:     "Scalar string CSV with spaces",
+			yaml:     `bucket-type: " zonal , pirlo , flat "`,
+			expected: BucketTypeList{"zonal", "pirlo", "flat"},
+		},
+		{
+			name:     "Sequence of strings",
+			yaml:     `bucket-type: ["zonal", "pirlo"]`,
+			expected: BucketTypeList{"zonal", "pirlo"},
+		},
+		{
+			name:     "Sequence with CSV string inside",
+			yaml:     `bucket-type: ["zonal, pirlo", "hierarchical"]`,
+			expected: BucketTypeList{"zonal", "pirlo", "hierarchical"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var bto BucketTypeOptimization
+			err := yaml.Unmarshal([]byte(tc.yaml), &bto)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, bto.BucketTypes)
+		})
+	}
+}

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -130,10 +130,10 @@ func validateParam(param Param) error {
 		validBucketTypes := []string{"zonal", "hierarchical", "flat", "pirlo"}
 		seenBucketTypes := make(map[string]bool)
 		for _, bto := range param.Optimizations.BucketTypeOptimization {
-			if len(bto.BucketType) == 0 {
+			if len(bto.BucketTypes) == 0 {
 				return fmt.Errorf("bucket-type list is empty for flag %s", param.FlagName)
 			}
-			for _, bt := range bto.BucketType {
+			for _, bt := range bto.BucketTypes {
 				if !slices.Contains(validBucketTypes, bt) {
 					return fmt.Errorf("invalid bucket-type %q for flag %s; must be one of: %v",
 						bt, param.FlagName, validBucketTypes)

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -128,10 +128,20 @@ func validateParam(param Param) error {
 	// Validate bucket-based optimizations if present.
 	if param.Optimizations != nil {
 		validBucketTypes := []string{"zonal", "hierarchical", "flat", "pirlo"}
+		seenBucketTypes := make(map[string]bool)
 		for _, bto := range param.Optimizations.BucketTypeOptimization {
-			if !slices.Contains(validBucketTypes, bto.BucketType) {
-				return fmt.Errorf("invalid bucket-type %q for flag %s; must be one of: %v",
-					bto.BucketType, param.FlagName, validBucketTypes)
+			if len(bto.BucketType) == 0 {
+				return fmt.Errorf("bucket-type list is empty for flag %s", param.FlagName)
+			}
+			for _, bt := range bto.BucketType {
+				if !slices.Contains(validBucketTypes, bt) {
+					return fmt.Errorf("invalid bucket-type %q for flag %s; must be one of: %v",
+						bt, param.FlagName, validBucketTypes)
+				}
+				if seenBucketTypes[bt] {
+					return fmt.Errorf("duplicate bucket-type %q for flag %s", bt, param.FlagName)
+				}
+				seenBucketTypes[bt] = true
 			}
 		}
 	}

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -195,7 +195,7 @@ params:
     "usage": "Whether to enable kernel-based reader"
     optimizations:
       bucket-type-optimization:
-        - bucket-type: ["zonal", "flat", "pirlo"]
+        - bucket-type: "zonal, flat, pirlo"
           value: true
         - bucket-type: "hierarchical"
           value: false
@@ -208,7 +208,7 @@ params:
       bucket-type-optimization:
         - bucket-type: "zonal"
           value: 1024
-        - bucket-type: ["hierarchical", "flat", "pirlo"]
+        - bucket-type: "hierarchical, flat, pirlo"
           value: 2048
       machine-based-optimization:
         - group: high-performance
@@ -401,8 +401,7 @@ params:
     usage: "Test flag for bucket type validation"
     optimizations:
       bucket-type-optimization:
-        - bucket-type:
-            - "invalid-bucket-type"
+        - bucket-type: "invalid-bucket-type"
           value: true
 `,
 			expectedErrorSubstring: "invalid bucket-type",
@@ -418,9 +417,7 @@ params:
     usage: "Test flag for duplicate bucket type validation"
     optimizations:
       bucket-type-optimization:
-        - bucket-type:
-            - "zonal"
-            - "zonal"
+        - bucket-type: "zonal, zonal"
           value: true
 `,
 			expectedErrorSubstring: "duplicate bucket-type \"zonal\"",
@@ -436,7 +433,7 @@ params:
     usage: "Test flag for empty bucket type validation"
     optimizations:
       bucket-type-optimization:
-        - bucket-type: []
+        - bucket-type: ""
           value: true
 `,
 			expectedErrorSubstring: "bucket-type list is empty",

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -195,14 +195,10 @@ params:
     "usage": "Whether to enable kernel-based reader"
     optimizations:
       bucket-type-optimization:
-        - bucket-type: zonal
+        - bucket-type: ["zonal", "flat", "pirlo"]
           value: true
-        - bucket-type: hierarchical
+        - bucket-type: "hierarchical"
           value: false
-        - bucket-type: flat
-          value: true
-        - bucket-type: pirlo
-          value: true
   - config-path: "file-system.max-read-ahead-kb"
     flag-name: "max-read-ahead-kb"
     type: "int"
@@ -210,13 +206,9 @@ params:
     "usage": "Maximum read ahead in KB"
     optimizations:
       bucket-type-optimization:
-        - bucket-type: zonal
+        - bucket-type: "zonal"
           value: 1024
-        - bucket-type: hierarchical
-          value: 2048
-        - bucket-type: flat
-          value: 2048
-        - bucket-type: pirlo
+        - bucket-type: ["hierarchical", "flat", "pirlo"]
           value: 2048
       machine-based-optimization:
         - group: high-performance
@@ -266,10 +258,8 @@ params:
 		require.NotNil(t, param.Optimizations)
 		expected := &shared.OptimizationRules{
 			BucketTypeOptimization: []shared.BucketTypeOptimization{
-				{BucketType: "zonal", Value: true},
-				{BucketType: "hierarchical", Value: false},
-				{BucketType: "flat", Value: true},
-				{BucketType: "pirlo", Value: true},
+				{BucketType: shared.BucketTypeList{"zonal", "flat", "pirlo"}, Value: true},
+				{BucketType: shared.BucketTypeList{"hierarchical"}, Value: false},
 			},
 		}
 		assert.Equal(t, "file-system.enable-kernel-reader", param.ConfigPath)
@@ -283,10 +273,8 @@ params:
 		require.NotNil(t, param.Optimizations)
 		expected := &shared.OptimizationRules{
 			BucketTypeOptimization: []shared.BucketTypeOptimization{
-				{BucketType: "zonal", Value: 1024},
-				{BucketType: "hierarchical", Value: 2048},
-				{BucketType: "flat", Value: 2048},
-				{BucketType: "pirlo", Value: 2048},
+				{BucketType: shared.BucketTypeList{"zonal"}, Value: 1024},
+				{BucketType: shared.BucketTypeList{"hierarchical", "flat", "pirlo"}, Value: 2048},
 			},
 			MachineBasedOptimization: []shared.MachineBasedOptimization{
 				{Group: "high-performance", Value: 2048},
@@ -413,10 +401,45 @@ params:
     usage: "Test flag for bucket type validation"
     optimizations:
       bucket-type-optimization:
-        - bucket-type: "invalid-bucket-type"
+        - bucket-type:
+            - "invalid-bucket-type"
           value: true
 `,
 			expectedErrorSubstring: "invalid bucket-type",
+		},
+		{
+			name: "DuplicateBucketType",
+			yamlContent: `
+params:
+  - config-path: "test-param"
+    flag-name: "test-flag"
+    type: "bool"
+    default: false
+    usage: "Test flag for duplicate bucket type validation"
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type:
+            - "zonal"
+            - "zonal"
+          value: true
+`,
+			expectedErrorSubstring: "duplicate bucket-type \"zonal\"",
+		},
+		{
+			name: "EmptyBucketTypeList",
+			yamlContent: `
+params:
+  - config-path: "test-param"
+    flag-name: "test-flag"
+    type: "bool"
+    default: false
+    usage: "Test flag for empty bucket type validation"
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: []
+          value: true
+`,
+			expectedErrorSubstring: "bucket-type list is empty",
 		},
 	}
 

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -258,8 +258,8 @@ params:
 		require.NotNil(t, param.Optimizations)
 		expected := &shared.OptimizationRules{
 			BucketTypeOptimization: []shared.BucketTypeOptimization{
-				{BucketType: shared.BucketTypeList{"zonal", "flat", "pirlo"}, Value: true},
-				{BucketType: shared.BucketTypeList{"hierarchical"}, Value: false},
+				{BucketTypes: shared.BucketTypeList{"zonal", "flat", "pirlo"}, Value: true},
+				{BucketTypes: shared.BucketTypeList{"hierarchical"}, Value: false},
 			},
 		}
 		assert.Equal(t, "file-system.enable-kernel-reader", param.ConfigPath)
@@ -273,8 +273,8 @@ params:
 		require.NotNil(t, param.Optimizations)
 		expected := &shared.OptimizationRules{
 			BucketTypeOptimization: []shared.BucketTypeOptimization{
-				{BucketType: shared.BucketTypeList{"zonal"}, Value: 1024},
-				{BucketType: shared.BucketTypeList{"hierarchical", "flat", "pirlo"}, Value: 2048},
+				{BucketTypes: shared.BucketTypeList{"zonal"}, Value: 1024},
+				{BucketTypes: shared.BucketTypeList{"hierarchical", "flat", "pirlo"}, Value: 2048},
 			},
 			MachineBasedOptimization: []shared.MachineBasedOptimization{
 				{Group: "high-performance", Value: 2048},

--- a/tools/config-gen/templates/config.tpl
+++ b/tools/config-gen/templates/config.tpl
@@ -44,7 +44,11 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{
 		BucketTypeOptimization: []shared.BucketTypeOptimization{
 			{{- range .Optimizations.BucketTypeOptimization }}
 			{
-				BucketType: "{{ .BucketType }}",
+				BucketType: shared.BucketTypeList{
+					{{- range .BucketType }}
+					"{{ . }}",
+					{{- end }}
+				},
 				Value:      {{$goType}}({{ formatValue .Value }}),
 			},
 			{{- end }}

--- a/tools/config-gen/templates/config.tpl
+++ b/tools/config-gen/templates/config.tpl
@@ -44,8 +44,8 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{
 		BucketTypeOptimization: []shared.BucketTypeOptimization{
 			{{- range .Optimizations.BucketTypeOptimization }}
 			{
-				BucketType: shared.BucketTypeList{
-					{{- range .BucketType }}
+				BucketTypes: shared.BucketTypeList{
+					{{- range .BucketTypes }}
 					"{{ . }}",
 					{{- end }}
 				},

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -62,7 +62,8 @@ func TestApplyOptimizations(t *testing.T) {
 				},
 				{{- if .Optimizations.BucketTypeOptimization }}
 				{{- $bto := index .Optimizations.BucketTypeOptimization 0 }}
-				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
+				{{- $bt := index $bto.BucketType 0 }}
+				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				{{- else }}
 				input:           nil,
 				{{- end }}
@@ -111,14 +112,17 @@ func TestApplyOptimizations(t *testing.T) {
 		{{- end }}
 		{{- range .Optimizations.BucketTypeOptimization }}
 			{{- $bto := . }}
+			{{- range $bto.BucketType }}
+			{{- $bt := . }}
 			{
-				name:   "bucket_type_{{$bto.BucketType}}",
+				name:   "bucket_type_{{$bt}}",
 				config: Config{Profile: ""},
 				userSetFlags: map[string]any{},
-				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
+				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				expectOptimized: {{if ne (printf "%v" $bto.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$bto.Value}},
 			},
+			{{- end }}
 		{{- end }}
 		{{- if and .Optimizations.Profiles .Optimizations.MachineBasedOptimization }}
 			{{- $profile := index .Optimizations.Profiles 0 -}}
@@ -138,11 +142,12 @@ func TestApplyOptimizations(t *testing.T) {
 		{{- if and .Optimizations.Profiles .Optimizations.BucketTypeOptimization }}
 			{{- $profile := index .Optimizations.Profiles 0 -}}
 			{{- $bto := index .Optimizations.BucketTypeOptimization 0 -}}
+			{{- $bt := index $bto.BucketType 0 }}
 			{
 				name:   "profile_overrides_bucket_type",
 				config: Config{Profile: "{{$profile.Name}}"},
 				userSetFlags: map[string]any{},
-				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
+				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				expectOptimized: {{if ne (printf "%v" $profile.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$profile.Value}},
 			},
@@ -151,13 +156,14 @@ func TestApplyOptimizations(t *testing.T) {
 			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
 			{{- $bto := index .Optimizations.BucketTypeOptimization 0 -}}
 			{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 }}
+			{{- $bt := index $bto.BucketType 0 }}
 			{
 				name:   "machine_type_overrides_bucket_type",
 				config: Config{Profile: ""},
 				userSetFlags: map[string]any{
 					"machine-type": "{{$machineType}}",
 				},
-				input:           &OptimizationInput{BucketType: BucketType{{ $bto.BucketType | title }}},
+				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				expectOptimized: {{if ne (printf "%v" $mbo.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
 				expectedValue:   {{$mbo.Value}},
 			},

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -62,7 +62,7 @@ func TestApplyOptimizations(t *testing.T) {
 				},
 				{{- if .Optimizations.BucketTypeOptimization }}
 				{{- $bto := index .Optimizations.BucketTypeOptimization 0 }}
-				{{- $bt := index $bto.BucketType 0 }}
+				{{- $bt := index $bto.BucketTypes 0 }}
 				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				{{- else }}
 				input:           nil,
@@ -112,7 +112,7 @@ func TestApplyOptimizations(t *testing.T) {
 		{{- end }}
 		{{- range .Optimizations.BucketTypeOptimization }}
 			{{- $bto := . }}
-			{{- range $bto.BucketType }}
+			{{- range $bto.BucketTypes }}
 			{{- $bt := . }}
 			{
 				name:   "bucket_type_{{$bt}}",
@@ -142,7 +142,7 @@ func TestApplyOptimizations(t *testing.T) {
 		{{- if and .Optimizations.Profiles .Optimizations.BucketTypeOptimization }}
 			{{- $profile := index .Optimizations.Profiles 0 -}}
 			{{- $bto := index .Optimizations.BucketTypeOptimization 0 -}}
-			{{- $bt := index $bto.BucketType 0 }}
+			{{- $bt := index $bto.BucketTypes 0 }}
 			{
 				name:   "profile_overrides_bucket_type",
 				config: Config{Profile: "{{$profile.Name}}"},
@@ -156,7 +156,7 @@ func TestApplyOptimizations(t *testing.T) {
 			{{- $mbo := index .Optimizations.MachineBasedOptimization 0 -}}
 			{{- $bto := index .Optimizations.BucketTypeOptimization 0 -}}
 			{{- $machineType := index $.MachineTypeGroups $mbo.Group 0 }}
-			{{- $bt := index $bto.BucketType 0 }}
+			{{- $bt := index $bto.BucketTypes 0 }}
 			{
 				name:   "machine_type_overrides_bucket_type",
 				config: Config{Profile: ""},


### PR DESCRIPTION
### Description
### Summary
Enables specifying multiple bucket types using a comma-separated string (e.g. `bucket-type: "zonal, pirlo"`) in `params.yaml` for flag optimization rules, eliminating duplicate entries for identical configurations across bucket types.

### Key Changes
- **Configuration Types (`cfg/shared/types.go`)**:
  - Added `BucketTypeList` type with custom `UnmarshalYAML` support to parse CSV-style strings (`"zonal, pirlo"` or `"zonal"`).
  - Updated `BucketTypeOptimization` struct to use `BucketTypes BucketTypeList` (formerly single string `BucketType`).
- **Optimization Evaluation (`cfg/optimize.go`)**:
  - Updated `getOptimizedValue` to iterate over all bucket types listed in `BucketTypes` when matching against the active mount's bucket type.
- **Config Generator & Validation (`tools/config-gen/`)**:
  - Updated parser to validate `BucketTypeList` rules, ensuring no duplicate bucket types or empty lists are specified per flag.
  - Updated `config.tpl` and `config_test.tpl` templates to generate and test multi-bucket-type optimization rules.
- **Parameter Simplification (`cfg/params.yaml` & `cfg/config.go`)**:
  - Consolidated duplicate `zonal` and `pirlo` optimization entries in `params.yaml` into single `- bucket-type: "zonal, pirlo"` rules and regenerated `cfg/config.go`.

### Testing
- Added unit tests in `cfg/shared/types_test.go` and `tools/config-gen/parser_test.go` verifying valid CSV parsing and error handling for invalid/duplicate entries.
- Verified all generated code (`go generate`) and passed all existing/new unit tests (`go test ./cfg/... ./tools/config-gen/...`).

### Link to the issue in case of a bug fix.
b/533339400

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
