### PR TITLE
feat(native-retries): wire Control Plane mount retry predicate (ShouldRetryOnMount)

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -142,7 +142,7 @@ func getConfigForUserAgent(mountConfig *cfg.Config) string {
 	}
 	return strings.Join(parts, ":")
 }
-func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle metrics.MetricHandle, isGKE bool) (storageHandle storage.StorageHandle, err error) {
+func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle metrics.MetricHandle, isGKE bool, isDynamicMount bool) (storageHandle storage.StorageHandle, err error) {
 	storageClientConfig := storageutil.StorageClientConfig{
 		ClientProtocol:                          newConfig.GcsConnection.ClientProtocol,
 		MaxConnsPerHost:                         int(newConfig.GcsConnection.MaxConnsPerHost),
@@ -151,6 +151,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		MaxRetrySleep:                           newConfig.GcsRetries.MaxRetrySleep,
 		MaxRetryAttempts:                        int(newConfig.GcsRetries.MaxRetryAttempts),
 		RetryMultiplier:                         newConfig.GcsRetries.Multiplier,
+		EnableMountRetries:                      newConfig.GcsRetries.EnableMountRetries && !isDynamicMount,
 		UserAgent:                               userAgent,
 		CustomEndpoint:                          newConfig.GcsConnection.CustomEndpoint,
 		KeyFile:                                 string(newConfig.GcsAuth.KeyFile),
@@ -202,7 +203,7 @@ func mountWithArgs(bucketName string, mountPoint string, newConfig *cfg.Config, 
 	if bucketName != canned.FakeBucketName {
 		userAgent := getUserAgent(newConfig.AppName, getConfigForUserAgent(newConfig), logger.MountInstanceID(fsName(bucketName)))
 		logger.Info("Creating Storage handle...")
-		storageHandle, err = createStorageHandle(newConfig, userAgent, metricHandle, isGKE)
+		storageHandle, err = createStorageHandle(newConfig, userAgent, metricHandle, isGKE, isDynamicMount(bucketName))
 		if err != nil {
 			err = fmt.Errorf("failed to create storage handle using createStorageHandle: %w", err)
 			return

--- a/cmd/legacy_main_test.go
+++ b/cmd/legacy_main_test.go
@@ -48,7 +48,7 @@ func (t *MainTest) TestCreateStorageHandle() {
 		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
 	}
 
-	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), false)
+	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), false, false)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), storageHandle)
@@ -60,7 +60,7 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPC() {
 		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
 	}
 
-	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), false)
+	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), false, false)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), storageHandle)
@@ -72,7 +72,7 @@ func (t *MainTest) TestCreateStorageHandle_WithClientProtocolAsGRPCIsGKE() {
 		GcsAuth:       cfg.GcsAuthConfig{KeyFile: "testdata/test_creds.json"},
 	}
 
-	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), true)
+	storageHandle, err := createStorageHandle(newConfig, "AppName", metrics.NewNoopMetrics(), true, false)
 
 	assert.Nil(t.T(), err)
 	assert.NotNil(t.T(), storageHandle)

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -91,6 +91,8 @@ type storageControlClientWithRetry struct {
 
 	// Whether or not to enable retries for folder APIs.
 	enableRetriesOnFolderAPIs bool
+	// Whether or not to enable mount retries for GetStorageLayout call.
+	enableRetriesOnMount bool
 }
 
 func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Context,
@@ -100,6 +102,9 @@ func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Conte
 		return sccwros.raw.GetStorageLayout(attemptCtx, req, opts...)
 	}
 
+	if sccwros.enableRetriesOnMount {
+		return storageutil.ExecuteWithCustomShouldRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, storageutil.ShouldRetryOnMount, logger.LevelInfo)
+	}
 	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, logger.LevelInfo)
 }
 
@@ -220,11 +225,16 @@ func NewStorageControlClient(raw StorageControlClient, clientConfig *storageutil
 		raw:         rawClient,
 		retryConfig: retryConfig,
 	}
+	// 2. Enable retries on mount if configured and supported
+	if clientConfig != nil {
+		wrapped.enableRetriesOnMount = clientConfig.EnableMountRetries
+	}
+	// 3. Wrap with retries on folder APIs if configured
 	if state.folderRetries {
 		wrapped.enableRetriesOnFolderAPIs = true
 	}
 
