### PR TITLE
fix(metrics): Fixing double counting issue in read bytes count metrics in Kernel Range Reader & Buffered Reader

### DIFF
--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -312,7 +312,6 @@ func (p *BufferedReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest) (res
 	defer func() {
 		dur := time.Since(start)
 		p.metricHandle.BufferedReadReadLatency(ctx, dur)
-		p.metricHandle.GcsReadBytesCount(int64(bytesRead))
 
 		if err == nil || errors.Is(err, io.EOF) {
 			logger.Tracef("%.13v -> ReadAt(): Ok(%v)", reqID, dur)

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -283,7 +283,6 @@ func TestGCSMetrics_DownloadBytesCount_Explicit(t *testing.T) {
 		1)
 }
 
-
 // TestGCSMetrics_With_FileCache validates GCS metrics behavior when file cache is enabled.
 //
 // Expected Behavior:

--- a/internal/fs/gcs_metrics_test.go
+++ b/internal/fs/gcs_metrics_test.go
@@ -272,6 +272,9 @@ func TestGCSMetrics_DownloadBytesCount_Explicit(t *testing.T) {
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count",
 		attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeBufferedAttr))),
 		int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count",
+		attribute.NewSet(),
+		int64(len(content)))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/reader_count",
 		attribute.NewSet(attribute.String("io_method", "opened")),
 		1)
@@ -279,6 +282,7 @@ func TestGCSMetrics_DownloadBytesCount_Explicit(t *testing.T) {
 		attribute.NewSet(attribute.String("io_method", "closed")),
 		1)
 }
+
 
 // TestGCSMetrics_With_FileCache validates GCS metrics behavior when file cache is enabled.
 //

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -641,7 +641,6 @@ func TestReadFile_KernelRangeReaderMetrics(t *testing.T) {
 	require.NoError(t, err, "ReadFile")
 	waitForMetricsProcessing()
 
-	require.NoError(t, err, "ReadFile")
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(1))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))

--- a/internal/fs/metrics_test.go
+++ b/internal/fs/metrics_test.go
@@ -109,7 +109,7 @@ func createTestFileSystemWithMetrics(ctx context.Context, t *testing.T, params *
 		TraceHandle:  tracing.NewNoopTracer(),
 		CacheClock:   &timeutil.SimulatedClock{},
 		BucketName:   bucketName,
-		BucketManager: &fakeBucketManager{
+		BucketManager: &fakeBucketManagerWithMetrics{
 			buckets: map[string]gcs.Bucket{
 				bucketName: bucket,
 			},
@@ -609,6 +609,44 @@ func TestReadFile_KernelMRDReaderMetrics(t *testing.T) {
 	metrics.VerifyHistogramMetric(t, ctx, reader, "gcs/request_latencies", attribute.NewSet(attribute.String("gcs_method", "MultiRangeDownloader::Add")), uint64(1))
 }
 
+func TestReadFile_KernelRangeReaderMetrics(t *testing.T) {
+	ctx := context.Background()
+	params := defaultServerConfigParams()
+	params.enableKernelReader = true
+	bucket, server, mh, reader := createTestFileSystemWithMetrics(ctx, t, params, false)
+	server = wrappers.WithMonitoring(server, mh)
+	fileName := "test.txt"
+	content := "test content"
+	createWithContents(ctx, t, bucket, fileName, content)
+	lookupOp := &fuseops.LookUpInodeOp{
+		Parent: fuseops.RootInodeID,
+		Name:   fileName,
+	}
+	err := server.LookUpInode(ctx, lookupOp)
+	require.NoError(t, err, "LookUpInode")
+	openOp := &fuseops.OpenFileOp{
+		Inode: lookupOp.Entry.Child,
+	}
+	err = server.OpenFile(ctx, openOp)
+	require.NoError(t, err, "OpenFile")
+	readOp := &fuseops.ReadFileOp{
+		Inode:  lookupOp.Entry.Child,
+		Handle: openOp.Handle,
+		Offset: 0,
+		Size:   int64(len(content)),
+		Dst:    make([]byte, len(content)),
+	}
+
+	err = server.ReadFile(ctx, readOp)
+	require.NoError(t, err, "ReadFile")
+	waitForMetricsProcessing()
+
+	require.NoError(t, err, "ReadFile")
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(1))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeParallelAttr))), int64(len(content)))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
+}
+
 func TestReadFile_GCSReaderSequentialReadMetrics(t *testing.T) {
 	testCases := []struct {
 		name            string
@@ -652,6 +690,7 @@ func TestReadFile_GCSReaderSequentialReadMetrics(t *testing.T) {
 			require.NoError(t, err, "ReadFile")
 			metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeSequentialAttr))), int64(1))
 			metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeSequentialAttr))), int64(len(content)))
+			metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(len(content)))
 		})
 	}
 }
@@ -699,6 +738,7 @@ func TestReadFile_GCSReaderRandomReadMetrics(t *testing.T) {
 
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(4))
 	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/download_bytes_count", attribute.NewSet(attribute.String("read_type", string(metrics.ReadTypeRandomAttr))), int64(30))
+	metrics.VerifyCounterMetric(t, ctx, reader, "gcs/read_bytes_count", attribute.NewSet(), int64(30))
 }
 
 func TestGetInodeAttributes_Metrics(t *testing.T) {

--- a/internal/gcsx/kernel_readers/kernel_range_reader.go
+++ b/internal/gcsx/kernel_readers/kernel_range_reader.go
@@ -133,7 +133,6 @@ func (krr *KernelRangeReader) ReadAt(ctx context.Context, req *gcsx.ReadRequest)
 
 	if krr.metrics != nil {
 		metrics.CaptureGCSReadMetrics(krr.metrics, metrics.ReadTypeParallelAttr, int64(n))
-		krr.metrics.GcsReadBytesCount(int64(n))
 	}
 
 	return resp, err


### PR DESCRIPTION
### Description
Currently read bytes count is getting double counted in Kernel Range Reader and Buffered reader since monitoringReadCloser reader (which wraps the GCS reader) increments the read bytes count internally. Hence, the readers don't have to increment it.

### Link to the issue in case of a bug fix.
b/534618517

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
