### PR TITLE
style(gcsx): use `gofmt -s -w .` instead of `go fmt` for formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Formatting and Imports check
       run: |
         goimports -w .
-        go fmt ./...
+        gofmt -s -w .
         go mod tidy
         git diff --exit-code --name-only
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ imports: generate
 	goimports -w .
 
 fmt: imports
-	go mod tidy && go fmt ./...
+	go mod tidy && gofmt -s -w .
 
 vet: fmt
 	go vet ./...

--- a/internal/gcsx/compose_object_creator.go
+++ b/internal/gcsx/compose_object_creator.go
@@ -137,12 +137,12 @@ func (oc *composeObjectCreator) Create(
 			DstGenerationPrecondition:     &srcObject.Generation,
 			DstMetaGenerationPrecondition: &srcObject.MetaGeneration,
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name:       srcObject.Name,
 					Generation: srcObject.Generation,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name:       tmp.Name,
 					Generation: tmp.Generation,
 				},

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -1817,7 +1817,7 @@ func (t *composeTest) OneSimpleSource() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 			},
@@ -1872,11 +1872,11 @@ func (t *composeTest) TwoSimpleSources() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -1993,19 +1993,19 @@ func (t *composeTest) RepeatedSources() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2059,11 +2059,11 @@ func (t *composeTest) CompositeSources() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "2",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2080,15 +2080,15 @@ func (t *composeTest) CompositeSources() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[2].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[2].Name,
 				},
 			},
@@ -2141,11 +2141,11 @@ func (t *composeTest) Metadata() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2184,11 +2184,11 @@ func (t *composeTest) DestinationNameMatchesSource() {
 		&gcs.ComposeObjectsRequest{
 			DstName: sources[0].Name,
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2225,15 +2225,15 @@ func (t *composeTest) OneSourceDoesntExist() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: "blah",
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2264,12 +2264,12 @@ func (t *composeTest) ExplicitGenerations_Exist() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name:       sources[0].Name,
 					Generation: sources[0].Generation,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name:       sources[1].Name,
 					Generation: sources[1].Generation,
 				},
@@ -2299,17 +2299,17 @@ func (t *composeTest) ExplicitGenerations_OneDoesntExist() {
 		&gcs.ComposeObjectsRequest{
 			DstName: "foo",
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name:       sources[0].Name,
 					Generation: sources[0].Generation,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name:       sources[1].Name,
 					Generation: sources[1].Generation + 1,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name:       sources[2].Name,
 					Generation: sources[2].Generation,
 				},
@@ -2341,11 +2341,11 @@ func (t *composeTest) DestinationExists_NoPreconditions() {
 		&gcs.ComposeObjectsRequest{
 			DstName: sources[0].Name,
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2385,11 +2385,11 @@ func (t *composeTest) DestinationExists_GenerationPreconditionNotSatisfied() {
 			DstGenerationPrecondition: &precond,
 
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2425,11 +2425,11 @@ func (t *composeTest) DestinationExists_MetaGenerationPreconditionNotSatisfied()
 			DstMetaGenerationPrecondition: &precond,
 
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2466,11 +2466,11 @@ func (t *composeTest) DestinationExists_PreconditionsSatisfied() {
 			DstMetaGenerationPrecondition: &sources[0].MetaGeneration,
 
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2510,11 +2510,11 @@ func (t *composeTest) DestinationDoesntExist_PreconditionNotSatisfied() {
 			DstGenerationPrecondition: &precond,
 
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2548,11 +2548,11 @@ func (t *composeTest) DestinationDoesntExist_PreconditionSatisfied() {
 			DstGenerationPrecondition: &precond,
 
 			Sources: []gcs.ComposeSource{
-				gcs.ComposeSource{
+				{
 					Name: sources[0].Name,
 				},
 
-				gcs.ComposeSource{
+				{
 					Name: sources[1].Name,
 				},
 			},
@@ -2661,8 +2661,8 @@ func (t *composeTest) ComponentCountLimits() {
 	req = &gcs.ComposeObjectsRequest{
 		DstName: "foo",
 		Sources: []gcs.ComposeSource{
-			gcs.ComposeSource{Name: large.Name},
-			gcs.ComposeSource{Name: small.Name},
+			{Name: large.Name},
+			{Name: small.Name},
 		},
 	}
 
@@ -2689,8 +2689,8 @@ func (t *composeTest) InterestingNames() {
 				&gcs.ComposeObjectsRequest{
 					DstName: name,
 					Sources: []gcs.ComposeSource{
-						gcs.ComposeSource{Name: srcName},
-						gcs.ComposeSource{Name: srcName},
+						{Name: srcName},
+						{Name: srcName},
 					},
 				})
 
@@ -2723,8 +2723,8 @@ func (t *composeTest) IllegalNames() {
 				&gcs.ComposeObjectsRequest{
 					DstName: name,
 					Sources: []gcs.ComposeSource{
-						gcs.ComposeSource{Name: srcName},
-						gcs.ComposeSource{Name: srcName},
+						{Name: srcName},
+						{Name: srcName},
 					},
 				})
 


### PR DESCRIPTION
### Description
- Updated the `fmt` target in `Makefile` to use `gofmt -s -w .` so that redundant composite literal types are automatically simplified during format checks.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Ran `make build` locally to verify successful compilation, formatting, and linting (`golangci-lint` clean).
2. Unit tests - Verified tests build successfully via `make build`.
3. Integration tests - N/A (formatting and style updates only).

### Any backward incompatible change? If so, please explain.
N/A
