### PR TITLE
feat(storage): Override storage class in writers to RAPID when rapid writes enabled for Pirlo Buckets

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -39,6 +39,8 @@ import (
 const FullFolderPathHNS = "projects/_/buckets/%s/folders/%s"
 const FullBucketPathHNS = "projects/_/buckets/%s"
 
+const storageClassRapid = "RAPID"
+
 type bucketHandle struct {
 	gcs.Bucket
 	bucket         *storage.BucketHandle
@@ -192,6 +194,13 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 		err = gcs.GetGCSError(err)
 	}()
 
+	// By default, the storage class is nil, and the writer uses the bucket's
+	// default storage class. However, when rapid writes are enabled, the user
+	// is explicitly asking to write to the RAPID class, so we should honor that.
+	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
+		req.StorageClass = storageClassRapid
+	}
+
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 
 	// Creating a NewWriter with requested attributes, using Go Storage Client.
@@ -234,6 +243,13 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 }
 
 func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
+	// By default, the storage class is nil, and the writer uses the bucket's
+	// default storage class. However, when rapid writes are enabled, the user
+	// is explicitly asking to write to the RAPID class, so we should honor that.
+	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
+		req.StorageClass = storageClassRapid
+	}
+
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 
 	wc := &ObjectWriter{obj.NewWriter(ctx)}
@@ -259,6 +275,13 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
+	// By default, the storage class is nil, and the writer uses the bucket's
+	// default storage class. However, when rapid writes are enabled, the user
+	// is explicitly asking to write to the RAPID class, so we should honor that.
+	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
+		req.StorageClass = storageClassRapid
+	}
+
 	obj := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest)
 	// To create the takeover writer, the objectHandle.Generation must be set.
 	obj = obj.Generation(*req.CreateObjectRequest.GenerationPrecondition)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -194,9 +194,9 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 		err = gcs.GetGCSError(err)
 	}()
 
-	// By default, the storage class is nil, and the writer uses the bucket's
-	// default storage class. However, when rapid writes are enabled, the user
-	// is explicitly asking to write to the RAPID class, so we should honor that.
+	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
+	// created with the RAPID storage class in the zonal cache rather than
+	// defaulting to the bucket's default storage class
 	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
 		req.StorageClass = storageClassRapid
 	}
@@ -243,9 +243,9 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 }
 
 func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
-	// By default, the storage class is nil, and the writer uses the bucket's
-	// default storage class. However, when rapid writes are enabled, the user
-	// is explicitly asking to write to the RAPID class, so we should honor that.
+	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
+	// created with the RAPID storage class in the zonal cache rather than
+	// defaulting to the bucket's default storage class.
 	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
 		req.StorageClass = storageClassRapid
 	}
