### PR TITLE
refactor(retries): Refactor StorageControlClient retry wrapper and improve encapsulation

### DIFF
--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -163,51 +163,72 @@ func (sccwros *storageControlClientWithRetry) CreateFolder(ctx context.Context,
 	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "CreateFolder", reqDescription, req.RequestId, apiCall)
 }
 
-// newStorageControlClientWithRetry creates a new storageControlClientWithRetry builder.
-// It wraps the provided StorageControlClient raw client with retry capabilities.
-// It also checks if the raw client is already a storageControlClientWithRetry, and if so,
-// unwraps the inner client to prevent nested retry wrapping.
-func newStorageControlClientWithRetry(raw StorageControlClient, clientConfig *storageutil.StorageClientConfig) *storageControlClientWithRetry {
-	// Avoid creating a nested wrapper.
+// ControlClientOption defines a functional option configuration.
+type ControlClientOption func(*clientConfigState)
+
+type clientConfigState struct {
+	folderRetries  bool
+	billingProject string
+}
+
+// WithRetriesOnFolderAPI returns an option that enables folder-level API stall retries.
+func WithRetriesOnFolderAPI() ControlClientOption {
+	return func(s *clientConfigState) {
+		s.folderRetries = true
+	}
+}
+
+// WithBillingProject returns an option that configures the billing project ID header to be injected into outgoing requests.
+func WithBillingProject(project string) ControlClientOption {
+	return func(s *clientConfigState) {
+		s.billingProject = project
+	}
+}
+
+// NewStorageControlClient creates a new StorageControlClient wrapping the provided raw client
+// with stall retry capabilities and optional billing project header injection.
+//
+// It automatically unwraps any existing wrapper instances to prevent nested wrapping.
+// By default, the wrapper only retries GetStorageLayout requests. Folder API retries
+// and billing project headers can be enabled and configured via the provided ControlClientOptions.
+func NewStorageControlClient(raw StorageControlClient, clientConfig *storageutil.StorageClientConfig, opts ...ControlClientOption) StorageControlClient {
+	var state clientConfigState
+	for _, opt := range opts {
+		opt(&state)
+	}
+
+	// Unwrap raw client to avoid nested wrappers.
 	rawClient := raw
 	var existingConfig *storageutil.RetryConfig
-	if sccwros, ok := raw.(*storageControlClientWithRetry); ok {
+	// Check if the client is wrapped with billing project header injection first, and peel it off.
+	if sccwbp, ok := rawClient.(*storageControlClientWithBillingProject); ok {
+		rawClient = sccwbp.raw
+	}
+	// Check if the client is wrapped with retry logic next, and peel it off while capturing
+	// its existing retry configuration.
+	if sccwros, ok := rawClient.(*storageControlClientWithRetry); ok {
 		rawClient = sccwros.raw
 		existingConfig = sccwros.retryConfig
 	}
+
+	// 1. Wrap with retry capability
 	retryConfig := existingConfig
 	if retryConfig == nil && clientConfig != nil {
 		retryConfig = storageutil.NewRetryConfig(clientConfig)
 	}
-	return &storageControlClientWithRetry{
+	wrapped := &storageControlClientWithRetry{
 		raw:         rawClient,
 		retryConfig: retryConfig,
 	}
-}
+	if state.folderRetries {
+		wrapped.enableRetriesOnFolderAPIs = true
+	}
 
-// WithRetriesOnFolderAPI returns a new client with folder API retries enabled.
-// Calling this method makes folder operations (CreateFolder, DeleteFolder, RenameFolder, GetFolder)
-// use the configured retry policies.
-func (scc *storageControlClientWithRetry) WithRetriesOnFolderAPI() *storageControlClientWithRetry {
-	if scc == nil {
-		return nil
+	// 2. Wrap with billing project if configured
+	if state.billingProject != "" {
+		return &storageControlClientWithBillingProject{raw: wrapped, billingProject: state.billingProject}
 	}
-	newClient := *scc
-	newClient.enableRetriesOnFolderAPIs = true
-	return &newClient
-}
-
-// WithBillingProject returns a StorageControlClient that wraps the current client
-// to inject the billing project ID header ("x-goog-user-project") into outgoing gRPC requests.
-// If the billing project is empty, it returns the current client directly without wrapping.
-func (scc *storageControlClientWithRetry) WithBillingProject(billingProject string) StorageControlClient {
-	if scc == nil {
-		return nil
-	}
-	if billingProject != "" {
-		return &storageControlClientWithBillingProject{raw: scc, billingProject: billingProject}
-	}
-	return scc
+	return wrapped
 }
 
 func storageControlClientGaxRetryOptions(clientConfig *storageutil.StorageClientConfig) []gax.CallOption {

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -80,8 +80,6 @@ func (sccwbp *storageControlClientWithBillingProject) CreateFolder(ctx context.C
 	return sccwbp.raw.CreateFolder(sccwbp.contextWithBillingProject(ctx), req, opts...)
 }
 
-
-
 // storageControlClientWithRetry is a wrapper for an existing StorageControlClient object
 // that implements time-bound, exponential backoff retries for Storage Control API calls.
 // By default, only GetStorageLayout requests are retried. Retry logic for folder-related

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -17,7 +17,6 @@ package storage
 import (
 	"context"
 	"fmt"
-	"time"
 
 	control "cloud.google.com/go/storage/control/apiv2"
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
@@ -81,23 +80,17 @@ func (sccwbp *storageControlClientWithBillingProject) CreateFolder(ctx context.C
 	return sccwbp.raw.CreateFolder(sccwbp.contextWithBillingProject(ctx), req, opts...)
 }
 
-func withBillingProject(controlClient StorageControlClient, billingProject string) StorageControlClient {
-	if billingProject != "" {
-		controlClient = &storageControlClientWithBillingProject{raw: controlClient, billingProject: billingProject}
-	}
-	return controlClient
-}
+
 
 // storageControlClientWithRetry is a wrapper for an existing StorageControlClient object
-// which implements gcsfuse-level retry logic if any of the control-client call gets stalled or returns a retryable error.
-// It makes time-bound attempts to call the underlying StorageControlClient methods,
-// retrying on errors that should be retried according to gcsfuse's retry logic.
+// that implements time-bound, exponential backoff retries for Storage Control API calls.
+// By default, only GetStorageLayout requests are retried. Retry logic for folder-related
+// API calls can be selectively enabled using the WithFolderAPIRetries builder.
+// It also provides a WithBillingProject builder to optionally inject billing project headers.
 type storageControlClientWithRetry struct {
 	raw         StorageControlClient
 	retryConfig *storageutil.RetryConfig
 
-	// Whether or not to enable retries for GetStorageLayout call.
-	enableRetriesOnStorageLayoutAPI bool
 	// Whether or not to enable retries for folder APIs.
 	enableRetriesOnFolderAPIs bool
 }
@@ -105,10 +98,6 @@ type storageControlClientWithRetry struct {
 func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Context,
 	req *controlpb.GetStorageLayoutRequest,
 	opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
-	if !sccwros.enableRetriesOnStorageLayoutAPI {
-		return sccwros.raw.GetStorageLayout(ctx, req, opts...)
-	}
-
 	apiCall := func(attemptCtx context.Context) (*controlpb.StorageLayout, error) {
 		return sccwros.raw.GetStorageLayout(attemptCtx, req, opts...)
 	}
@@ -176,37 +165,51 @@ func (sccwros *storageControlClientWithRetry) CreateFolder(ctx context.Context,
 	return storageutil.ExecuteWithRetry(ctx, sccwros.retryConfig, "CreateFolder", reqDescription, req.RequestId, apiCall)
 }
 
-// newRetryWrapper creates a new StorageControlClient with retry capabilities.
-// It accepts various parameters to configure the retry behavior.
-// The returned control client retries storage-layout.
-// It also retries folder-related APIs if `retryFolderAPIs` is true.
-func newRetryWrapper(controlClient StorageControlClient, clientConfig *storageutil.StorageClientConfig, retryDeadline, totalRetryBudget, initialBackoff time.Duration, retryFolderAPIs bool) StorageControlClient {
+// newStorageControlClientWithRetry creates a new storageControlClientWithRetry builder.
+// It wraps the provided StorageControlClient raw client with retry capabilities.
+// It also checks if the raw client is already a storageControlClientWithRetry, and if so,
+// unwraps the inner client to prevent nested retry wrapping.
+func newStorageControlClientWithRetry(raw StorageControlClient, clientConfig *storageutil.StorageClientConfig) *storageControlClientWithRetry {
 	// Avoid creating a nested wrapper.
-	raw := controlClient
-	if sccwros, ok := controlClient.(*storageControlClientWithRetry); ok {
-		raw = sccwros.raw
+	rawClient := raw
+	var existingConfig *storageutil.RetryConfig
+	if sccwros, ok := raw.(*storageControlClientWithRetry); ok {
+		rawClient = sccwros.raw
+		existingConfig = sccwros.retryConfig
 	}
-
-	retryConfig := storageutil.NewRetryConfig(clientConfig, retryDeadline, totalRetryBudget, initialBackoff)
+	retryConfig := existingConfig
+	if retryConfig == nil && clientConfig != nil {
+		retryConfig = storageutil.NewRetryConfig(clientConfig)
+	}
 	return &storageControlClientWithRetry{
-		raw:                             raw,
-		retryConfig:                     retryConfig,
-		enableRetriesOnStorageLayoutAPI: true,
-		enableRetriesOnFolderAPIs:       retryFolderAPIs,
+		raw:         rawClient,
+		retryConfig: retryConfig,
 	}
 }
 
-// withRetryOnAllAPIs wraps a StorageControlClient to do a time-bound retry approach for retryable errors for all API calls through it.
-func withRetryOnAllAPIs(controlClient StorageControlClient,
-	clientConfig *storageutil.StorageClientConfig) StorageControlClient {
-	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, true)
+// WithRetriesOnFolderAPI returns a new client with folder API retries enabled.
+// Calling this method makes folder operations (CreateFolder, DeleteFolder, RenameFolder, GetFolder)
+// use the configured retry policies.
+func (scc *storageControlClientWithRetry) WithRetriesOnFolderAPI() *storageControlClientWithRetry {
+	if scc == nil {
+		return nil
+	}
+	newClient := *scc
+	newClient.enableRetriesOnFolderAPIs = true
+	return &newClient
 }
 
-// withRetryOnStorageLayout wraps a StorageControlClient to do a time-bound retry approach for retryable errors for the GetStorageLayout call through it.
-func withRetryOnStorageLayout(controlClient StorageControlClient,
-	clientConfig *storageutil.StorageClientConfig) StorageControlClient {
-	return newRetryWrapper(controlClient, clientConfig, storageutil.DefaultRetryDeadline, storageutil.DefaultTotalRetryBudget, storageutil.DefaultInitialBackoff, false)
-
+// WithBillingProject returns a StorageControlClient that wraps the current client
+// to inject the billing project ID header ("x-goog-user-project") into outgoing gRPC requests.
+// If the billing project is empty, it returns the current client directly without wrapping.
+func (scc *storageControlClientWithRetry) WithBillingProject(billingProject string) StorageControlClient {
+	if scc == nil {
+		return nil
+	}
+	if billingProject != "" {
+		return &storageControlClientWithBillingProject{raw: scc, billingProject: billingProject}
+	}
+	return scc
 }
 
 func storageControlClientGaxRetryOptions(clientConfig *storageutil.StorageClientConfig) []gax.CallOption {

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -296,19 +296,26 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 		MaxRetrySleep:   maxRetrySleep,
 		RetryMultiplier: backoffMultiplier,
 	}
-	scc := newStorageControlClientWithRetry(controlClient, clientConfig)
+	var opts []ControlClientOption
 	if retryFolderAPIs {
-		scc = scc.WithRetriesOnFolderAPI()
+		opts = append(opts, WithRetriesOnFolderAPI())
 	}
+	scc := NewStorageControlClient(controlClient, clientConfig, opts...)
 
-	scc.retryConfig = storageutil.NewRetryConfigForTesting(
-		retryDeadline,
-		totalRetryBudget,
-		initialBackoff,
-		maxRetrySleep,
-		backoffMultiplier,
-		clientConfig.MaxRetryAttempts,
-	)
+	var retryClient *storageControlClientWithRetry
+	if rc, ok := scc.(*storageControlClientWithRetry); ok {
+		retryClient = rc
+	}
+	if retryClient != nil {
+		retryClient.retryConfig = storageutil.NewRetryConfigForTesting(
+			retryDeadline,
+			totalRetryBudget,
+			initialBackoff,
+			maxRetrySleep,
+			backoffMultiplier,
+			clientConfig.MaxRetryAttempts,
+		)
+	}
 	return scc
 }
 
@@ -652,65 +659,56 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_AllAttemptsTimeOut() {
 }
 
 func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetry_StorageLayout_WrapsClient() {
-	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	wrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig)
+	wrappedClient := NewStorageControlClient(mockClient, &clientConfig)
 
-	// Assert
 	require.NotNil(testSuite.T(), wrappedClient)
-	retryWrapper := wrappedClient
+	retryWrapper, ok := wrappedClient.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw)
 	assert.False(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs")
 }
 
 func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetry_StorageLayout_UnwrapsNestedRetryClient() {
-	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	alreadyWrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig)
+	alreadyWrappedClient := NewStorageControlClient(mockClient, &clientConfig)
 
-	// Wrap it again.
-	doubleWrappedClient := newStorageControlClientWithRetry(alreadyWrappedClient, &clientConfig)
+	doubleWrappedClient := NewStorageControlClient(alreadyWrappedClient, &clientConfig)
 
-	// Assert
 	require.NotNil(testSuite.T(), doubleWrappedClient)
-	retryWrapper := doubleWrappedClient
+	retryWrapper, ok := doubleWrappedClient.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw, "Should unwrap the nested retry client")
 	assert.NotSame(testSuite.T(), alreadyWrappedClient, retryWrapper.raw)
 	assert.False(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs")
 }
 
 func (testSuite *AllApiRetryWrapperTest) TestWithRetry_AllAPIs_WrapsClient() {
-	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	wrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithRetriesOnFolderAPI()
+	wrappedClient := NewStorageControlClient(mockClient, &clientConfig, WithRetriesOnFolderAPI())
 
-	// Assert
 	require.NotNil(testSuite.T(), wrappedClient)
-	retryWrapper := wrappedClient
+	retryWrapper, ok := wrappedClient.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw)
 	assert.True(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs")
 }
 
 func (testSuite *AllApiRetryWrapperTest) TestWithRetry_AllAPIs_UnwrapsNestedRetryClient() {
-	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	alreadyWrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithRetriesOnFolderAPI()
+	alreadyWrappedClient := NewStorageControlClient(mockClient, &clientConfig, WithRetriesOnFolderAPI())
 
-	// Wrap it again.
-	doubleWrappedClient := newStorageControlClientWithRetry(alreadyWrappedClient, &clientConfig).
-		WithRetriesOnFolderAPI()
+	doubleWrappedClient := NewStorageControlClient(alreadyWrappedClient, &clientConfig, WithRetriesOnFolderAPI())
 
-	// Assert
 	require.NotNil(testSuite.T(), doubleWrappedClient)
-	retryWrapper := doubleWrappedClient
+	retryWrapper, ok := doubleWrappedClient.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw, "Should unwrap the nested retry client")
 	assert.NotSame(testSuite.T(), alreadyWrappedClient, retryWrapper.raw)
 	assert.True(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs")
@@ -796,8 +794,7 @@ func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_EmptyStri
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithBillingProject("")
+	scc := NewStorageControlClient(mockClient, &clientConfig, WithBillingProject(""))
 
 	require.NotNil(testSuite.T(), scc)
 	// Empty string should return the *storageControlClientWithRetry without wrapping with billing project.
@@ -809,8 +806,7 @@ func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_NonEmptyS
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithBillingProject("my-project")
+	scc := NewStorageControlClient(mockClient, &clientConfig, WithBillingProject("my-project"))
 
 	require.NotNil(testSuite.T(), scc)
 	// Non-empty string should wrap the client with billing project.
@@ -822,8 +818,7 @@ func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_NonEmptyS
 func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_InjectsHeader() {
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithBillingProject("my-project")
+	scc := NewStorageControlClient(mockClient, &clientConfig, WithBillingProject("my-project"))
 	req := &controlpb.GetStorageLayoutRequest{Name: "buckets/my-bucket"}
 	// Verify that when GetStorageLayout is called, the context has outgoing metadata "x-goog-user-project: my-project"
 	mockClient.On("GetStorageLayout", mock.MatchedBy(func(ctx context.Context) bool {
@@ -844,8 +839,7 @@ func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_InjectsHe
 func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_RenameFolder_NoHeader() {
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
-		WithBillingProject("my-project")
+	scc := NewStorageControlClient(mockClient, &clientConfig, WithBillingProject("my-project"))
 	req := &controlpb.RenameFolderRequest{Name: "buckets/my-bucket/folders/f1", DestinationFolderId: "f2"}
 	// Verify that when RenameFolder is called, the context does not have outgoing metadata "x-goog-user-project"
 	mockClient.On("RenameFolder", mock.MatchedBy(func(ctx context.Context) bool {
@@ -863,18 +857,13 @@ func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_RenameFol
 	mockClient.AssertExpectations(testSuite.T())
 }
 
-func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetriesOnFolderAPI_NilReceiver() {
-	var scc *storageControlClientWithRetry
+func (testSuite *StorageLayoutRetryWrapperTest) TestNewStorageControlClient_NilRawClient() {
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	result := scc.WithRetriesOnFolderAPI()
+	scc := NewStorageControlClient(nil, &clientConfig)
 
-	assert.Nil(testSuite.T(), result)
-}
-
-func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_NilReceiver() {
-	var scc *storageControlClientWithRetry
-
-	result := scc.WithBillingProject("my-project")
-
-	assert.Nil(testSuite.T(), result)
+	require.NotNil(testSuite.T(), scc)
+	retryClient, ok := scc.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok)
+	assert.Nil(testSuite.T(), retryClient.raw)
 }

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	control "cloud.google.com/go/storage/control/apiv2"
@@ -295,7 +296,20 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 		MaxRetrySleep:   maxRetrySleep,
 		RetryMultiplier: backoffMultiplier,
 	}
-	return newRetryWrapper(t.stallingClient, clientConfig, retryDeadline, totalRetryBudget, initialBackoff, retryFolderAPIs)
+	scc := newStorageControlClientWithRetry(controlClient, clientConfig)
+	if retryFolderAPIs {
+		scc = scc.WithRetriesOnFolderAPI()
+	}
+
+	scc.retryConfig = storageutil.NewRetryConfigForTesting(
+		retryDeadline,
+		totalRetryBudget,
+		initialBackoff,
+		maxRetrySleep,
+		backoffMultiplier,
+		clientConfig.MaxRetryAttempts,
+	)
+	return scc
 }
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {
@@ -637,79 +651,68 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_AllAttemptsTimeOut() {
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
-func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetryOnStorageLayout_WrapsClient() {
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetry_StorageLayout_WrapsClient() {
 	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	// Act
-	wrappedClient := withRetryOnStorageLayout(mockClient, &clientConfig)
+	wrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig)
 
 	// Assert
 	require.NotNil(testSuite.T(), wrappedClient)
-	retryWrapper, ok := wrappedClient.(*storageControlClientWithRetry)
-	require.True(testSuite.T(), ok, "The returned client should be of type *storageControlClientWithRetry")
+	retryWrapper := wrappedClient
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw)
-	assert.True(testSuite.T(), retryWrapper.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout APIs")
 	assert.False(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs")
 }
 
-func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetryOnStorageLayout_UnwrapsNestedRetryClient() {
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetry_StorageLayout_UnwrapsNestedRetryClient() {
 	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	// Create a client that is already wrapped.
-	alreadyWrappedClient := withRetryOnStorageLayout(mockClient, &clientConfig)
+	alreadyWrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig)
 
-	// Act
 	// Wrap it again.
-	doubleWrappedClient := withRetryOnStorageLayout(alreadyWrappedClient, &clientConfig)
+	doubleWrappedClient := newStorageControlClientWithRetry(alreadyWrappedClient, &clientConfig)
 
 	// Assert
 	require.NotNil(testSuite.T(), doubleWrappedClient)
-	retryWrapper, ok := doubleWrappedClient.(*storageControlClientWithRetry)
-	require.True(testSuite.T(), ok, "The returned client should be of type *storageControlClientWithRetry")
+	retryWrapper := doubleWrappedClient
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw, "Should unwrap the nested retry client")
 	assert.NotSame(testSuite.T(), alreadyWrappedClient, retryWrapper.raw)
-	assert.True(testSuite.T(), retryWrapper.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout APIs")
 	assert.False(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs")
 }
 
-func (testSuite *AllApiRetryWrapperTest) TestWithRetryOnAllAPIs_WrapsClient() {
+func (testSuite *AllApiRetryWrapperTest) TestWithRetry_AllAPIs_WrapsClient() {
 	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
 
-	// Act
-	wrappedClient := withRetryOnAllAPIs(mockClient, &clientConfig)
+	wrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithRetriesOnFolderAPI()
 
 	// Assert
 	require.NotNil(testSuite.T(), wrappedClient)
-	retryWrapper, ok := wrappedClient.(*storageControlClientWithRetry)
-	require.True(testSuite.T(), ok, "The returned client should be of type *storageControlClientWithRetry")
+	retryWrapper := wrappedClient
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw)
-	assert.True(testSuite.T(), retryWrapper.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout APIs")
 	assert.True(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs")
 }
 
-func (testSuite *AllApiRetryWrapperTest) TestWithRetryOnAllAPIs_UnwrapsNestedRetryClient() {
+func (testSuite *AllApiRetryWrapperTest) TestWithRetry_AllAPIs_UnwrapsNestedRetryClient() {
 	// Arrange
 	mockClient := new(MockStorageControlClient)
 	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
-	// Create a client that is already wrapped.
-	alreadyWrappedClient := withRetryOnAllAPIs(mockClient, &clientConfig)
+	alreadyWrappedClient := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithRetriesOnFolderAPI()
 
-	// Act
 	// Wrap it again.
-	doubleWrappedClient := withRetryOnAllAPIs(alreadyWrappedClient, &clientConfig)
+	doubleWrappedClient := newStorageControlClientWithRetry(alreadyWrappedClient, &clientConfig).
+		WithRetriesOnFolderAPI()
 
 	// Assert
 	require.NotNil(testSuite.T(), doubleWrappedClient)
-	retryWrapper, ok := doubleWrappedClient.(*storageControlClientWithRetry)
-	require.True(testSuite.T(), ok, "The returned client should be of type *storageControlClientWithRetry")
+	retryWrapper := doubleWrappedClient
 	assert.Same(testSuite.T(), mockClient, retryWrapper.raw, "Should unwrap the nested retry client")
 	assert.NotSame(testSuite.T(), alreadyWrappedClient, retryWrapper.raw)
-	assert.True(testSuite.T(), retryWrapper.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout APIs")
 	assert.True(testSuite.T(), retryWrapper.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs")
 }
 
@@ -787,4 +790,91 @@ func (testSuite *ControlClientGaxRetryWrapperTest) TestAddGaxRetriesForFolderAPI
 	assert.Len(testSuite.T(), rawControlClient.CallOptions.GetFolder, 2)       // GetFolder should have GAX retries applied
 	assert.Len(testSuite.T(), rawControlClient.CallOptions.CreateFolder, 2)    // CreateFolder should have GAX retries applied
 	assert.Len(testSuite.T(), rawControlClient.CallOptions.RenameFolder, 2)    // RenameFolder should have GAX retries applied
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_EmptyString() {
+	mockClient := new(MockStorageControlClient)
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+
+	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithBillingProject("")
+
+	require.NotNil(testSuite.T(), scc)
+	// Empty string should return the *storageControlClientWithRetry without wrapping with billing project.
+	_, ok := scc.(*storageControlClientWithRetry)
+	assert.True(testSuite.T(), ok, "Expected *storageControlClientWithRetry type when billing project is empty")
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_NonEmptyString() {
+	mockClient := new(MockStorageControlClient)
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+
+	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithBillingProject("my-project")
+
+	require.NotNil(testSuite.T(), scc)
+	// Non-empty string should wrap the client with billing project.
+	wrappedClient, ok := scc.(*storageControlClientWithBillingProject)
+	assert.True(testSuite.T(), ok, "Expected *storageControlClientWithBillingProject type")
+	assert.Equal(testSuite.T(), "my-project", wrappedClient.billingProject)
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_InjectsHeader() {
+	mockClient := new(MockStorageControlClient)
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithBillingProject("my-project")
+	req := &controlpb.GetStorageLayoutRequest{Name: "buckets/my-bucket"}
+	// Verify that when GetStorageLayout is called, the context has outgoing metadata "x-goog-user-project: my-project"
+	mockClient.On("GetStorageLayout", mock.MatchedBy(func(ctx context.Context) bool {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			return false
+		}
+		values := md.Get("x-goog-user-project")
+		return len(values) == 1 && values[0] == "my-project"
+	}), req, mock.Anything).Return(&controlpb.StorageLayout{}, nil).Once()
+
+	_, err := scc.GetStorageLayout(context.Background(), req)
+
+	assert.NoError(testSuite.T(), err)
+	mockClient.AssertExpectations(testSuite.T())
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_RenameFolder_NoHeader() {
+	mockClient := new(MockStorageControlClient)
+	clientConfig := storageutil.GetDefaultStorageClientConfig(keyFile)
+	scc := newStorageControlClientWithRetry(mockClient, &clientConfig).
+		WithBillingProject("my-project")
+	req := &controlpb.RenameFolderRequest{Name: "buckets/my-bucket/folders/f1", DestinationFolderId: "f2"}
+	// Verify that when RenameFolder is called, the context does not have outgoing metadata "x-goog-user-project"
+	mockClient.On("RenameFolder", mock.MatchedBy(func(ctx context.Context) bool {
+		md, ok := metadata.FromOutgoingContext(ctx)
+		if !ok {
+			return true // No metadata is correct
+		}
+		values := md.Get("x-goog-user-project")
+		return len(values) == 0
+	}), req, mock.Anything).Return(&control.RenameFolderOperation{}, nil).Once()
+
+	_, err := scc.RenameFolder(context.Background(), req)
+
+	assert.NoError(testSuite.T(), err)
+	mockClient.AssertExpectations(testSuite.T())
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithRetriesOnFolderAPI_NilReceiver() {
+	var scc *storageControlClientWithRetry
+
+	result := scc.WithRetriesOnFolderAPI()
+
+	assert.Nil(testSuite.T(), result)
+}
+
+func (testSuite *StorageLayoutRetryWrapperTest) TestWithBillingProject_NilReceiver() {
+	var scc *storageControlClientWithRetry
+
+	result := scc.WithBillingProject("my-project")
+
+	assert.Nil(testSuite.T(), result)
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -415,10 +415,12 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		if err != nil {
 			return nil, fmt.Errorf("could not add custom gax retries to StorageControl Client: %w", err)
 		}
-		// Wrap the control client with retry-on-stall logic.
-		// This will retry on only on GetStorageLayout call for all buckets.
-		controlClient = newStorageControlClientWithRetry(rawStorageControlClientWithoutGaxRetries, &clientConfig).
-			WithBillingProject(billingProject)
+		// Create a default storage control client with billing project.
+		// This client is used during mount initialization and subsequent bucket type lookups
+		// for GetStorageLayout operations only, and has stall retries enabled by default on GetStorageLayout calls.
+		controlClient = NewStorageControlClient(rawStorageControlClientWithoutGaxRetries, &clientConfig,
+			WithBillingProject(billingProject),
+		)
 	} else {
 		logger.Infof("Skipping storage control client creation because custom-endpoint %q was passed, which is assumed to be a storage testbench server because of 'localhost' in it.", clientConfig.CustomEndpoint)
 	}
@@ -483,8 +485,8 @@ func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Con
 	return sh.httpClient, err
 }
 
-// controlClientForBucketHandle returns a storage control client for the given bucket handle,
-// which takes care of properly adding support for retries and for billing project.
+// controlClientForBucketHandle returns a bucket-specific StorageControlClient which is used after the mount is complete.
+// Depending on the bucket type, it calls NewStorageControlClient with appropriate options.
 func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType, billingProject string) StorageControlClient {
 	if sh.rawStorageControlClientWithGaxRetries == nil || sh.rawStorageControlClientWithoutGaxRetries == nil {
 		return nil
@@ -492,16 +494,18 @@ func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType
 
 	if bucketType.IsRapid() || sh.clientConfig.ExperimentalNonrapidFolderApiStallRetry {
 		// For rapid buckets or when non-rapid folder API stall retries are enabled, use the raw
-		// control client without gax retries, and wrap it with storageControlClientWithRetry with retries on folder API and wrap with billing project.
-		return newStorageControlClientWithRetry(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig).
-			WithRetriesOnFolderAPI().
-			WithBillingProject(billingProject)
+		// control client without gax retries, and wrap it with stall retries on folder APIs and the billing project.
+		return NewStorageControlClient(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig,
+			WithRetriesOnFolderAPI(),
+			WithBillingProject(billingProject),
+		)
 	}
 
 	// For non-rapid buckets, use the raw client that already has GAX retries applied.
-	// Wrap it with storageControlClientWithRetry to add stall retries for GetStorageLayout and wrap with billing project.
-	return newStorageControlClientWithRetry(sh.rawStorageControlClientWithGaxRetries, &sh.clientConfig).
-		WithBillingProject(billingProject)
+	// Wrap it with stall retries for GetStorageLayout and the billing project.
+	return NewStorageControlClient(sh.rawStorageControlClientWithGaxRetries, &sh.clientConfig,
+		WithBillingProject(billingProject),
+	)
 }
 
 func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error) {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -78,8 +78,12 @@ type storageClient struct {
 	grpcClientWithBidiConfig *storage.Client
 	clientConfig             storageutil.StorageClientConfig
 	// rawStorageControlClientWithoutGaxRetries is without any retries.
+	// WARNING: Do not mutate this client or its CallOptions in-place after initialization,
+	// as it is a shared template client used to derive bucket-specific control clients.
 	rawStorageControlClientWithoutGaxRetries *control.StorageControlClient
 	// rawStorageControlClientWithGaxRetries is with retry for Folder APIs.
+	// WARNING: Do not mutate this client or its CallOptions in-place after initialization,
+	// as it is a shared template client used to derive bucket-specific control clients.
 	rawStorageControlClientWithGaxRetries *control.StorageControlClient
 	// storageControlClient is with retry for GetStorageLayout and with handling for billing project.
 	storageControlClient StorageControlClient
@@ -487,18 +491,15 @@ func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType
 	}
 
 	if bucketType.IsRapid() || sh.clientConfig.ExperimentalNonrapidFolderApiStallRetry {
-		// sh.storageControlClient already contains handling for billing project,
-		// and enhanced retries for GetStorageLayout API call. Extending it here for
-		// retries for folder APIs.
-		// For rapid buckets, wrap the control client with retry-on-all-APIs.
+		// For rapid buckets or when non-rapid folder API stall retries are enabled, use the raw
+		// control client without gax retries, and wrap it with storageControlClientWithRetry with retries on folder API and wrap with billing project.
 		return newStorageControlClientWithRetry(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig).
 			WithRetriesOnFolderAPI().
 			WithBillingProject(billingProject)
 	}
 
-	// Apply GAX retries to the raw storage control client and returns a copy of it,
-	// as it is important to avoid overwriting it,
-	// as it is used with enhanced retries used by zonal buckets.
+	// For non-rapid buckets, use the raw client that already has GAX retries applied.
+	// Wrap it with storageControlClientWithRetry to add stall retries for GetStorageLayout and wrap with billing project.
 	return newStorageControlClientWithRetry(sh.rawStorageControlClientWithGaxRetries, &sh.clientConfig).
 		WithBillingProject(billingProject)
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -239,7 +239,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		RetryMultiplier:  clientConfig.RetryMultiplier,
 		MaxRetryAttempts: directPathDetectionMaxAttempts,
 	}
-	retryConfig := storageutil.NewRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration, storageutil.DefaultInitialBackoff)
+	retryConfig := storageutil.NewCustomRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration)
 
 	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
 		return bucketHandle.Object(testObject).Attrs(attemptCtx)
@@ -411,11 +411,10 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		if err != nil {
 			return nil, fmt.Errorf("could not add custom gax retries to StorageControl Client: %w", err)
 		}
-		// special handling for mounts created with custom billing projects.
-		controlClientWithBillingProject := withBillingProject(rawStorageControlClientWithoutGaxRetries, billingProject)
 		// Wrap the control client with retry-on-stall logic.
 		// This will retry on only on GetStorageLayout call for all buckets.
-		controlClient = withRetryOnStorageLayout(controlClientWithBillingProject, &clientConfig)
+		controlClient = newStorageControlClientWithRetry(rawStorageControlClientWithoutGaxRetries, &clientConfig).
+			WithBillingProject(billingProject)
 	} else {
 		logger.Infof("Skipping storage control client creation because custom-endpoint %q was passed, which is assumed to be a storage testbench server because of 'localhost' in it.", clientConfig.CustomEndpoint)
 	}
@@ -487,23 +486,21 @@ func (sh *storageClient) controlClientForBucketHandle(bucketType *gcs.BucketType
 		return nil
 	}
 
-	var controlClientWithoutBillingProject StorageControlClient
 	if bucketType.IsRapid() || sh.clientConfig.ExperimentalNonrapidFolderApiStallRetry {
 		// sh.storageControlClient already contains handling for billing project,
 		// and enhanced retries for GetStorageLayout API call. Extending it here for
 		// retries for folder APIs.
 		// For rapid buckets, wrap the control client with retry-on-all-APIs.
-		controlClientWithoutBillingProject = withRetryOnAllAPIs(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig)
-	} else {
-		// Apply GAX retries to the raw storage control client and returns a copy of it,
-		// as it is important to avoid overwriting it,
-		// as it is used with enhanced retries used by zonal buckets.
-		controlClientWithoutBillingProject = withRetryOnStorageLayout(sh.rawStorageControlClientWithGaxRetries, &sh.clientConfig)
+		return newStorageControlClientWithRetry(sh.rawStorageControlClientWithoutGaxRetries, &sh.clientConfig).
+			WithRetriesOnFolderAPI().
+			WithBillingProject(billingProject)
 	}
 
-	// Special handling for mounts created with custom billing projects.
-	// Wrap it with billing-project, if there is any.
-	return withBillingProject(controlClientWithoutBillingProject, billingProject)
+	// Apply GAX retries to the raw storage control client and returns a copy of it,
+	// as it is important to avoid overwriting it,
+	// as it is used with enhanced retries used by zonal buckets.
+	return newStorageControlClientWithRetry(sh.rawStorageControlClientWithGaxRetries, &sh.clientConfig).
+		WithBillingProject(billingProject)
 }
 
 func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, billingProject string) (bh *bucketHandle, err error) {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -313,7 +313,6 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithoutBillingProject() 
 	retrierControlClient, ok := storageClient.storageControlClient.(*storageControlClientWithRetry)
 	require.True(testSuite.T(), ok, "retrierControlClient should be of type *storageControlClientWithRetry")
 	require.NotNil(testSuite.T(), retrierControlClient, "retrierControlClient should not be nil")
-	assert.True(testSuite.T(), retrierControlClient.enableRetriesOnStorageLayoutAPI, "enableRetriesOnStorageLayoutAPI should be true")
 	assert.False(testSuite.T(), retrierControlClient.enableRetriesOnFolderAPIs, "enableRetriesOnFolderAPIs should be false")
 	// Confirm that it has no underlying storageControlClientWithBillingProject in it.
 	_, ok = retrierControlClient.raw.(*storageControlClientWithBillingProject)
@@ -334,16 +333,18 @@ func (testSuite *StorageHandleTest) TestNewStorageHandleWithBillingProject() {
 	storageClient, ok := handleCreated.(*storageClient)
 	assert.NotNil(testSuite.T(), storageClient)
 	assert.True(testSuite.T(), ok)
-	retrierControlClient := storageClient.storageControlClient.(*storageControlClientWithRetry)
 	// Confirm that the returned storage-handle's control-client is of type storageControlClientWithBillingProject
 	// and its billing-project is same as the one passed while
 	// creating the storage-handle.
 	// Check that storageControlClient is wrapped correctly and billing project is set.
-	billingProjectControlClient, ok := retrierControlClient.raw.(*storageControlClientWithBillingProject)
-	require.True(testSuite.T(), ok, "raw should be of type *storageControlClientWithBillingProject")
+	billingProjectControlClient, ok := storageClient.storageControlClient.(*storageControlClientWithBillingProject)
+	require.True(testSuite.T(), ok, "storageControlClient should be of type *storageControlClientWithBillingProject")
 	require.NotNil(testSuite.T(), billingProjectControlClient, "storageControlClientWithBillingProject should not be nil")
 	assert.Equal(testSuite.T(), projectID, billingProjectControlClient.billingProject, "billingProject should match the provided projectID")
-	assert.NotNil(testSuite.T(), billingProjectControlClient.raw, "raw client inside storageControlClientWithBillingProject should not be nil")
+	retrierControlClient, ok := billingProjectControlClient.raw.(*storageControlClientWithRetry)
+	require.True(testSuite.T(), ok, "raw should be of type *storageControlClientWithRetry")
+	require.NotNil(testSuite.T(), retrierControlClient, "retrierControlClient should not be nil")
+	assert.NotNil(testSuite.T(), retrierControlClient.raw, "raw client inside storageControlClientWithRetry should not be nil")
 }
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleWithInvalidClientProtocol() {
@@ -1006,7 +1007,6 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle() {
 			}
 			retryWrapper, ok := underlyingControlClient.(*storageControlClientWithRetry)
 			require.True(testSuite.T(), ok, "Expected a retry wrapper")
-			assert.True(testSuite.T(), retryWrapper.enableRetriesOnStorageLayoutAPI, "Retries should always be enabled for storage layout APIs")
 			assert.Equal(testSuite.T(), tc.expectFolderRetries, retryWrapper.enableRetriesOnFolderAPIs)
 			gaxClient, ok := retryWrapper.raw.(*control.StorageControlClient)
 			require.True(testSuite.T(), ok)
@@ -1041,7 +1041,6 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	controlClientWithAllRetriesNonZB, ok := controlClientForNonZB.(*storageControlClientWithRetry)
 	require.True(testSuite.T(), ok)
 	require.NotNil(testSuite.T(), controlClientWithAllRetriesNonZB)
-	assert.True(testSuite.T(), controlClientWithAllRetriesNonZB.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout API on non-zonal buckets")
 	assert.False(testSuite.T(), controlClientWithAllRetriesNonZB.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs on non-zonal buckets")
 	require.Same(testSuite.T(), mockRawControlClientWithRetries, controlClientWithAllRetriesNonZB.raw)
 
@@ -1057,7 +1056,6 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	require.True(testSuite.T(), ok, "Expected a control client with retry")
 	assert.Same(testSuite.T(), mockRawControlClientWithoutRetries, controlClientWithRetry.raw)
 	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs on zonal buckets")
-	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout API on zonal buckets")
 	require.Same(testSuite.T(), mockRawControlClientWithoutRetries, controlClientWithRetry.raw)
 }
 
@@ -1089,7 +1087,6 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	controlClientWithAllRetriesNonZB, ok := controlClientWithBillingProjectAndAllRetriesForNonZB.raw.(*storageControlClientWithRetry)
 	require.True(testSuite.T(), ok)
 	require.NotNil(testSuite.T(), controlClientWithAllRetriesNonZB)
-	assert.True(testSuite.T(), controlClientWithAllRetriesNonZB.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout API on non-zonal buckets")
 	assert.False(testSuite.T(), controlClientWithAllRetriesNonZB.enableRetriesOnFolderAPIs, "Retries should not be enabled for folder APIs on non-zonal buckets")
 	require.Same(testSuite.T(), mockRawControlClientWithRetries, controlClientWithAllRetriesNonZB.raw)
 
@@ -1109,6 +1106,5 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	require.True(testSuite.T(), ok, "Expected a control client with retry")
 	require.NotNil(testSuite.T(), controlClientWithRetry)
 	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs on zonal buckets")
-	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout API on zonal buckets")
 	assert.Same(testSuite.T(), mockRawControlClientWithoutRetries, controlClientWithRetry.raw)
 }

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -58,7 +58,7 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 		logger.Infof("Bypassing UniverseDomain metadata server lookup on standard commercial GCP setup")
 		domain = auth2.UniverseDomainDefault
 	} else {
-		retryConfig := NewRetryConfig(config, DefaultRetryDeadline, DefaultTotalRetryBudget, DefaultInitialBackoff)
+		retryConfig := NewRetryConfig(config)
 
 		apiCall := func(attemptCtx context.Context) (string, error) {
 			d, err := cred.UniverseDomain(attemptCtx)

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -101,16 +101,37 @@ type RetryConfig struct {
 	BackoffConfig exponentialBackoffConfig
 }
 
-// NewRetryConfig creates a new RetryConfig.
-func NewRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetryBudget, initialBackoff time.Duration) *RetryConfig {
+// NewCustomRetryConfig creates a new RetryConfig with custom retry timeout parameters.
+func NewCustomRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetryBudget time.Duration) *RetryConfig {
 	return &RetryConfig{
 		RetryDeadline:    retryDeadline,
 		TotalRetryBudget: totalRetryBudget,
 		MaxAttempts:      clientConfig.MaxRetryAttempts,
 		BackoffConfig: exponentialBackoffConfig{
-			initial:    initialBackoff,
+			initial:    DefaultInitialBackoff,
 			max:        clientConfig.MaxRetrySleep,
 			multiplier: clientConfig.RetryMultiplier,
+		},
+	}
+}
+
+// NewRetryConfig creates a new RetryConfig using the standard defaults for
+// deadline and total budget, combined with the user-provided clientConfig.
+func NewRetryConfig(clientConfig *StorageClientConfig) *RetryConfig {
+	return NewCustomRetryConfig(clientConfig, DefaultRetryDeadline, DefaultTotalRetryBudget)
+}
+
+// NewRetryConfigForTesting creates a RetryConfig with custom parameters for testing.
+// It is intended for use in tests of other packages (like package storage) to avoid slow tests.
+func NewRetryConfigForTesting(retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, retryMultiplier float64, maxAttempts int) *RetryConfig {
+	return &RetryConfig{
+		RetryDeadline:    retryDeadline,
+		TotalRetryBudget: totalRetryBudget,
+		MaxAttempts:      maxAttempts,
+		BackoffConfig: exponentialBackoffConfig{
+			initial:    initialBackoff,
+			max:        maxRetrySleep,
+			multiplier: retryMultiplier,
 		},
 	}
 }

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -219,7 +219,7 @@ type RetryConfigTestSuite struct {
 	suite.Suite
 }
 
-func (t *RetryConfigTestSuite) TestNewRetryConfig() {
+func (t *RetryConfigTestSuite) TestNewCustomRetryConfig() {
 	// Arrange
 	clientConfig := &StorageClientConfig{
 		MaxRetrySleep:   10 * time.Second,
@@ -227,16 +227,34 @@ func (t *RetryConfigTestSuite) TestNewRetryConfig() {
 	}
 	retryDeadline := 5 * time.Second
 	totalRetryBudget := 30 * time.Second
-	initialBackoff := 500 * time.Millisecond
 
 	// Act
-	retryConfig := NewRetryConfig(clientConfig, retryDeadline, totalRetryBudget, initialBackoff)
+	retryConfig := NewCustomRetryConfig(clientConfig, retryDeadline, totalRetryBudget)
 
 	// Assert
 	assert.NotNil(t.T(), retryConfig)
 	assert.Equal(t.T(), retryDeadline, retryConfig.RetryDeadline)
 	assert.Equal(t.T(), totalRetryBudget, retryConfig.TotalRetryBudget)
-	assert.Equal(t.T(), initialBackoff, retryConfig.BackoffConfig.initial)
+	assert.Equal(t.T(), DefaultInitialBackoff, retryConfig.BackoffConfig.initial)
+	assert.Equal(t.T(), clientConfig.MaxRetrySleep, retryConfig.BackoffConfig.max)
+	assert.Equal(t.T(), clientConfig.RetryMultiplier, retryConfig.BackoffConfig.multiplier)
+}
+
+func (t *RetryConfigTestSuite) TestNewRetryConfig() {
+	// Arrange
+	clientConfig := &StorageClientConfig{
+		MaxRetrySleep:   10 * time.Second,
+		RetryMultiplier: 2.5,
+	}
+
+	// Act
+	retryConfig := NewRetryConfig(clientConfig)
+
+	// Assert
+	assert.NotNil(t.T(), retryConfig)
+	assert.Equal(t.T(), DefaultRetryDeadline, retryConfig.RetryDeadline)
+	assert.Equal(t.T(), DefaultTotalRetryBudget, retryConfig.TotalRetryBudget)
+	assert.Equal(t.T(), DefaultInitialBackoff, retryConfig.BackoffConfig.initial)
 	assert.Equal(t.T(), clientConfig.MaxRetrySleep, retryConfig.BackoffConfig.max)
 	assert.Equal(t.T(), clientConfig.RetryMultiplier, retryConfig.BackoffConfig.multiplier)
 }


### PR DESCRIPTION
### Description
This PR simplifies and refactors the retry wrapping logic for the gRPC StorageControlClient (used for HNS buckets on both RAPID and STANDARD storage class). It replaces legacy positional wrapper functions with a unified functional positional options, improves overall package encapsulation, and adds safety checks.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Run as part of pre-submits both zonal and standard e2e.

### Any backward incompatible change? If so, please explain.
NONE