### PR TITLE
feat(auth): add --experimental-auth-token-file for short-lived OAuth2 access tokens

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -594,6 +594,8 @@ type FileSystemConfig struct {
 type GcsAuthConfig struct {
 	AnonymousAccess bool `yaml:"anonymous-access"`
 
+	ExperimentalAuthTokenFile ResolvedPath `yaml:"experimental-auth-token-file"`
+
 	KeyFile ResolvedPath `yaml:"key-file"`
 
 	ReuseTokenFromUrl bool `yaml:"reuse-token-from-url"`
@@ -1026,6 +1028,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("enable-unsupported-path-support"); err != nil {
 		return err
 	}
+
+	flagSet.StringP("experimental-auth-token-file", "", "", "Experimental: Absolute path to a file containing an OAuth2 token response in JSON format ({\"access_token\": \"...\", \"expires_in\": 3600, \"token_type\": \"Bearer\"}), to be used directly as the GCS credential. Mounting fails if the token is expired. The file is re-read when the token expires, so an external process may refresh the credential by rewriting the file.")
 
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")
 
@@ -1637,6 +1641,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-unsupported-path-support", flagSet.Lookup("enable-unsupported-path-support")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-auth.experimental-auth-token-file", flagSet.Lookup("experimental-auth-token-file")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -644,6 +644,8 @@ type FileSystemConfig struct {
 type GcsAuthConfig struct {
 	AnonymousAccess bool `yaml:"anonymous-access"`
 
+	ExperimentalAuthTokenFile ResolvedPath `yaml:"experimental-auth-token-file"`
+
 	KeyFile ResolvedPath `yaml:"key-file"`
 
 	ReuseTokenFromUrl bool `yaml:"reuse-token-from-url"`
@@ -1090,6 +1092,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	if err := flagSet.MarkHidden("enable-unsupported-path-support"); err != nil {
 		return err
 	}
+
+	flagSet.StringP("experimental-auth-token-file", "", "", "Experimental: Absolute path to a file containing an OAuth2 token response in JSON format ({\"access_token\": \"...\", \"expires_in\": 3600, \"token_type\": \"Bearer\"}), to be used directly as the GCS credential. Mounting fails if the token is expired. The file is re-read when the token expires, so an external process may refresh the credential by rewriting the file.")
 
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")
 
@@ -1749,6 +1753,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-unsupported-path-support", flagSet.Lookup("enable-unsupported-path-support")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-auth.experimental-auth-token-file", flagSet.Lookup("experimental-auth-token-file")); err != nil {
 		return err
 	}
 

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1093,7 +1093,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.StringP("experimental-auth-token-file", "", "", "Experimental: Absolute path to a file containing an OAuth2 token response in JSON format ({\"access_token\": \"...\", \"expires_in\": 3600, \"token_type\": \"Bearer\"}), to be used directly as the GCS credential. Mounting fails if the token is expired. The file is re-read when the token expires, so an external process may refresh the credential by rewriting the file.")
+	flagSet.StringP("experimental-auth-token-file", "", "", "Experimental: Absolute path to a file containing an OAuth2 token response in JSON format ({\"access_token\": \"...\", \"expires_in\": 3600, \"token_type\": \"Bearer\"}), to be used directly as the GCS credential. A relative \"expires_in\" is measured from the file's modification time; an absolute RFC 3339 \"expiry\" field takes precedence if present. Mounting fails if the token is expired. The file is re-read when the token expires, so an external process may refresh the credential by replacing the file; do so atomically (write a temporary file, then rename it over the token file). The file is a credential: restrict its permissions to the owner, as with key-file.")
 
 	flagSet.BoolP("experimental-enable-dentry-cache", "", false, "When enabled, it sets the Dentry cache entry timeout same as metadata-cache-ttl. This enables kernel to use cached entry to map the file paths to inodes, instead of making LookUpInode calls to GCSFuse.")
 

--- a/cfg/config.proto
+++ b/cfg/config.proto
@@ -180,4 +180,5 @@ message Config {
   bool write_finalize_file_for_rapid = 156;
   sint64 write_global_max_blocks = 157;
   sint64 write_max_blocks_per_file = 158;
+  bool is_gcs_auth_experimental_auth_token_file_set = 159;
 }

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -583,6 +583,16 @@ params:
     usage: "This flag disables authentication."
     default: false
 
+  - config-path: "gcs-auth.experimental-auth-token-file"
+    flag-name: "experimental-auth-token-file"
+    type: "resolvedPath"
+    usage: >-
+      Experimental: Absolute path to a file containing an OAuth2 token response
+      in JSON format ({"access_token": "...", "expires_in": 3600, "token_type":
+      "Bearer"}), to be used directly as the GCS credential. Mounting fails if
+      the token is expired. The file is re-read when the token expires, so an
+      external process may refresh the credential by rewriting the file.
+
   - config-path: "gcs-auth.key-file"
     flag-name: "key-file"
     type: "resolvedPath"

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -694,9 +694,14 @@ params:
     usage: >-
       Experimental: Absolute path to a file containing an OAuth2 token response
       in JSON format ({"access_token": "...", "expires_in": 3600, "token_type":
-      "Bearer"}), to be used directly as the GCS credential. Mounting fails if
-      the token is expired. The file is re-read when the token expires, so an
-      external process may refresh the credential by rewriting the file.
+      "Bearer"}), to be used directly as the GCS credential. A relative
+      "expires_in" is measured from the file's modification time; an absolute
+      RFC 3339 "expiry" field takes precedence if present. Mounting fails if the
+      token is expired. The file is re-read when the token expires, so an
+      external process may refresh the credential by replacing the file; do so
+      atomically (write a temporary file, then rename it over the token file).
+      The file is a credential: restrict its permissions to the owner, as with
+      key-file.
 
   - config-path: "gcs-auth.key-file"
     proto-tag: 67

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -687,6 +687,17 @@ params:
     usage: "This flag disables authentication."
     default: false
 
+  - config-path: "gcs-auth.experimental-auth-token-file"
+    proto-tag: 159
+    flag-name: "experimental-auth-token-file"
+    type: "resolvedPath"
+    usage: >-
+      Experimental: Absolute path to a file containing an OAuth2 token response
+      in JSON format ({"access_token": "...", "expires_in": 3600, "token_type":
+      "Bearer"}), to be used directly as the GCS credential. Mounting fails if
+      the token is expired. The file is re-read when the token expires, so an
+      external process may refresh the credential by rewriting the file.
+
   - config-path: "gcs-auth.key-file"
     proto-tag: 67
     flag-name: "key-file"

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -318,6 +318,18 @@ func isValidOptimizationProfile(config *Config) error {
 	return nil
 }
 
+func isValidGcsAuthConfig(config *GcsAuthConfig) error {
+	if config.ExperimentalAuthTokenFile != "" {
+		if config.KeyFile != "" {
+			return fmt.Errorf("experimental-auth-token-file cannot be used together with key-file")
+		}
+		if config.TokenUrl != "" {
+			return fmt.Errorf("experimental-auth-token-file cannot be used together with token-url")
+		}
+	}
+	return nil
+}
+
 // ValidateConfig returns a non-nil error if the config is invalid.
 func ValidateConfig(v *viper.Viper, config *Config) error {
 	var err error
@@ -340,6 +352,10 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 
 	if err = isValidURL(config.GcsAuth.TokenUrl); err != nil {
 		return fmt.Errorf("error parsing token-url config: %w", err)
+	}
+
+	if err = isValidGcsAuthConfig(&config.GcsAuth); err != nil {
+		return fmt.Errorf("error parsing gcs-auth config: %w", err)
 	}
 
 	if err = isValidSequentialReadSizeMB(config.GcsConnection.SequentialReadSizeMb); err != nil {

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -355,6 +355,18 @@ func isValidOptimizationProfile(config *Config) error {
 	return nil
 }
 
+func isValidGcsAuthConfig(config *GcsAuthConfig) error {
+	if config.ExperimentalAuthTokenFile != "" {
+		if config.KeyFile != "" {
+			return fmt.Errorf("experimental-auth-token-file cannot be used together with key-file")
+		}
+		if config.TokenUrl != "" {
+			return fmt.Errorf("experimental-auth-token-file cannot be used together with token-url")
+		}
+	}
+	return nil
+}
+
 // ValidateConfig returns a non-nil error if the config is invalid.
 func ValidateConfig(v *viper.Viper, config *Config) error {
 	var err error
@@ -377,6 +389,10 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 
 	if err = isValidURL(config.GcsAuth.TokenUrl); err != nil {
 		return fmt.Errorf("error parsing token-url config: %w", err)
+	}
+
+	if err = isValidGcsAuthConfig(&config.GcsAuth); err != nil {
+		return fmt.Errorf("error parsing gcs-auth config: %w", err)
 	}
 
 	if err = isValidSequentialReadSizeMB(config.GcsConnection.SequentialReadSizeMb); err != nil {

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -89,6 +89,29 @@ func TestValidateConfigSuccessful(t *testing.T) {
 			},
 		},
 		{
+			name: "Valid Config with experimental-auth-token-file set.",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsAuth: GcsAuthConfig{
+					ExperimentalAuthTokenFile: "/token.json",
+				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "disabled",
+				},
+				Metrics: MetricsConfig{
+					Workers:    3,
+					BufferSize: 256,
+				},
+				Mrd: MrdConfig{
+					PoolSize: 4,
+				},
+			},
+		},
+		{
 			name: "Valid Config where input and expected custom endpoint differ.",
 			config: &Config{
 				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
@@ -446,6 +469,40 @@ func TestValidateConfig_ErrorScenarios(t *testing.T) {
 				FileCache: validFileCacheConfig(t),
 				GcsAuth: GcsAuthConfig{
 					TokenUrl: "a_b://abc",
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
+			},
+		},
+		{
+			name: "Invalid Config due to experimental-auth-token-file set together with key-file",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsAuth: GcsAuthConfig{
+					ExperimentalAuthTokenFile: "/token.json",
+					KeyFile:                   "/key.json",
+				},
+				MetadataCache: MetadataCacheConfig{
+					ExperimentalMetadataPrefetchOnMount: "sync",
+				},
+				GcsConnection: GcsConnectionConfig{
+					SequentialReadSizeMb: 200,
+				},
+			},
+		},
+		{
+			name: "Invalid Config due to experimental-auth-token-file set together with token-url",
+			config: &Config{
+				Logging:   LoggingConfig{LogRotate: validLogRotateConfig()},
+				FileCache: validFileCacheConfig(t),
+				GcsAuth: GcsAuthConfig{
+					ExperimentalAuthTokenFile: "/token.json",
+					TokenUrl:                  "https://www.abc.com",
 				},
 				MetadataCache: MetadataCacheConfig{
 					ExperimentalMetadataPrefetchOnMount: "sync",

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -154,6 +154,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		UserAgent:                               userAgent,
 		CustomEndpoint:                          newConfig.GcsConnection.CustomEndpoint,
 		KeyFile:                                 string(newConfig.GcsAuth.KeyFile),
+		ExperimentalAuthTokenFile:               string(newConfig.GcsAuth.ExperimentalAuthTokenFile),
 		AnonymousAccess:                         newConfig.GcsAuth.AnonymousAccess,
 		TokenUrl:                                newConfig.GcsAuth.TokenUrl,
 		ReuseTokenFromUrl:                       newConfig.GcsAuth.ReuseTokenFromUrl,

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -158,6 +158,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		UserAgent:                  userAgent,
 		CustomEndpoint:             newConfig.GcsConnection.CustomEndpoint,
 		KeyFile:                    string(newConfig.GcsAuth.KeyFile),
+		ExperimentalAuthTokenFile:  string(newConfig.GcsAuth.ExperimentalAuthTokenFile),
 		AnonymousAccess:            newConfig.GcsAuth.AnonymousAccess,
 		TokenUrl:                   newConfig.GcsAuth.TokenUrl,
 		ReuseTokenFromUrl:          newConfig.GcsAuth.ReuseTokenFromUrl,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -754,14 +754,25 @@ func TestArgsParsing_GCSAuthFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "Test experimental-auth-token-file flag.",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsAuth: cfg.GcsAuthConfig{
+					ExperimentalAuthTokenFile: cfg.ResolvedPath(path.Join(wd, "token.json")),
+					ReuseTokenFromUrl:         true,
+				},
+			},
+		},
+		{
 			name: "Test default gcs auth flags.",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				GcsAuth: cfg.GcsAuthConfig{
-					AnonymousAccess:   false,
-					KeyFile:           "",
-					ReuseTokenFromUrl: true,
-					TokenUrl:          "",
+					AnonymousAccess:           false,
+					KeyFile:                   "",
+					ExperimentalAuthTokenFile: "",
+					ReuseTokenFromUrl:         true,
+					TokenUrl:                  "",
 				},
 			},
 		},
@@ -803,6 +814,14 @@ func TestArgsParsing_GCSAuthFlagsThrowsError(t *testing.T) {
 		{
 			name: "Invalid value for token-url flag",
 			args: []string{"gcsfuse", "--token-url=a_b://abc", "abc", "pqr"},
+		},
+		{
+			name: "experimental-auth-token-file set together with key-file",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "--key-file=key.file", "abc", "pqr"},
+		},
+		{
+			name: "experimental-auth-token-file set together with token-url",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "--token-url=www.abc.com", "abc", "pqr"},
 		},
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -764,14 +764,25 @@ func TestArgsParsing_GCSAuthFlags(t *testing.T) {
 			},
 		},
 		{
+			name: "Test experimental-auth-token-file flag.",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsAuth: cfg.GcsAuthConfig{
+					ExperimentalAuthTokenFile: cfg.ResolvedPath(path.Join(wd, "token.json")),
+					ReuseTokenFromUrl:         true,
+				},
+			},
+		},
+		{
 			name: "Test default gcs auth flags.",
 			args: []string{"gcsfuse", "abc", "pqr"},
 			expectedConfig: &cfg.Config{
 				GcsAuth: cfg.GcsAuthConfig{
-					AnonymousAccess:   false,
-					KeyFile:           "",
-					ReuseTokenFromUrl: true,
-					TokenUrl:          "",
+					AnonymousAccess:           false,
+					KeyFile:                   "",
+					ExperimentalAuthTokenFile: "",
+					ReuseTokenFromUrl:         true,
+					TokenUrl:                  "",
 				},
 			},
 		},
@@ -813,6 +824,14 @@ func TestArgsParsing_GCSAuthFlagsThrowsError(t *testing.T) {
 		{
 			name: "Invalid value for token-url flag",
 			args: []string{"gcsfuse", "--token-url=a_b://abc", "abc", "pqr"},
+		},
+		{
+			name: "experimental-auth-token-file set together with key-file",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "--key-file=key.file", "abc", "pqr"},
+		},
+		{
+			name: "experimental-auth-token-file set together with token-url",
+			args: []string{"gcsfuse", "--experimental-auth-token-file=token.json", "--token-url=www.abc.com", "abc", "pqr"},
 		},
 	}
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -88,6 +88,7 @@ func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oau
 func GetTokenSource(
 	ctx context.Context,
 	keyFile string,
+	tokenFile string,
 	tokenUrl string,
 	reuseTokenFromUrl bool,
 ) (tokenSrc oauth2.TokenSource, err error) {
@@ -95,7 +96,10 @@ func GetTokenSource(
 	const scope = storagev1.DevstorageFullControlScope
 	var method string
 
-	if keyFile != "" {
+	if tokenFile != "" {
+		tokenSrc, err = NewTokenSourceFromTokenFile(tokenFile)
+		method = "NewTokenSourceFromTokenFile"
+	} else if keyFile != "" {
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
 	} else if tokenUrl != "" {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -88,23 +88,28 @@ func newTokenSourceFromPath(ctx context.Context, path string, scope string) (oau
 func GetTokenSource(
 	ctx context.Context,
 	keyFile string,
+	tokenFile string,
 	tokenUrl string,
 	reuseTokenFromUrl bool,
 ) (tokenSrc oauth2.TokenSource, err error) {
-	return GetTokenSourceWithScope(ctx, keyFile, tokenUrl, reuseTokenFromUrl, storagev1.DevstorageFullControlScope)
+	return GetTokenSourceWithScope(ctx, keyFile, tokenFile, tokenUrl, reuseTokenFromUrl, storagev1.DevstorageFullControlScope)
 }
 
 // GetTokenSourceWithScope generates the token-source for a specific scope.
 func GetTokenSourceWithScope(
 	ctx context.Context,
 	keyFile string,
+	tokenFile string,
 	tokenUrl string,
 	reuseTokenFromUrl bool,
 	scope string,
 ) (tokenSrc oauth2.TokenSource, err error) {
 	var method string
 
-	if keyFile != "" {
+	if tokenFile != "" {
+		tokenSrc, err = NewTokenSourceFromTokenFile(tokenFile)
+		method = "NewTokenSourceFromTokenFile"
+	} else if keyFile != "" {
 		tokenSrc, err = newTokenSourceFromPath(ctx, keyFile, scope)
 		method = "newTokenSourceFromPath"
 	} else if tokenUrl != "" {

--- a/internal/auth/file_token_source.go
+++ b/internal/auth/file_token_source.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"golang.org/x/oauth2"
+)
+
+// fileTokenSource is an oauth2.TokenSource that reads an OAuth2 token
+// response from a JSON file on disk.
+type fileTokenSource struct {
+	path string
+}
+
+func (ts fileTokenSource) Token() (*oauth2.Token, error) {
+	contents, err := os.ReadFile(ts.path)
+	if err != nil {
+		return nil, fmt.Errorf("fileTokenSource cannot read token file: %w", err)
+	}
+
+	token := &oauth2.Token{}
+	if err := json.Unmarshal(contents, token); err != nil {
+		return nil, fmt.Errorf("fileTokenSource cannot decode token file %q: %w", ts.path, err)
+	}
+
+	// The expires_in field is relative, so anchor it to the time the file was
+	// read to get an absolute expiry. An absolute expiry field, if present in
+	// the file, takes precedence.
+	if token.Expiry.IsZero() && token.ExpiresIn > 0 {
+		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+	if !token.Valid() {
+		return nil, fmt.Errorf("token file %q contains an invalid or expired token", ts.path)
+	}
+
+	return token, nil
+}
+
+// NewTokenSourceFromTokenFile returns a TokenSource backed by a file
+// containing an OAuth2 token response in JSON format, e.g.
+// {"access_token": "...", "expires_in": 3600, "token_type": "Bearer"}.
+// The file is read eagerly so that an invalid or expired token fails at mount
+// time, and re-read when the token expires, so an external process may
+// refresh the credential by rewriting the file.
+func NewTokenSourceFromTokenFile(path string) (oauth2.TokenSource, error) {
+	ts := fileTokenSource{path: path}
+	token, err := ts.Token()
+	if err != nil {
+		return nil, err
+	}
+	return oauth2.ReuseTokenSource(token, ts), nil
+}

--- a/internal/auth/file_token_source.go
+++ b/internal/auth/file_token_source.go
@@ -16,54 +16,138 @@ package auth
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"golang.org/x/oauth2"
+)
+
+const (
+	// tokenFileReadAttempts is the number of times a token file is read before
+	// a transient failure (missing file, empty file, or malformed JSON) is
+	// reported. This tolerates writers that replace the file non-atomically,
+	// where a read landing mid-write may observe a partially written file.
+	tokenFileReadAttempts = 5
+	// tokenFileReadRetryDelay is the initial delay between read attempts; it
+	// doubles on each subsequent attempt.
+	tokenFileReadRetryDelay = 10 * time.Millisecond
 )
 
 // fileTokenSource is an oauth2.TokenSource that reads an OAuth2 token
 // response from a JSON file on disk.
 type fileTokenSource struct {
 	path string
+	// retryDelay is the initial delay between read attempts on transient
+	// failures. It exists as a field so tests can shorten it.
+	retryDelay time.Duration
+}
+
+// readToken reads and decodes the token file once. It reports whether a
+// failure is transient, i.e. consistent with the file being mid-rewrite by an
+// external process, so the caller can retry.
+func (ts fileTokenSource) readToken() (token *oauth2.Token, transient bool, err error) {
+	f, err := os.Open(ts.path)
+	if err != nil {
+		// A writer that removes and recreates the file (rather than renaming
+		// over it) leaves a brief window where the file does not exist.
+		return nil, errors.Is(err, os.ErrNotExist), fmt.Errorf("fileTokenSource cannot read token file: %w", err)
+	}
+	defer f.Close()
+
+	// Stat the open descriptor rather than the path so the modification time
+	// belongs to the same file contents we are about to read, even if the
+	// file is replaced concurrently.
+	info, err := f.Stat()
+	if err != nil {
+		return nil, false, fmt.Errorf("fileTokenSource cannot stat token file: %w", err)
+	}
+	contents, err := io.ReadAll(f)
+	if err != nil {
+		return nil, false, fmt.Errorf("fileTokenSource cannot read token file: %w", err)
+	}
+	if len(contents) == 0 {
+		return nil, true, fmt.Errorf("token file %q is empty", ts.path)
+	}
+
+	token = &oauth2.Token{}
+	if err := json.Unmarshal(contents, token); err != nil {
+		return nil, true, fmt.Errorf("fileTokenSource cannot decode token file %q: %w", ts.path, err)
+	}
+
+	// The expires_in field is relative to when the token was issued, which we
+	// approximate by the file's modification time, i.e. when the external
+	// process wrote the refreshed credential. Anchoring to the read time
+	// instead would overestimate the remaining lifetime by however long the
+	// file sat on disk before being read. An absolute expiry field, if present
+	// in the file, takes precedence.
+	if token.Expiry.IsZero() && token.ExpiresIn > 0 {
+		token.Expiry = info.ModTime().Add(time.Duration(token.ExpiresIn) * time.Second)
+	}
+	if !token.Valid() {
+		return nil, false, fmt.Errorf("token file %q contains an invalid or expired token", ts.path)
+	}
+
+	return token, false, nil
 }
 
 func (ts fileTokenSource) Token() (*oauth2.Token, error) {
-	contents, err := os.ReadFile(ts.path)
-	if err != nil {
-		return nil, fmt.Errorf("fileTokenSource cannot read token file: %w", err)
+	delay := ts.retryDelay
+	if delay <= 0 {
+		delay = tokenFileReadRetryDelay
 	}
-
-	token := &oauth2.Token{}
-	if err := json.Unmarshal(contents, token); err != nil {
-		return nil, fmt.Errorf("fileTokenSource cannot decode token file %q: %w", ts.path, err)
+	var err error
+	for attempt := 1; ; attempt++ {
+		var token *oauth2.Token
+		var transient bool
+		token, transient, err = ts.readToken()
+		if err == nil {
+			return token, nil
+		}
+		if !transient || attempt >= tokenFileReadAttempts {
+			return nil, err
+		}
+		time.Sleep(delay)
+		delay *= 2
 	}
-
-	// The expires_in field is relative, so anchor it to the time the file was
-	// read to get an absolute expiry. An absolute expiry field, if present in
-	// the file, takes precedence.
-	if token.Expiry.IsZero() && token.ExpiresIn > 0 {
-		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
-	}
-	if !token.Valid() {
-		return nil, fmt.Errorf("token file %q contains an invalid or expired token", ts.path)
-	}
-
-	return token, nil
 }
 
 // NewTokenSourceFromTokenFile returns a TokenSource backed by a file
 // containing an OAuth2 token response in JSON format, e.g.
 // {"access_token": "...", "expires_in": 3600, "token_type": "Bearer"}.
+//
 // The file is read eagerly so that an invalid or expired token fails at mount
 // time, and re-read when the token expires, so an external process may
-// refresh the credential by rewriting the file.
+// refresh the credential by rewriting the file. Writers should replace the
+// file atomically (write to a temporary file in the same directory, then
+// rename over the token file); reads that observe a partially written file
+// are retried briefly, but atomic replacement is what makes refresh reliable.
+//
+// The token file is a credential and should be protected with filesystem
+// permissions like any other credential file (e.g. --key-file). A warning is
+// logged if the file is writable by group or others.
 func NewTokenSourceFromTokenFile(path string) (oauth2.TokenSource, error) {
 	ts := fileTokenSource{path: path}
 	token, err := ts.Token()
 	if err != nil {
 		return nil, err
 	}
+	warnIfTokenFileIsWidelyWritable(path)
 	return oauth2.ReuseTokenSource(token, ts), nil
+}
+
+// warnIfTokenFileIsWidelyWritable logs a warning when the token file can be
+// modified by processes other than its owner, since any such process could
+// substitute its own credential.
+func warnIfTokenFileIsWidelyWritable(path string) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if perm := info.Mode().Perm(); perm&0o022 != 0 {
+		logger.Warnf("token file %q has permissions %04o and is writable by group or others; restrict it to the owner (e.g. chmod 600)", path, perm)
+	}
 }

--- a/internal/auth/file_token_source_test.go
+++ b/internal/auth/file_token_source_test.go
@@ -1,0 +1,115 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package auth
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeTokenFile(t *testing.T, contents string) string {
+	t.Helper()
+	tokenFile := path.Join(t.TempDir(), "token.json")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(contents), 0o600))
+	return tokenFile
+}
+
+func Test_NewTokenSourceFromTokenFile_Success(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","expires_in":3600,"token_type":"Bearer"}`)
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+	token, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-token", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	// expires_in must be anchored to an absolute expiry.
+	assert.False(t, token.Expiry.IsZero())
+	assert.True(t, token.Expiry.After(time.Now()))
+}
+
+func Test_NewTokenSourceFromTokenFile_NoExpiry(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","token_type":"Bearer"}`)
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	require.NoError(t, err)
+	token, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "test-access-token", token.AccessToken)
+	assert.True(t, token.Expiry.IsZero())
+}
+
+func Test_NewTokenSourceFromTokenFile_ExpiredToken(t *testing.T) {
+	expiry := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	tokenFile := writeTokenFile(t, fmt.Sprintf(`{"access_token":"test-access-token","token_type":"Bearer","expiry":%q}`, expiry))
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid or expired token")
+	assert.Nil(t, ts)
+}
+
+func Test_NewTokenSourceFromTokenFile_MissingAccessToken(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"expires_in":3600,"token_type":"Bearer"}`)
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid or expired token")
+	assert.Nil(t, ts)
+}
+
+func Test_NewTokenSourceFromTokenFile_InvalidJSON(t *testing.T) {
+	tokenFile := writeTokenFile(t, "not-json")
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "cannot decode token file")
+	assert.Nil(t, ts)
+}
+
+func Test_NewTokenSourceFromTokenFile_FileNotFound(t *testing.T) {
+	ts, err := NewTokenSourceFromTokenFile(path.Join(t.TempDir(), "missing.json"))
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "cannot read token file")
+	assert.Nil(t, ts)
+}
+
+func TestFileTokenSource_RereadsFileOnEachCall(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"token-1","token_type":"Bearer"}`)
+	ts := fileTokenSource{path: tokenFile}
+	token, err := ts.Token()
+	require.NoError(t, err)
+	require.Equal(t, "token-1", token.AccessToken)
+
+	// An external process may refresh the credential by rewriting the file.
+	require.NoError(t, os.WriteFile(tokenFile, []byte(`{"access_token":"token-2","token_type":"Bearer"}`), 0o600))
+
+	token, err = ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-2", token.AccessToken)
+}

--- a/internal/auth/file_token_source_test.go
+++ b/internal/auth/file_token_source_test.go
@@ -32,6 +32,12 @@ func writeTokenFile(t *testing.T, contents string) string {
 	return tokenFile
 }
 
+// fastFileTokenSource returns a fileTokenSource whose transient-failure
+// retries complete quickly.
+func fastFileTokenSource(tokenFile string) fileTokenSource {
+	return fileTokenSource{path: tokenFile, retryDelay: time.Millisecond}
+}
+
 func Test_NewTokenSourceFromTokenFile_Success(t *testing.T) {
 	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","expires_in":3600,"token_type":"Bearer"}`)
 
@@ -46,6 +52,48 @@ func Test_NewTokenSourceFromTokenFile_Success(t *testing.T) {
 	// expires_in must be anchored to an absolute expiry.
 	assert.False(t, token.Expiry.IsZero())
 	assert.True(t, token.Expiry.After(time.Now()))
+}
+
+func Test_NewTokenSourceFromTokenFile_ExpiresInAnchoredToModTime(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","expires_in":3600,"token_type":"Bearer"}`)
+	// Simulate a token that was written 30 minutes ago and only read now.
+	writtenAt := time.Now().Add(-30 * time.Minute).Truncate(time.Second)
+	require.NoError(t, os.Chtimes(tokenFile, writtenAt, writtenAt))
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	require.NoError(t, err)
+	token, err := ts.Token()
+	require.NoError(t, err)
+	// The remaining lifetime is 3600s measured from when the file was written,
+	// not from when it was read.
+	assert.WithinDuration(t, writtenAt.Add(time.Hour), token.Expiry, time.Second)
+}
+
+func Test_NewTokenSourceFromTokenFile_ExpiresInElapsedSinceModTime(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","expires_in":60,"token_type":"Bearer"}`)
+	// The token had 60s of life when written two hours ago, so it is expired
+	// even though a read-time anchor would consider it fresh.
+	writtenAt := time.Now().Add(-2 * time.Hour)
+	require.NoError(t, os.Chtimes(tokenFile, writtenAt, writtenAt))
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid or expired token")
+	assert.Nil(t, ts)
+}
+
+func Test_NewTokenSourceFromTokenFile_AbsoluteExpiryTakesPrecedence(t *testing.T) {
+	expiry := time.Now().Add(10 * time.Minute).Truncate(time.Second)
+	tokenFile := writeTokenFile(t, fmt.Sprintf(`{"access_token":"test-access-token","expires_in":3600,"token_type":"Bearer","expiry":%q}`, expiry.Format(time.RFC3339)))
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	require.NoError(t, err)
+	token, err := ts.Token()
+	require.NoError(t, err)
+	assert.True(t, expiry.Equal(token.Expiry), "expected %v, got %v", expiry, token.Expiry)
 }
 
 func Test_NewTokenSourceFromTokenFile_NoExpiry(t *testing.T) {
@@ -91,6 +139,16 @@ func Test_NewTokenSourceFromTokenFile_InvalidJSON(t *testing.T) {
 	assert.Nil(t, ts)
 }
 
+func Test_NewTokenSourceFromTokenFile_EmptyFile(t *testing.T) {
+	tokenFile := writeTokenFile(t, "")
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "is empty")
+	assert.Nil(t, ts)
+}
+
 func Test_NewTokenSourceFromTokenFile_FileNotFound(t *testing.T) {
 	ts, err := NewTokenSourceFromTokenFile(path.Join(t.TempDir(), "missing.json"))
 
@@ -99,9 +157,20 @@ func Test_NewTokenSourceFromTokenFile_FileNotFound(t *testing.T) {
 	assert.Nil(t, ts)
 }
 
+func Test_NewTokenSourceFromTokenFile_WidelyWritableFileStillMounts(t *testing.T) {
+	tokenFile := writeTokenFile(t, `{"access_token":"test-access-token","token_type":"Bearer"}`)
+	require.NoError(t, os.Chmod(tokenFile, 0o666))
+
+	ts, err := NewTokenSourceFromTokenFile(tokenFile)
+
+	// Loose permissions produce a warning, not a failure.
+	require.NoError(t, err)
+	assert.NotNil(t, ts)
+}
+
 func TestFileTokenSource_RereadsFileOnEachCall(t *testing.T) {
 	tokenFile := writeTokenFile(t, `{"access_token":"token-1","token_type":"Bearer"}`)
-	ts := fileTokenSource{path: tokenFile}
+	ts := fastFileTokenSource(tokenFile)
 	token, err := ts.Token()
 	require.NoError(t, err)
 	require.Equal(t, "token-1", token.AccessToken)
@@ -112,4 +181,57 @@ func TestFileTokenSource_RereadsFileOnEachCall(t *testing.T) {
 	token, err = ts.Token()
 	require.NoError(t, err)
 	assert.Equal(t, "token-2", token.AccessToken)
+}
+
+func TestFileTokenSource_RetriesWhileFileIsBeingRewritten(t *testing.T) {
+	// Simulate a non-atomic writer that has truncated the file but not yet
+	// written the new contents.
+	tokenFile := writeTokenFile(t, "")
+	ts := fastFileTokenSource(tokenFile)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(tokenFile, []byte(`{"access_token":"refreshed","token_type":"Bearer"}`), 0o600)
+	}()
+
+	token, err := ts.Token()
+
+	<-done
+	require.NoError(t, err)
+	assert.Equal(t, "refreshed", token.AccessToken)
+}
+
+func TestFileTokenSource_RetriesWhileFileIsBeingReplaced(t *testing.T) {
+	// Simulate a writer that removes the file and recreates it, leaving a
+	// brief window where it does not exist.
+	dir := t.TempDir()
+	tokenFile := path.Join(dir, "token.json")
+	ts := fastFileTokenSource(tokenFile)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		time.Sleep(5 * time.Millisecond)
+		_ = os.WriteFile(tokenFile, []byte(`{"access_token":"recreated","token_type":"Bearer"}`), 0o600)
+	}()
+
+	token, err := ts.Token()
+
+	<-done
+	require.NoError(t, err)
+	assert.Equal(t, "recreated", token.AccessToken)
+}
+
+func TestFileTokenSource_DoesNotRetryExpiredToken(t *testing.T) {
+	expiry := time.Now().Add(-time.Hour).Format(time.RFC3339)
+	tokenFile := writeTokenFile(t, fmt.Sprintf(`{"access_token":"test-access-token","token_type":"Bearer","expiry":%q}`, expiry))
+	ts := fileTokenSource{path: tokenFile, retryDelay: time.Second}
+
+	start := time.Now()
+	_, err := ts.Token()
+
+	// An expired token is a definitive failure, so it must not burn through
+	// the retry budget.
+	assert.Error(t, err)
+	assert.Less(t, time.Since(start), time.Second)
 }

--- a/internal/monitor/otelexporters.go
+++ b/internal/monitor/otelexporters.go
@@ -464,7 +464,7 @@ func isOtelEndpointInsecure(endpoint string) bool {
 
 // getGcpOtelHttpClient creates an authenticated HTTP client for a specific GCP scope.
 func getGcpOtelHttpClient(ctx context.Context, authConfig cfg.GcsAuthConfig, scope string) (*http.Client, error) {
-	ts, err := auth.GetTokenSourceWithScope(ctx, string(authConfig.KeyFile), authConfig.TokenUrl, authConfig.ReuseTokenFromUrl, scope)
+	ts, err := auth.GetTokenSourceWithScope(ctx, string(authConfig.KeyFile), string(authConfig.ExperimentalAuthTokenFile), authConfig.TokenUrl, authConfig.ReuseTokenFromUrl, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -28,8 +28,19 @@ import (
 	"google.golang.org/api/option"
 )
 
-// GetClientAuthOptionsAndToken returns client options and a token source using either a token URL or fallback to key file/ADC.
+// GetClientAuthOptionsAndToken returns client options and a token source using either an auth token file, a token URL or fallback to key file/ADC.
 func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConfig) ([]option.ClientOption, oauth2.TokenSource, error) {
+	// If an auth token file is provided, use its token directly as the credential.
+	if config.ExperimentalAuthTokenFile != "" {
+		tokenSrc, err := auth2.NewTokenSourceFromTokenFile(config.ExperimentalAuthTokenFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("while creating token source from token file: %w", err)
+		}
+
+		clientOpts := []option.ClientOption{option.WithTokenSource(tokenSrc)}
+		return clientOpts, tokenSrc, nil
+	}
+
 	// If Token URL is provided, attempt to fetch token source directly.
 	if config.TokenUrl != "" {
 		tokenSrc, err := auth2.NewTokenSourceFromURL(ctx, config.TokenUrl, config.ReuseTokenFromUrl)

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -28,8 +28,19 @@ import (
 	"google.golang.org/api/option"
 )
 
-// GetClientAuthOptionsAndTokenSource returns client options and a token source using either a token URL or fallback to key file/ADC.
+// GetClientAuthOptionsAndTokenSource returns client options and a token source using either an auth token file, a token URL or fallback to key file/ADC.
 func GetClientAuthOptionsAndTokenSource(ctx context.Context, config *StorageClientConfig) ([]option.ClientOption, oauth2.TokenSource, error) {
+	// If an auth token file is provided, use its token directly as the credential.
+	if config.ExperimentalAuthTokenFile != "" {
+		tokenSrc, err := auth2.NewTokenSourceFromTokenFile(config.ExperimentalAuthTokenFile)
+		if err != nil {
+			return nil, nil, fmt.Errorf("while creating token source from token file: %w", err)
+		}
+
+		clientOpts := []option.ClientOption{option.WithTokenSource(tokenSrc)}
+		return clientOpts, tokenSrc, nil
+	}
+
 	retryConfig := NewRetryConfig(config)
 	// If Token URL is provided, attempt to fetch token source directly.
 	if config.TokenUrl != "" {

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -19,15 +19,45 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 )
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
+
+func Test_GetClientAuthOptionsAndToken_AuthTokenFileSuccess(t *testing.T) {
+	tokenFile := path.Join(t.TempDir(), "token.json")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(`{"access_token":"dummy-token","expires_in":3600,"token_type":"Bearer"}`), 0o600))
+	config := &StorageClientConfig{
+		ExperimentalAuthTokenFile: tokenFile,
+	}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.Len(t, clientOpts, 1) // Only tokenSource option attached
+	token, err := tokenSrc.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy-token", token.AccessToken)
+}
+
+func Test_GetClientAuthOptionsAndToken_AuthTokenFileError(t *testing.T) {
+	config := &StorageClientConfig{ExperimentalAuthTokenFile: path.Join(t.TempDir(), "missing.json")}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+
+	assert.Error(t, err)
+	assert.Nil(t, tokenSrc)
+	assert.Empty(t, clientOpts)
+}
 
 func Test_GetClientAuthOptionsAndToken_TokenUrlSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -19,15 +19,45 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/api/option"
 )
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
+
+func Test_GetClientAuthOptionsAndTokenSource_AuthTokenFileSuccess(t *testing.T) {
+	tokenFile := path.Join(t.TempDir(), "token.json")
+	require.NoError(t, os.WriteFile(tokenFile, []byte(`{"access_token":"dummy-token","expires_in":3600,"token_type":"Bearer"}`), 0o600))
+	config := &StorageClientConfig{
+		ExperimentalAuthTokenFile: tokenFile,
+	}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.Len(t, clientOpts, 1) // Only tokenSource option attached
+	token, err := tokenSrc.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy-token", token.AccessToken)
+}
+
+func Test_GetClientAuthOptionsAndTokenSource_AuthTokenFileError(t *testing.T) {
+	config := &StorageClientConfig{ExperimentalAuthTokenFile: path.Join(t.TempDir(), "missing.json")}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
+
+	assert.Error(t, err)
+	assert.Nil(t, tokenSrc)
+	assert.Empty(t, clientOpts)
+}
 
 func Test_GetClientAuthOptionsAndTokenSource_TokenUrlSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -15,6 +15,7 @@
 package storageutil
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -30,7 +31,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 
@@ -56,6 +56,7 @@ type StorageClientConfig struct {
 	UserAgent                               string
 	CustomEndpoint                          string
 	KeyFile                                 string
+	ExperimentalAuthTokenFile               string
 	TokenUrl                                string
 	ReuseTokenFromUrl                       bool
 	ExperimentalNonrapidFolderApiStallRetry bool
@@ -181,7 +182,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig, tokenSrc oauth2.
 // It creates the token-source from the provided
 // key-file or using ADC search order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func CreateTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
-	return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
+	return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.ExperimentalAuthTokenFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
 }
 
 // StripScheme strips the scheme part of given url.

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -53,16 +53,17 @@ type StorageClientConfig struct {
 	/** Common client parameters. */
 
 	// ClientProtocol decides the go-sdk client to create.
-	ClientProtocol     cfg.Protocol
-	UserAgent          string
-	CustomEndpoint     string
-	KeyFile            string
-	TokenUrl           string
-	ReuseTokenFromUrl  bool
-	MaxRetrySleep      time.Duration
-	RetryMultiplier    float64
-	EnableMountRetries bool
-	LocalSocketAddress string
+	ClientProtocol            cfg.Protocol
+	UserAgent                 string
+	CustomEndpoint            string
+	KeyFile                   string
+	ExperimentalAuthTokenFile string
+	TokenUrl                  string
+	ReuseTokenFromUrl         bool
+	MaxRetrySleep             time.Duration
+	RetryMultiplier           float64
+	EnableMountRetries        bool
+	LocalSocketAddress        string
 
 	/** HTTP client parameters. */
 	MaxConnsPerHost            int
@@ -185,7 +186,7 @@ func CreateHttpClient(storageClientConfig *StorageClientConfig, tokenSrc oauth2.
 // It creates the token-source from the provided
 // key-file or using ADC search order (https://cloud.google.com/docs/authentication/application-default-credentials#order).
 func CreateTokenSource(storageClientConfig *StorageClientConfig) (tokenSrc oauth2.TokenSource, err error) {
-	return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
+	return auth.GetTokenSource(context.Background(), storageClientConfig.KeyFile, storageClientConfig.ExperimentalAuthTokenFile, storageClientConfig.TokenUrl, storageClientConfig.ReuseTokenFromUrl)
 }
 
 // StripScheme strips the scheme part of given url.


### PR DESCRIPTION
Fixes #4686

## What

Adds `--experimental-auth-token-file <path>` (config: `gcs-auth.experimental-auth-token-file`), a flag that points at a file containing an OAuth2 token response in JSON format, used directly as the GCS credential:

```bash
echo '{"access_token":"ya29...","expires_in":3600,"token_type":"Bearer"}' > /tmp/gcs-token
gcsfuse --experimental-auth-token-file=/tmp/gcs-token --only-dir=user-prefix bucket /mnt/gcs
```

This targets short-lived sandbox environments (Firecracker microVM providers like e2b, Modal, Daytona) where an orchestrator mints a downscoped, prefix-scoped access token (e.g. via STS Credential Access Boundaries) and hands it to gcsfuse inside the sandbox — without shipping a long-lived SA key into an environment executing untrusted code, and without running a localhost HTTP server just to satisfy `--token-url`.

## Design decisions (per maintainer guidance on #4686)

- **Flag name**: `--experimental-auth-token-file` (@trinadhkotturu preferred `auth-token-file`, @anushka567 asked for the `experimental-` prefix for external contributions).
- **Fail at mount, not at GCS**: the token file is read eagerly when the token source is constructed, so mounting fails immediately if the token is missing, malformed, empty, or expired (@trinadhkotturu's recommendation).
- **File shape**: the OAuth2 token response JSON, consistent with what `--token-url` endpoints return (@anushka567's recommendation). The relative `expires_in` field is anchored to the file read time; an absolute `expiry` field (RFC 3339), when present, takes precedence.
- **Refresh**: the source is wrapped in `oauth2.ReuseTokenSource`, so the file is re-read when the cached token expires. An external process may therefore refresh the credential by rewriting the file; if the file isn't refreshed, requests fail with an "invalid or expired token" error rather than hitting GCS with a stale credential.
- **Mutual exclusion**: combining the new flag with `--key-file` or `--token-url` is rejected at config validation time, to fail early instead of silently picking one. Happy to relax this to a documented precedence order if you'd prefer.

## Changes

- `cfg/params.yaml` + regenerated `cfg/config.go` (via `go generate`): new param, type `resolvedPath`.
- `internal/auth/file_token_source.go`: new `fileTokenSource` + `NewTokenSourceFromTokenFile`, mirroring the existing `proxyTokenSource` structure.
- `internal/storage/storageutil/auth_client_option.go`: token-file branch in `GetClientAuthOptionsAndToken` (google-lib-auth flow).
- `internal/auth/auth.go` / `internal/storage/storageutil/client.go`: token-file support in the legacy `GetTokenSource` flow; also replaced the deprecated `golang.org/x/net/context` import with `context` in `client.go` to satisfy the `govet` inline check on the touched line.
- `cfg/validate.go`: `isValidGcsAuthConfig` mutual-exclusion check.
- Tests: `internal/auth/file_token_source_test.go` (valid/expired/no-expiry/malformed/missing/empty-token/re-read cases), `storageutil/auth_client_option_test.go`, `cfg/validate_test.go`, and a happy-path + conflict cases in `cmd/root_test.go`, per the dev guide.

## Testing

- `go test ./cmd/... ./cfg/... ./internal/auth/... ./internal/storage/storageutil/...` passes on linux/amd64 (Docker, golang:1.26).
- `go test -run=PATTERN_THAT_DOES_NOT_MATCH_ANYTHING ./...` (buildTest) compiles cleanly on linux/amd64.
- `golangci-lint run -E=unused --new-from-rev=master` reports 0 issues on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
