### PR TITLE
docs(skills): add ssh-connection-management agent skill

### DIFF
--- a/.agents/skills/ssh-connection-management/SKILL.md
+++ b/.agents/skills/ssh-connection-management/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: ssh-connection-management
+description: Guides on establishing persistent master SSH multiplexing sockets at ~/.ssh/sockets/<TARGET_NAME>.sock using ssh -N -M -S, testing connection liveness, removing stale control sockets, and recreating sockets following user group modifications like docker usermod updates.
+---
+
+# SSH Connection Management for GCSFuse NPI
+
+This skill guides you through establishing, managing, and troubleshooting persistent SSH socket multiplexing connections to target GCE VMs or GKE intermediate controller VMs. Socket multiplexing speeds up command execution and maintains session resilience across automated workflow steps.
+
+## Prerequisites & Trigger Conditions
+
+### Prerequisites
+1. **GCP Compute SSH Keys**: Local SSH key pair present at `~/.ssh/google_compute_engine` (or standard `~/.ssh/id_rsa`).
+2. **GCP Authentication**: Local `gcloud` authenticated with compute viewer/admin permissions.
+3. **Network Reachability**: Internal IP or hostname reachability to target VM (e.g. `nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com`).
+4. **OpenSSH Client**: Local OpenSSH client supporting ControlMaster options (`-M`, `-S`).
+
+### Trigger Conditions
+- Executed prior to running remote commands, setup scripts, conformance test suites, or benchmark runs on target GCE VMs or GKE intermediate VMs.
+- Triggered when SSH connections fail due to stale socket files ("Control socket connect failed").
+- Triggered when user permissions on target VM are modified (e.g., adding user to `docker` group) requiring session group ID refresh.
+
+## Input/Output Contract
+
+### Inputs
+- **Target Connection Details**:
+  - Target Name (`<TARGET_NAME>`, e.g., `gce-c4-ssd` from `targets.json`).
+  - VM Name (`<VM_NAME>`).
+  - Zone (`<ZONE>`).
+  - GCP Project ID (`<PROJECT_ID>`).
+  - SSH User (`<SSH_USER>`).
+- **Socket Cache Directory**: `~/.ssh/sockets/`.
+
+### Outputs
+- **Active Master Socket File**: Unix domain socket located at `~/.ssh/sockets/<TARGET_NAME>.sock`.
+- **Background SSH Process**: Persistent background `ssh -N -M` process holding the master channel open.
+
+## Step-by-Step Procedure
+
+### Step 1: Create Socket Cache Directory
+
+Ensure local socket directory exists:
+```bash
+mkdir -p ~/.ssh/sockets
+```
+
+### Step 2: Clean Up Stale Sockets
+
+Before starting a master connection, remove any pre-existing or broken socket file for the target:
+```bash
+rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
+```
+
+### Step 3: Establish Master SSH Connection
+
+Launch the persistent master SSH connection in the background (or persistent terminal):
+```bash
+ssh -N -M -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
+```
+
+Key options explained:
+- `-N`: Do not execute a remote command (background connection mode).
+- `-M`: Place the SSH client into master mode for connection sharing.
+- `-S ~/.ssh/sockets/<TARGET_NAME>.sock`: Path to the control socket.
+- `-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null`: Prevent interactive host key prompts.
+
+### Step 4: Verify Connection Liveness
+
+Test remote command execution over the master socket:
+```bash
+ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "echo 'Connection Alive'"
+```
+
+### Step 5: Refreshing / Recreating Sockets
+
+If user permissions change on the remote VM (e.g., after adding the user to the `docker` group via `usermod -aG docker`):
+1. Terminate/remove the master socket:
+   ```bash
+   rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
+   ```
+2. Re-establish the master connection by repeating Step 3.
+
+## Failure Modes & Edge Cases
+
+| Failure Scenario | Root Cause | Remediation / Recovery Action |
+|---|---|---|
+| **`Control socket connect failed: Connection refused`** | Master SSH process died unexpectedly, leaving a dead socket file | Delete stale socket file (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`) and re-run master connection command. |
+| **`Permission Denied (publickey)`** | SSH key `~/.ssh/google_compute_engine` missing or expired GCP IAM SSH login credentials | Run `gcloud compute config-default-ssh-keys` or `gcloud compute ssh <VM_NAME> --zone=<ZONE>` to refresh SSH keys. |
+| **Permission Group Refresh Delay (Docker)** | Added user to `docker` group, but commands fail with `permission denied while trying to connect to Docker daemon` | Active SSH master session retains original group IDs. Remove socket (`rm -f ~/.ssh/sockets/*.sock`) and start new master SSH socket. |
+| **Connection Drop / Network Disconnect** | Remote VM rebooted or network path reset | Remove stale socket and re-establish master SSH connection. |
+
+## Verification Checks
+
+1. **Local Socket File Check**: Confirm socket file exists and is a active socket file:
+   ```bash
+   test -S ~/.ssh/sockets/<TARGET_NAME>.sock && echo "SOCKET_EXISTS"
+   ```
+2. **Remote Echo Check**: Confirm commands execute over multiplexed socket:
+   ```bash
+   ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "echo 'Connection Alive'"
+   ```

--- a/.agents/skills/ssh-connection-management/SKILL.md
+++ b/.agents/skills/ssh-connection-management/SKILL.md
@@ -1,30 +1,30 @@
 ---
 name: ssh-connection-management
-description: Guides on establishing persistent master SSH multiplexing sockets at ~/.ssh/sockets/<TARGET_NAME>.sock using ssh -N -M -S, testing connection liveness, removing stale control sockets, and recreating sockets following user group modifications like docker usermod updates.
+description: Guides on establishing persistent master SSH multiplexing sockets at ~/.ssh/sockets/<TARGET_NAME>.sock using ssh -f -N -M -S, testing connection liveness, gracefully terminating via -O exit, removing stale control sockets, and recreating sockets when remote user permissions or groups change.
 ---
 
-# SSH Connection Management for GCSFuse NPI
+# SSH Connection Management
 
-This skill guides you through establishing, managing, and troubleshooting persistent SSH socket multiplexing connections to target GCE VMs or GKE intermediate controller VMs. Socket multiplexing speeds up command execution and maintains session resilience across automated workflow steps.
+This skill guides you through establishing, managing, and troubleshooting persistent SSH socket multiplexing connections to target GCE VMs or remote VMs. Socket multiplexing speeds up command execution and maintains session resilience across automated workflow steps such as remote testing, benchmarking, or environment management.
 
 ## Prerequisites & Trigger Conditions
 
 ### Prerequisites
 1. **GCP Compute SSH Keys**: Local SSH key pair present at `~/.ssh/google_compute_engine` (or standard `~/.ssh/id_rsa`).
 2. **GCP Authentication**: Local `gcloud` authenticated with compute viewer/admin permissions.
-3. **Network Reachability**: Internal IP or hostname reachability to target VM (e.g. `nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com`).
+3. **Network Reachability**: Internal IP or hostname reachability to target VM (e.g. `nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com` or `<REMOTE_HOST>`).
 4. **OpenSSH Client**: Local OpenSSH client supporting ControlMaster options (`-M`, `-S`).
 
 ### Trigger Conditions
-- Executed prior to running remote commands, setup scripts, conformance test suites, or benchmark runs on target GCE VMs or GKE intermediate VMs.
+- Executed prior to running remote commands, setup scripts, conformance test suites, benchmarking, or environment management on target GCE or remote VMs.
 - Triggered when SSH connections fail due to stale socket files ("Control socket connect failed").
-- Triggered when user permissions on target VM are modified (e.g., adding user to `docker` group) requiring session group ID refresh.
+- Triggered when user permissions or group memberships on target VM are modified requiring session group ID refresh.
 
 ## Input/Output Contract
 
 ### Inputs
 - **Target Connection Details**:
-  - Target Name (`<TARGET_NAME>`, e.g., `gce-c4-ssd` from `targets.json`).
+  - Target Name (`<TARGET_NAME>`, e.g., `gce-c4-ssd` or target VM identifier).
   - VM Name (`<VM_NAME>`).
   - Zone (`<ZONE>`).
   - GCP Project ID (`<PROJECT_ID>`).
@@ -33,7 +33,7 @@ This skill guides you through establishing, managing, and troubleshooting persis
 
 ### Outputs
 - **Active Master Socket File**: Unix domain socket located at `~/.ssh/sockets/<TARGET_NAME>.sock`.
-- **Background SSH Process**: Persistent background `ssh -N -M` process holding the master channel open.
+- **Background SSH Process**: Persistent background `ssh -f -N -M` process holding the master channel open.
 
 ## Step-by-Step Procedure
 
@@ -53,12 +53,13 @@ rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
 
 ### Step 3: Establish Master SSH Connection
 
-Launch the persistent master SSH connection in the background (or persistent terminal):
+Launch the persistent master SSH connection in the background (forks immediately via `-f`):
 ```bash
-ssh -N -M -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
+ssh -f -N -M -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
 ```
 
 Key options explained:
+- `-f`: Requests ssh to go to background just before command execution (forks into background).
 - `-N`: Do not execute a remote command (background connection mode).
 - `-M`: Place the SSH client into master mode for connection sharing.
 - `-S ~/.ssh/sockets/<TARGET_NAME>.sock`: Path to the control socket.
@@ -73,29 +74,37 @@ ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnow
 
 ### Step 5: Refreshing / Recreating Sockets
 
-If user permissions change on the remote VM (e.g., after adding the user to the `docker` group via `usermod -aG docker`):
-1. Terminate/remove the master socket:
+If user permissions or group memberships change on the remote VM (e.g., after `usermod -aG <group>`):
+1. Gracefully terminate the active master SSH session:
+   ```bash
+   ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
+   ```
+2. Remove any leftover or stale socket file:
    ```bash
    rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
    ```
-2. Re-establish the master connection by repeating Step 3.
+3. Re-establish the master connection by repeating Step 3.
 
 ## Failure Modes & Edge Cases
 
 | Failure Scenario | Root Cause | Remediation / Recovery Action |
 |---|---|---|
-| **`Control socket connect failed: Connection refused`** | Master SSH process died unexpectedly, leaving a dead socket file | Delete stale socket file (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`) and re-run master connection command. |
+| **`Control socket connect failed: Connection refused`** | Master SSH process died unexpectedly, leaving a dead socket file | Gracefully exit or remove stale socket file (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST> 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`) and re-run master connection command. |
 | **`Permission Denied (publickey)`** | SSH key `~/.ssh/google_compute_engine` missing or expired GCP IAM SSH login credentials | Run `gcloud compute config-default-ssh-keys` or `gcloud compute ssh <VM_NAME> --zone=<ZONE>` to refresh SSH keys. |
-| **Permission Group Refresh Delay (Docker)** | Added user to `docker` group, but commands fail with `permission denied while trying to connect to Docker daemon` | Active SSH master session retains original group IDs. Remove socket (`rm -f ~/.ssh/sockets/*.sock`) and start new master SSH socket. |
-| **Connection Drop / Network Disconnect** | Remote VM rebooted or network path reset | Remove stale socket and re-establish master SSH connection. |
+| **Permission / Group Refresh Delay** | User added to a new group or permissions modified, but commands fail with permission errors | Active SSH master session retains original user and group IDs. Gracefully exit master session (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST>`), remove socket (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and start new master SSH socket. |
+| **Connection Drop / Network Disconnect** | Remote VM rebooted or network path reset | Gracefully exit master socket if responsive (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST> 2>/dev/null`), remove stale socket (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and re-establish master SSH connection. |
 
 ## Verification Checks
 
-1. **Local Socket File Check**: Confirm socket file exists and is a active socket file:
+1. **Local Socket File Check**: Confirm socket file exists and is an active socket file:
    ```bash
    test -S ~/.ssh/sockets/<TARGET_NAME>.sock && echo "SOCKET_EXISTS"
    ```
 2. **Remote Echo Check**: Confirm commands execute over multiplexed socket:
    ```bash
    ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/google_compute_engine <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com "echo 'Connection Alive'"
+   ```
+3. **Graceful Teardown Check**: Confirm graceful termination of the master socket:
+   ```bash
+   ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
    ```

--- a/.agents/skills/ssh-connection-management/SKILL.md
+++ b/.agents/skills/ssh-connection-management/SKILL.md
@@ -44,11 +44,11 @@ Ensure local socket directory exists:
 mkdir -p ~/.ssh/sockets
 ```
 
-### Step 2: Clean Up Stale Sockets
+### Step 2: Clean Up Lingering Sessions and Stale Sockets
 
-Before starting a master connection, remove any pre-existing or broken socket file for the target:
+Before starting a master connection, gracefully terminate any active master SSH daemon associated with the target to avoid leaving orphaned background processes in memory, and remove any broken or stale socket file:
 ```bash
-rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
+ssh -O exit -S ~/.ssh/sockets/<TARGET_NAME>.sock <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
 ```
 
 ### Step 3: Establish Master SSH Connection
@@ -75,24 +75,20 @@ ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -o StrictHostKeyChecking=no -o UserKnow
 ### Step 5: Refreshing / Recreating Sockets
 
 If user permissions or group memberships change on the remote VM (e.g., after `usermod -aG <group>`):
-1. Gracefully terminate the active master SSH session:
+1. Gracefully terminate the active master SSH session and clean up the socket file:
    ```bash
-   ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com
+   ssh -O exit -S ~/.ssh/sockets/<TARGET_NAME>.sock <SSH_USER>@nic0.<VM_NAME>.<ZONE>.c.<PROJECT_ID>.internal.gcpnode.com 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
    ```
-2. Remove any leftover or stale socket file:
-   ```bash
-   rm -f ~/.ssh/sockets/<TARGET_NAME>.sock
-   ```
-3. Re-establish the master connection by repeating Step 3.
+2. Re-establish the master connection by repeating Step 3.
 
 ## Failure Modes & Edge Cases
 
 | Failure Scenario | Root Cause | Remediation / Recovery Action |
 |---|---|---|
-| **`Control socket connect failed: Connection refused`** | Master SSH process died unexpectedly, leaving a dead socket file | Gracefully exit or remove stale socket file (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST> 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`) and re-run master connection command. |
+| **`Control socket connect failed: Connection refused`** | Master SSH process died unexpectedly, leaving a dead socket file | Gracefully exit or remove stale socket file (`ssh -O exit -S ~/.ssh/sockets/<TARGET_NAME>.sock <SSH_USER>@<HOST> 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`) and re-run master connection command. |
 | **`Permission Denied (publickey)`** | SSH key `~/.ssh/google_compute_engine` missing or expired GCP IAM SSH login credentials | Run `gcloud compute config-default-ssh-keys` or `gcloud compute ssh <VM_NAME> --zone=<ZONE>` to refresh SSH keys. |
-| **Permission / Group Refresh Delay** | User added to a new group or permissions modified, but commands fail with permission errors | Active SSH master session retains original user and group IDs. Gracefully exit master session (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST>`), remove socket (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and start new master SSH socket. |
-| **Connection Drop / Network Disconnect** | Remote VM rebooted or network path reset | Gracefully exit master socket if responsive (`ssh -S ~/.ssh/sockets/<TARGET_NAME>.sock -O exit <SSH_USER>@<HOST> 2>/dev/null`), remove stale socket (`rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and re-establish master SSH connection. |
+| **Permission / Group Refresh Delay** | User added to a new group or permissions modified, but commands fail with permission errors | Active SSH master session retains original user and group IDs. Gracefully exit master session (`ssh -O exit -S ~/.ssh/sockets/<TARGET_NAME>.sock <SSH_USER>@<HOST> 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and start new master SSH socket. |
+| **Connection Drop / Network Disconnect** | Remote VM rebooted or network path reset | Gracefully exit master socket if responsive (`ssh -O exit -S ~/.ssh/sockets/<TARGET_NAME>.sock <SSH_USER>@<HOST> 2>/dev/null || rm -f ~/.ssh/sockets/<TARGET_NAME>.sock`), and re-establish master SSH connection. |
 
 ## Verification Checks
 


### PR DESCRIPTION
### Description

Adds the `ssh-connection-management` skill under `.agents/skills/` to provide guidance on setting up, managing, and troubleshooting persistent SSH multiplexing connection sockets for GCSFuse testing workflows.

### Link to the issue in case of a bug fix.

N/A

### Testing details
1. Manual - Ran `make build` pre-check successfully with exit code 0. Inspected structure and markdown formatting of `.agents/skills/ssh-connection-management/SKILL.md`.
2. Unit tests - N/A
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.

N/A
