### PR TITLE
perf(inode): optimized lookupCount struct to remove unnecessary fields

### DIFF
--- a/internal/fs/inode/base_dir.go
+++ b/internal/fs/inode/base_dir.go
@@ -85,7 +85,6 @@ func NewBaseDirInode(
 		metricHandle:                 metricHandle,
 		isEnableTypeCacheDeprecation: isEnableTypeCacheDeprecation,
 	}
-	typed.lc.Init(id)
 	typed.mu = locker.NewRW("BaseDirInode"+name.GcsObjectName(), func() {})
 
 	d = typed
@@ -134,18 +133,18 @@ func (d *baseDirInode) Name() Name {
 
 // LOCKS_REQUIRED(d)
 func (d *baseDirInode) IncrementLookupCount() {
-	d.lc.Inc()
+	d.lc.Inc(d.id)
 }
 
 // LOCKS_REQUIRED(d)
 func (d *baseDirInode) DecrementLookupCount(n uint64) (destroy bool) {
-	destroy = d.lc.Dec(n)
+	destroy = d.lc.Dec(d.id, n)
 	return
 }
 
 // LOCKS_REQUIRED(d)
 func (d *baseDirInode) Destroy() (err error) {
-	// Nothing interesting to do.
+	d.lc.Destroy()
 	return
 }
 

--- a/internal/fs/inode/dir.go
+++ b/internal/fs/inode/dir.go
@@ -371,8 +371,6 @@ func NewDirInode(
 		typed.cache = cache
 	}
 
-	typed.lc.Init(id)
-
 	// Set up invariant checking.
 	typed.mu = locker.NewRW(name.GcsObjectName(), typed.checkInvariants)
 
@@ -595,12 +593,12 @@ func (d *dirInode) Name() Name {
 
 // LOCKS_REQUIRED(d)
 func (d *dirInode) IncrementLookupCount() {
-	d.lc.Inc()
+	d.lc.Inc(d.id)
 }
 
 // LOCKS_REQUIRED(d)
 func (d *dirInode) DecrementLookupCount(n uint64) (destroy bool) {
-	destroy = d.lc.Dec(n)
+	destroy = d.lc.Dec(d.id, n)
 	return
 }
 
@@ -609,6 +607,7 @@ func (d *dirInode) Destroy() (err error) {
 	// When destroying the inode, we cancel its subdirectory prefetches.
 	// This cleans up any curr dir + child dir prefetchers.
 	d.CancelSubdirectoryPrefetches()
+	d.lc.Destroy()
 	return
 }
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -195,8 +195,6 @@ func NewFileInode(
 		f.kernelRangeReaderInstance = kernel_readers.NewKernelRangeReaderInstance(&minObj)
 	}
 
-	f.lc.Init(id)
-
 	// Set up invariant checking.
 	f.mu = syncutil.NewInvariantMutex(f.checkInvariants)
 
@@ -481,12 +479,12 @@ func (f *FileInode) SourceGeneration() (g Generation) {
 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) IncrementLookupCount() {
-	f.lc.Inc()
+	f.lc.Inc(f.id)
 }
 
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) DecrementLookupCount(n uint64) (destroy bool) {
-	destroy = f.lc.Dec(n)
+	destroy = f.lc.Dec(f.id, n)
 	return
 }
 
@@ -533,6 +531,7 @@ func (f *FileInode) UpdateSize(size uint64) {
 // LOCKS_REQUIRED(f.mu)
 func (f *FileInode) Destroy() (err error) {
 	f.destroyed = true
+	f.lc.Destroy()
 	if f.localFileCache {
 		cacheObjectKey := &contentcache.CacheObjectKey{BucketName: f.bucket.Name(), ObjectName: f.name.objectName}
 		f.contentCache.Remove(cacheObjectKey)

--- a/internal/fs/inode/lookup_count.go
+++ b/internal/fs/inode/lookup_count.go
@@ -24,40 +24,36 @@ import (
 // paranoid panics. External synchronization is required.
 //
 // May be embedded within a larger struct. Use Init to initialize.
-type lookupCount struct {
-	id        fuseops.InodeID
-	count     uint64
-	destroyed bool
-}
+type lookupCount int64
 
-func (lc *lookupCount) Init(id fuseops.InodeID) {
-	lc.id = id
-}
-
-func (lc *lookupCount) Inc() {
-	if lc.destroyed {
-		panic(fmt.Sprintf("Inode %v has already been destroyed", lc.id))
+func (lc *lookupCount) Inc(id fuseops.InodeID) {
+	if *lc == -1 {
+		panic(fmt.Sprintf("Inode %v has already been destroyed", id))
 	}
 
-	lc.count++
+	(*lc)++
 }
 
-func (lc *lookupCount) Dec(n uint64) (destroy bool) {
-	if lc.destroyed {
-		panic(fmt.Sprintf("Inode %v has already been destroyed", lc.id))
+func (lc *lookupCount) Dec(id fuseops.InodeID, n uint64) (destroy bool) {
+	if *lc == -1 {
+		panic(fmt.Sprintf("Inode %v has already been destroyed", id))
 	}
 
 	// Make sure n is in range.
-	if n > lc.count {
+	if n > uint64(*lc) {
 		panic(fmt.Sprintf(
 			"n is greater than lookup count: %v vs. %v",
 			n,
-			lc.count))
+			*lc))
 	}
 
 	// Decrement.
-	lc.count -= n
+	*lc -= lookupCount(n)
 
-	destroy = lc.count == 0
+	destroy = *lc == 0
 	return
+}
+
+func (lc *lookupCount) Destroy() {
+	*lc = -1
 }

--- a/internal/fs/inode/lookup_count_test.go
+++ b/internal/fs/inode/lookup_count_test.go
@@ -1,0 +1,99 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inode
+
+import (
+	"math"
+	"testing"
+
+	"github.com/jacobsa/fuse/fuseops"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLookupCount_Inc_Normal(t *testing.T) {
+	var lc lookupCount
+	id := fuseops.InodeID(1)
+
+	lc.Inc(id)
+
+	assert.Equal(t, lookupCount(1), lc)
+}
+
+func TestLookupCount_Inc_PanicsWhenDestroyed(t *testing.T) {
+	var lc lookupCount = -1
+	id := fuseops.InodeID(1)
+
+	assert.Panics(t, func() {
+		lc.Inc(id)
+	})
+}
+
+func TestLookupCount_Dec_Normal(t *testing.T) {
+	var lc lookupCount = 2
+	id := fuseops.InodeID(1)
+
+	destroy := lc.Dec(id, 1)
+
+	assert.False(t, destroy)
+	assert.Equal(t, lookupCount(1), lc)
+}
+
+func TestLookupCount_Dec_ReachesZero(t *testing.T) {
+	var lc lookupCount = 1
+	id := fuseops.InodeID(1)
+
+	destroy := lc.Dec(id, 1)
+
+	assert.True(t, destroy)
+	assert.Equal(t, lookupCount(0), lc)
+}
+
+func TestLookupCount_Dec_PanicsWhenDestroyed(t *testing.T) {
+	var lc lookupCount = -1
+	id := fuseops.InodeID(1)
+
+	assert.Panics(t, func() {
+		lc.Dec(id, 1)
+	})
+}
+
+func TestLookupCount_Dec_PanicsOnUnderflow(t *testing.T) {
+	var lc lookupCount = 1
+	id := fuseops.InodeID(1)
+
+	assert.Panics(t, func() {
+		lc.Dec(id, 2)
+	})
+}
+
+func TestLookupCount_Dec_ProtectsAgainstOverflowWrap(t *testing.T) {
+	var lc lookupCount = 1
+	id := fuseops.InodeID(1)
+
+	// Providing math.MaxUint64 would wrap to -1 if we casted it directly to int64.
+	// This ensures our uint64 comparison works safely.
+	assert.Panics(t, func() {
+		lc.Dec(id, math.MaxUint64)
+	})
+}
+
+func TestLookupCount_Destroy_IsIdempotent(t *testing.T) {
+	var lc lookupCount = 5
+
+	lc.Destroy()
+	lc.Destroy() // Second call should not panic
+
+	assert.Equal(t, lookupCount(-1), lc)
+}

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -109,9 +109,6 @@ func NewSymlinkInode(
 		metadata: m.Metadata,
 	}
 
-	// Set up lookup counting.
-	s.lc.Init(id)
-
 	s.target, err = s.resolveSymlinkTarget(ctx)
 	if err != nil {
 		return nil, err
@@ -222,18 +219,18 @@ func (s *SymlinkInode) UpdateSize(size uint64) {
 
 // LOCKS_REQUIRED(s.mu)
 func (s *SymlinkInode) IncrementLookupCount() {
-	s.lc.Inc()
+	s.lc.Inc(s.id)
 }
 
 // LOCKS_REQUIRED(s.mu)
 func (s *SymlinkInode) DecrementLookupCount(n uint64) (destroy bool) {
-	destroy = s.lc.Dec(n)
+	destroy = s.lc.Dec(s.id, n)
 	return
 }
 
 // LOCKS_REQUIRED(s.mu)
 func (s *SymlinkInode) Destroy() (err error) {
-	// Nothing to do.
+	s.lc.Destroy()
 	return
 }
 


### PR DESCRIPTION
### Description
Every inode (`FileInode`, `dirInode`, `SymlinkInode`, etc.) embeds a `lookupCount` struct to track active FUSE kernel lookups. Previously, this struct was defined as:

```go
type lookupCount struct {
    id        fuseops.InodeID // 8 bytes
    count     uint64          // 8 bytes
    destroyed bool            // 1 byte
}
```
Due to 64-bit compiler alignment padding, the 1-byte boolean padded the struct out to 24 bytes. Furthermore, the `destroyed` boolean was dead code (it was checked, but never set), and the `id` field was redundant because the parent inodes already store their own ID.

#### Changes Made
- **Type Aliasing**: Converted the struct into a pure type alias (`type lookupCount int64`), dropping the footprint to exactly 8 bytes.
- **State Merging**: The active count and "destroyed" state are now merged into a single `int64`. A value `>= 0` represents the active count, and `-1` represents the destroyed state.
- **Redundancy Removal**: Removed the redundant `.Init(id)` calls. The `.Inc(id)` and `.Dec(id)` methods now accept the `fuseops.InodeID` dynamically from the parent inode to preserve existing safety panic messages.
- **Overflow Protection**: Casted the internal count check to `uint64` in `.Dec()` to prevent negative wrap-around overflow bypasses in the event of an abnormally large decrement request.
 
Existing test passes seamlessly.
### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Added `internal/fs/inode/lookup_count_test.go` . Validated exact bounds checking, underflow panics, wrap-around protection (`math.MaxUint64`), and idempotent destruction.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
