### PR TITLE
refactor: prevent dangling sibling pointers in the radix trie after removal operations

### DIFF
--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -316,9 +316,10 @@ func (c *radixCache) compressPathUpwards(curr *radixNode) {
 			onlyChild.prefix = curr.prefix + onlyChild.prefix
 			onlyChild.parent = curr.parent
 
+			parent := curr.parent
 			curr.parent.replaceChild(curr, onlyChild)
 
-			curr = curr.parent
+			curr = parent
 			continue
 		}
 		break

--- a/internal/cache/lru/radix.go
+++ b/internal/cache/lru/radix.go
@@ -173,6 +173,10 @@ func (n *radixNode) removeChild(childToRemove *radixNode) {
 	for pcurr := &n.child; *pcurr != nil; pcurr = &(*pcurr).sibling {
 		if *pcurr == childToRemove {
 			*pcurr = childToRemove.sibling
+
+			childToRemove.sibling = nil
+			childToRemove.parent = nil
+
 			return
 		}
 	}
@@ -185,6 +189,10 @@ func (n *radixNode) replaceChild(oldChild, newChild *radixNode) {
 		if *pcurr == oldChild {
 			newChild.sibling = oldChild.sibling
 			*pcurr = newChild
+
+			oldChild.sibling = nil
+			oldChild.parent = nil
+
 			return
 		}
 	}


### PR DESCRIPTION
### Description
When nodes are detached from the tree (e.g., during subtree invalidation or path compression), we use the `removeChild` and `replaceChild` helper functions to bypass the removed node in the live tree.

While `removeChild` and `replaceChild` successfully updated the parent's child chain to skip over the target node, they did not scrub the target node's own pointers. This left the detached node's `sibling` and `parent` fields pointing directly into the live tree. Although Go's garbage collector can safely handle dead objects pointing to live objects, this practice leaves dangling references that can delay GC (if the detached node is held in memory) .

#### Fix 
Explicitly set `sibling = nil` and `parent = nil` on nodes as they are detached inside `removeChild` and `replaceChild`. This completely severs the removed nodes from the live tree structure, ensuring clean memory lifecycles for detached subtrees.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