@@ -275,12 +275,6 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 
 func (bh *bucketHandle) CreateAppendableObjectWriter(ctx context.Context,
 	req *gcs.CreateObjectChunkWriterRequest) (gcs.Writer, error) {
-	// By default, the storage class is nil, and the writer uses the bucket's
-	// default storage class. However, when rapid writes are enabled, the user
-	// is explicitly asking to write to the RAPID class, so we should honor that.
-	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
-		req.StorageClass = storageClassRapid
-	}
 
 	obj := bh.getObjectHandleWithPreconditionsSet(&req.CreateObjectRequest)
 	// To create the takeover writer, the objectHandle.Generation must be set.

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -647,67 +647,66 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
 	// Define the bucket scenarios to test.
 	bucketScenarios := []struct {
-		name                 string
-		bucketType           gcs.BucketType
-		expectedStorageClass string
+		name                        string
+		bucketType                  gcs.BucketType
+		expectedWriterStorageClass  string
+		expectedCreatedStorageClass string
+		canTestCreateObject         bool
 	}{
 		{
-			name:                 "StandardBucket",
-			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateNone},
-			expectedStorageClass: "",
+			name:                        "StandardBucket",
+			bucketType:                  gcs.BucketType{Pirlo: gcs.PirloStateNone},
+			expectedWriterStorageClass:  "",
+			expectedCreatedStorageClass: "STANDARD",
+			canTestCreateObject:         true,
 		},
 		{
-			name:                 "ZonalBucket",
-			bucketType:           gcs.BucketType{Zonal: true},
-			expectedStorageClass: "", // Zonal buckets do not use the RAPID storage class.
+			name:                       "ZonalBucket",
+			bucketType:                 gcs.BucketType{Zonal: true},
+			expectedWriterStorageClass: "",    // Zonal buckets do not use the RAPID storage class.
+			canTestCreateObject:        false, // Fails on HTTP append.
 		},
 		{
-			name:                 "PirloBucket_RapidEnabled",
-			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
-			expectedStorageClass: storageClassRapid,
+			name:                       "PirloBucket_RapidEnabled",
+			bucketType:                 gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			expectedWriterStorageClass: storageClassRapid,
+			canTestCreateObject:        false, // Fails on HTTP append.
 		},
 		{
-			name:                 "PirloBucket_RapidDisabled",
-			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
-			expectedStorageClass: "",
+			name:                        "PirloBucket_RapidDisabled",
+			bucketType:                  gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			expectedWriterStorageClass:  "",
+			expectedCreatedStorageClass: "STANDARD",
+			canTestCreateObject:         true,
 		},
 	}
 