-	// 2. Wrap with billing project if configured
+	// 4. Wrap with billing project if configured
 	if state.billingProject != "" {
 		return &storageControlClientWithBillingProject{raw: wrapped, billingProject: state.billingProject}
 	}

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -219,6 +219,51 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut(
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_Retry404ThenSuccess() {
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr).Times(2)
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
+
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	assert.NoError(t.T(), err)
+	assert.Equal(t.T(), expectedLayout, layout)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesDisabled_404FailsImmediately() {
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, false)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr).Once()
+
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), layout)
+	assert.Contains(t.T(), err.Error(), "failed:")
+	assert.Contains(t.T(), err.Error(), mountErr.Error())
+	t.mockRawClient.AssertExpectations(t.T())
+
+}
+
+func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_AllAttemptsTimeOut() {
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
+	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
+	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr)
+
+	layout, err := client.GetStorageLayout(t.ctx, req)
+
+	assert.Error(t.T(), err)
+	assert.Nil(t.T(), layout)
+	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	t.mockRawClient.AssertExpectations(t.T())
+}
+
 func (t *StorageLayoutRetryWrapperTest) TestGetFolder_IsNotRetried() {
 	// Arrange
 	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
@@ -295,6 +340,36 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 	clientConfig := &storageutil.StorageClientConfig{
 		MaxRetrySleep:   maxRetrySleep,
 		RetryMultiplier: backoffMultiplier,
+	}
+	var opts []ControlClientOption
+	if retryFolderAPIs {
+		opts = append(opts, WithRetriesOnFolderAPI())
+	}
+	scc := NewStorageControlClient(controlClient, clientConfig, opts...)
+
+	var retryClient *storageControlClientWithRetry
+	if rc, ok := scc.(*storageControlClientWithRetry); ok {
+		retryClient = rc
+	}
+	if retryClient != nil {
+		retryClient.retryConfig = storageutil.NewRetryConfigForTesting(
+			retryDeadline,
+			totalRetryBudget,
+			initialBackoff,
+			maxRetrySleep,
+			backoffMultiplier,
+			clientConfig.MaxRetryAttempts,
+		)
+	}
+	return scc
+}
+
+func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(controlClient StorageControlClient, retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool, enableRetriesOnMount bool) StorageControlClient {
+	t.T().Helper()
+	clientConfig := &storageutil.StorageClientConfig{
+		MaxRetrySleep:      maxRetrySleep,
+		RetryMultiplier:    backoffMultiplier,
+		EnableMountRetries: enableRetriesOnMount,
 	}
 	var opts []ControlClientOption
 	if retryFolderAPIs {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -700,6 +700,24 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithCustomEndpointAndEna
 	assert.NotNil(testSuite.T(), sh)
 }
 
+func (testSuite *StorageHandleTest) TestNewStorageHandleWithEnableMountRetries() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.EnableHNS = true
+	sc.EnableMountRetries = true
+
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+
+	assert.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), sh)
+	// Underlying storageClient controlClient should enable retries on mount when EnableMountRetries is true.
+	scClient, ok := sh.(*storageClient)
+	require.True(testSuite.T(), ok)
+	require.NotNil(testSuite.T(), scClient.storageControlClient)
+	sccwros, ok := scClient.storageControlClient.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
+	assert.True(testSuite.T(), sccwros.enableRetriesOnMount)
+}
+
 func (testSuite *StorageHandleTest) TestCreateClientOptionForGRPCClient() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -61,6 +61,7 @@ type StorageClientConfig struct {
 	ExperimentalNonrapidFolderApiStallRetry bool
 	MaxRetrySleep                           time.Duration
 	RetryMultiplier                         float64
+	EnableMountRetries                      bool
 	LocalSocketAddress                      string
 
 	/** HTTP client parameters. */


### PR DESCRIPTION
### Description
- Wires the new control plane mount retry predicate (`ShouldRetryOnMount`) for `GetStorageLayout` calls when the `--enable-mount-retries` flag is enabled.
- Prevents dynamic mounts (`bucketName == ""` or `bucketName == "_"`) from inheriting mount-time retries to avoid runtime lookup hangs.
- Resolves EnableMountRetries on StorageClientConfig during storage handle creation for dynamic mounts.

### Link to the issue in case of a bug fix.
b/530765797

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests in `legacy_main_test.go` and `storage_handle_test.go`. Verified all tests in `cmd` and `internal/storage` pass cleanly:
   `go test -v ./cmd/... ./internal/storage/...`
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No.
