### PR TITLE
test(machine_type_test): fix flag parsing and mounted directory in gke/machine_type_test

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
@@ -36,7 +36,7 @@ echo "Step 4: Running tests ..."
 # These tests are chosen to verify that machine-type is correctly passed by
 # CSI Driver to GCSFuse and GCSFuse is correctly accepting it and triggering optimization flags
 # like implicit-dirs and rename-dir-limit for high-performance machine-type as expected.
-export MOUNTED_DIR=/data_mnt
-go test -v ./tools/integration_tests/flag_optimizations/... -run "TestImplicitDirsEnabled|TestRenameDirLimitSet" -args --integrationTest --config-file="$(pwd)/tools/integration_tests/test_config.yaml" --mountedDirectory=/data_mnt --testbucket="$BUCKET_NAME"
+export MOUNTED_DIR="/data_mnt"
+go test -v ./tools/integration_tests/flag_optimizations/... -run "TestImplicitDirsEnabled|TestRenameDirLimitSet" -args --integrationTest --config-file="$(pwd)/tools/integration_tests/test_config.yaml" --mountedDirectory="${MOUNTED_DIR}" --testbucket="$BUCKET_NAME"
 
 echo "Step 5: Test finished successfully."

--- a/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
+++ b/perfmetrics/scripts/continuous_test/gke/machine_type_test/run_test.sh
@@ -36,6 +36,7 @@ echo "Step 4: Running tests ..."
 # These tests are chosen to verify that machine-type is correctly passed by
 # CSI Driver to GCSFuse and GCSFuse is correctly accepting it and triggering optimization flags
 # like implicit-dirs and rename-dir-limit for high-performance machine-type as expected.
-go test -v ./tools/integration_tests/flag_optimizations/... --integrationTest --config-file="$(pwd)/tools/integration_tests/test_config.yaml" --mountedDirectory=/data_mnt --testbucket="$BUCKET_NAME" -run "TestImplicitDirsEnabled|TestRenameDirLimitSet"
+export MOUNTED_DIR=/data_mnt
+go test -v ./tools/integration_tests/flag_optimizations/... -run "TestImplicitDirsEnabled|TestRenameDirLimitSet" -args --integrationTest --config-file="$(pwd)/tools/integration_tests/test_config.yaml" --mountedDirectory=/data_mnt --testbucket="$BUCKET_NAME"
 
 echo "Step 5: Test finished successfully."


### PR DESCRIPTION
### Description
It modifies the go test command to include the `-args` flag before passing the test-specific arguments. This ensures that custom flags like `--integrationTest` and `--mountedDirectory` are correctly passed to the compiled test binary instead of being incorrectly interpreted by the go test command itself.

### Link to the issue in case of a bug fix.
b/534386424

### Testing details
1. Manual - via KOKORO
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