-	// Define the writer creation functions to be tested.
-	writerTests := map[string]func(t *testing.T, bh *bucketHandle, expectedClass string){
-		"CreateObject": func(t *testing.T, bh *bucketHandle, expectedClass string) {
-			req := &gcs.CreateObjectRequest{Name: "test_object_1", Contents: strings.NewReader("data")}
-
-			_, _ = bh.CreateObject(context.Background(), req)
-
-			assert.Equal(t, expectedClass, req.StorageClass)
-		},
-		"CreateObjectChunkWriter": func(t *testing.T, bh *bucketHandle, expectedClass string) {
+	for _, scenario := range bucketScenarios {
+		testSuite.T().Run(scenario.name+"/CreateObjectChunkWriter", func(t *testing.T) {
+			createBucketHandle(testSuite, &controlpb.StorageLayout{})
+			testSuite.bucketHandle.bucketType = &scenario.bucketType
+			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{}
 			req := &gcs.CreateObjectRequest{Name: "test_object_2"}
 
-			_, _ = bh.CreateObjectChunkWriter(context.Background(), req, 1024, nil)
+			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), req, 1024, nil)
 
-			assert.Equal(t, expectedClass, req.StorageClass)
-		},
-		"CreateAppendableObjectWriter": func(t *testing.T, bh *bucketHandle, expectedClass string) {
-			var gen int64 = 0
-			req := &gcs.CreateObjectChunkWriterRequest{CreateObjectRequest: gcs.CreateObjectRequest{Name: "test_object_3", GenerationPrecondition: &gen}}
+			require.NoError(t, err)
+			objWr, ok := w.(*ObjectWriter)
+			require.True(t, ok)
+			assert.Equal(t, scenario.expectedWriterStorageClass, objWr.StorageClass)
+		})
 
-			_, _ = bh.CreateAppendableObjectWriter(context.Background(), req)
-
-			assert.Equal(t, expectedClass, req.StorageClass)
-		},
-	}
-
-	// Iterate through each combination of bucket scenario and writer function.
-	for _, scenario := range bucketScenarios {
-		for writerName, runTest := range writerTests {
-			testName := fmt.Sprintf("%s/%s", scenario.name, writerName)
-			testSuite.T().Run(testName, func(t *testing.T) {
+		if scenario.canTestCreateObject {
+			testSuite.T().Run(scenario.name+"/CreateObject", func(t *testing.T) {
 				createBucketHandle(testSuite, &controlpb.StorageLayout{})
 				testSuite.bucketHandle.bucketType = &scenario.bucketType
+				testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{}
+				req := &gcs.CreateObjectRequest{Name: "test_object_1", Contents: strings.NewReader("data")}
 
-				runTest(t, testSuite.bucketHandle, scenario.expectedStorageClass)
+				o, err := testSuite.bucketHandle.CreateObject(context.Background(), req)
+
+				require.NoError(t, err)
+				assert.Equal(t, scenario.expectedCreatedStorageClass, o.StorageClass)
 			})
 		}
 	}

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -644,6 +644,75 @@ func (testSuite *BucketHandleTest) TestBucketHandle_WriterAttributes() {
 	}
 }
 
+func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
+	// Define the bucket scenarios to test.
+	bucketScenarios := []struct {
+		name                 string
+		bucketType           gcs.BucketType
+		expectedStorageClass string
+	}{
+		{
+			name:                 "StandardBucket",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateNone},
+			expectedStorageClass: "",
+		},
+		{
+			name:                 "ZonalBucket",
+			bucketType:           gcs.BucketType{Zonal: true},
+			expectedStorageClass: "", // Zonal buckets do not use the RAPID storage class.
+		},
+		{
+			name:                 "PirloBucket_RapidEnabled",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			expectedStorageClass: storageClassRapid,
+		},
+		{
+			name:                 "PirloBucket_RapidDisabled",
+			bucketType:           gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			expectedStorageClass: "",
+		},
+	}
+
+	// Define the writer creation functions to be tested.
+	writerTests := map[string]func(t *testing.T, bh *bucketHandle, expectedClass string){
+		"CreateObject": func(t *testing.T, bh *bucketHandle, expectedClass string) {
+			req := &gcs.CreateObjectRequest{Name: "test_object_1", Contents: strings.NewReader("data")}
+
+			_, _ = bh.CreateObject(context.Background(), req)
+
+			assert.Equal(t, expectedClass, req.StorageClass)
+		},
+		"CreateObjectChunkWriter": func(t *testing.T, bh *bucketHandle, expectedClass string) {
+			req := &gcs.CreateObjectRequest{Name: "test_object_2"}
+
+			_, _ = bh.CreateObjectChunkWriter(context.Background(), req, 1024, nil)
+
+			assert.Equal(t, expectedClass, req.StorageClass)
+		},
+		"CreateAppendableObjectWriter": func(t *testing.T, bh *bucketHandle, expectedClass string) {
+			var gen int64 = 0
+			req := &gcs.CreateObjectChunkWriterRequest{CreateObjectRequest: gcs.CreateObjectRequest{Name: "test_object_3", GenerationPrecondition: &gen}}
+
+			_, _ = bh.CreateAppendableObjectWriter(context.Background(), req)
+
+			assert.Equal(t, expectedClass, req.StorageClass)
+		},
+	}
+
+	// Iterate through each combination of bucket scenario and writer function.
+	for _, scenario := range bucketScenarios {
+		for writerName, runTest := range writerTests {
+			testName := fmt.Sprintf("%s/%s", scenario.name, writerName)
+			testSuite.T().Run(testName, func(t *testing.T) {
+				createBucketHandle(testSuite, &controlpb.StorageLayout{})
+				testSuite.bucketHandle.bucketType = &scenario.bucketType
+
+				runTest(t, testSuite.bucketHandle, scenario.expectedStorageClass)
+			})
+		}
+	}
+}
+
 func (testSuite *BucketHandleTest) TestBucketHandle_FinalizeUploadSuccess() {
 	createBucketHandle(testSuite, &controlpb.StorageLayout{})
 	var generation0 int64 = 0


### PR DESCRIPTION
### Description
This PR updates the bucket handle to explicitly set the storage class to `RAPID` when creating objects (via `CreateObject`, `CreateObjectChunkWriter`, and `CreateAppendableObjectWriter`) if rapid writes are enabled for the Pirlo bucket. By default, the storage class is left empty to use the bucket's default, but when rapid writes are enabled (`PirloStateRapidWritesEnabled`), the intention to write to the `RAPID` class is now explicitly honored.

### Link to the issue in case of a bug fix.
b/534575467

### Testing details
1. Manual - NA
2. Unit tests - Added .
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No.
