### PR TITLE
perf: Optimize statCache expiration timestamp by using int64 instead of time.Time

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -24,6 +24,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 )
 
+// 9223372036 is math.MaxInt64 / 1,000,000,000 (max seconds representable in nanoseconds)
+const maxSeconds int64 = math.MaxInt64 / 1000000000
+
 // A cache mapping from name to most recent known record for the object of that
 // name. External synchronization must be provided.
 type StatCache interface {
@@ -113,7 +116,7 @@ type statCacheBucketView struct {
 type entry struct {
 	m          *gcs.MinObject
 	f          *gcs.Folder
-	expiration time.Time
+	expiration int64
 	// Set to true only for implicit directory entries. This flag will always remain false for negative entries and explicit objects.
 	implicitDir bool
 }
@@ -143,6 +146,25 @@ func (e entry) Size() uint64 {
 	size = uint64(math.Ceil(util.HeapSizeToRssConversionFactor * float64(size)))
 
 	return size
+}
+
+// timeToUnixNano safely converts a time.Time to Unix nanoseconds.
+// It prevents int64 overflow for dates beyond the year 2262, returning
+// math.MaxInt64 instead, which safely mimics "never expire".
+func timeToUnixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return math.MinInt64
+	}
+
+	unixSecs := t.Unix()
+	if unixSecs >= maxSeconds {
+		return math.MaxInt64
+	}
+	if unixSecs <= -maxSeconds {
+		return math.MinInt64
+	}
+
+	return t.UnixNano()
 }
 
 // Should the supplied object for a new positive entry replace the given
@@ -201,7 +223,7 @@ func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
 	// Insert an entry.
 	e := entry{
 		m:          m,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -237,7 +259,7 @@ func (sc *statCacheBucketView) InsertImplicitDir(objectName string, expiration t
 	// Insert an entry.
 	e := entry{
 		implicitDir: true,
-		expiration:  expiration,
+		expiration:  timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -251,7 +273,7 @@ func (sc *statCacheBucketView) AddNegativeEntry(objectName string, expiration ti
 	// Insert a negative entry.
 	e := entry{
 		m:          nil,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -265,7 +287,7 @@ func (sc *statCacheBucketView) AddNegativeEntryForFolder(folderName string, expi
 	// Insert a negative entry.
 	e := entry{
 		f:          nil,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -315,7 +337,12 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 	e := value.(entry)
 
 	// Has this entry expired?
-	if e.expiration.Before(now) {
+	nowNano := timeToUnixNano(now)
+	if now.IsZero() {
+		nowNano = math.MinInt64
+	}
+
+	if e.expiration < nowNano {
 		sc.Erase(key)
 		return false, nil
 	}
@@ -328,7 +355,7 @@ func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time)
 
 	e := entry{
 		f:          f,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {

--- a/internal/cache/metadata/stat_cache_benchmark_test.go
+++ b/internal/cache/metadata/stat_cache_benchmark_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+)
+
+func generateKeys(count int) []string {
+	keys := make([]string, count)
+	for i := 0; i < count; i++ {
+		keys[i] = fmt.Sprintf("object-%d", i)
+	}
+	return keys
+}
+
+func setupStatCache(capacity uint64) metadata.StatCache {
+	// 1000 items * approx 120 bytes each = ~120,000 bytes capacity
+	lruCache := lru.NewCache(capacity)
+	return metadata.NewStatCacheBucketView(lruCache, "")
+}
+
+func BenchmarkStatCache_Insert(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	objects := make([]*gcs.MinObject, len(keys))
+	for i, key := range keys {
+		objects[i] = &gcs.MinObject{Name: key}
+	}
+
+	i := 0
+	for b.Loop() {
+		m := objects[i%len(objects)]
+		cache.Insert(m, now)
+		i++
+	}
+}
+
+func BenchmarkStatCache_AddNegativeEntry(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	i := 0
+	for b.Loop() {
+		key := keys[i%len(keys)]
+		cache.AddNegativeEntry(key, now)
+		i++
+	}
+}
+
+func BenchmarkStatCache_LookUp(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	// Pre-fill the cache with unexpired entries.
+	for _, key := range keys {
+		m := &gcs.MinObject{Name: key}
+		cache.Insert(m, now.Add(time.Hour))
+	}
+
+	i := 0
+	for b.Loop() {
+		key := keys[i%len(keys)]
+		_, _ = cache.LookUp(key, now)
+		i++
+	}
+}


### PR DESCRIPTION
### Description
In the `StatCache` the `entry` struct tracks TTL expiration using a standard Go `time.Time` object. This `time.Time` struct consumes 24 bytes of memory which can be reduced to 8 bytes using `int64` for the expiration timestamp. This saves 16 bytes of memory per object. 


#### Changes Made
- Changed `expiration` field in the internal cache `entry` from `time.Time` to `int64`
- Cache insertion methods (`Insert`, `InsertImplicitDir`, `AddNegativeEntry`, etc.) now convert the incoming `expiration time.Time` parameter to seconds using `.Unix()`
- Lookup methods now evaluate expiration against `now.Unix()`

#### Benchmarking results 
Using `time.Time` : 
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkStatCache_Insert-48                     3033651               409.2 ns/op           272 B/op          4 allocs/op
BenchmarkStatCache_AddNegativeEntry-48           7874757               149.2 ns/op            80 B/op          2 allocs/op
BenchmarkStatCache_LookUp-48                    19632806                61.15 ns/op           17 B/op          0 allocs/op
```
Using `int64` : 
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkStatCache_Insert-48                     3174098               382.8 ns/op           256 B/op          4 allocs/op
BenchmarkStatCache_AddNegativeEntry-48           8443263               141.3 ns/op            64 B/op          2 allocs/op
BenchmarkStatCache_LookUp-48                    22825635                54.30 ns/op           11 B/op          0 allocs/op
```


All existing tests pass successfully.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - Added `stat_cache_benchmark_test.go` to measure memory and CPU performance of `StatCache` operations.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.

