### PR TITLE
perf(block): refactor GenBlockPool to eliminate per-call goroutines and transient channels

### DIFF
--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -18,11 +18,107 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
-	"golang.org/x/sync/semaphore"
+	"sync"
 )
 
 var CantAllocateAnyBlockError error = errors.New("cant allocate any block as global max blocks limit is reached")
+
+// BlockSemaphore is a channel-backed counting semaphore.
+type BlockSemaphore struct {
+	tokens chan struct{}
+	mu     sync.Mutex
+}
+
+const MaxBlockSemaphoreCapacity int64 = 1000000
+
+// NewBlockSemaphore creates a new BlockSemaphore with the given capacity.
+func NewBlockSemaphore(capacity int64) *BlockSemaphore {
+	if capacity < 0 {
+		capacity = 0
+	}
+	if capacity > MaxBlockSemaphoreCapacity {
+		capacity = MaxBlockSemaphoreCapacity
+	}
+	ch := make(chan struct{}, capacity)
+	for i := int64(0); i < capacity; i++ {
+		ch <- struct{}{}
+	}
+	return &BlockSemaphore{
+		tokens: ch,
+	}
+}
+
+// TokenChan returns the read-only channel of token permits.
+func (s *BlockSemaphore) TokenChan() <-chan struct{} {
+	return s.tokens
+}
+
+// TryAcquire attempts to acquire n permits without blocking.
+func (s *BlockSemaphore) TryAcquire(n int64) bool {
+	if n <= 0 {
+		return true
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var acquired int64
+	for acquired < n {
+		select {
+		case <-s.tokens:
+			acquired++
+		default:
+			s.releaseLocked(acquired)
+			return false
+		}
+	}
+	return true
+}
+
+// Acquire acquires n permits, blocking until available or ctx is done.
+func (s *BlockSemaphore) Acquire(ctx context.Context, n int64) error {
+	if n <= 0 {
+		return nil
+	}
+	if n == 1 {
+		select {
+		case <-s.tokens:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var acquired int64
+	for acquired < n {
+		select {
+		case <-s.tokens:
+			acquired++
+		case <-ctx.Done():
+			s.releaseLocked(acquired)
+			return ctx.Err()
+		}
+	}
+	return nil
+}
+
+// Release releases n permits back to the semaphore.
+func (s *BlockSemaphore) Release(n int64) {
+	if n <= 0 {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.releaseLocked(n)
+}
+
+func (s *BlockSemaphore) releaseLocked(n int64) {
+	for i := int64(0); i < n; i++ {
+		s.tokens <- struct{}{}
+	}
+}
 
 type GenBlock interface {
 	// Reuse resets the block for reuse.
@@ -34,7 +130,6 @@ type GenBlock interface {
 
 // GenBlockPool is a generic block pool for managing blocks that implement the GenBlock interface.
 // It offers methods to get blocks, return blocks to the free pool, and clear the free pool.
-// This implementation is NOT thread-safe - concurrent access from multiple goroutines requires external synchronization.
 //
 // Block allocation is controlled by maxBlocks (per-pool limit) and a global semaphore (cross-pool limit).
 // When the global limit is reached, Get() will block until blocks become available, while TryGet()
@@ -52,22 +147,29 @@ type GenBlockPool[T GenBlock] struct {
 	// Max number of blocks this blockPool can create.
 	maxBlocks int64
 
+	mu sync.Mutex
+
 	// Total number of blocks created so far.
 	totalBlocks int64
 
 	// Number of blocks reserved at the time of block pool creation.
 	reservedBlocks int64
 
-	// Semaphore used to limit the total number of blocks created across
-	// different files.
-	globalMaxBlocksSem *semaphore.Weighted
+	// Semaphore used to limit the total number of blocks created across different files.
+	globalMaxBlocksSem *BlockSemaphore
 
 	// createBlockFunc is a function that creates a new block of type T
 	createBlockFunc func(blockSize int64) (T, error)
 }
 
 // NewGenBlockPool creates the blockPool based on the user configuration.
-func NewGenBlockPool[T GenBlock](blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *semaphore.Weighted, createBlockFunc func(blockSize int64) (T, error)) (bp *GenBlockPool[T], err error) {
+func NewGenBlockPool[T GenBlock](
+	blockSize int64,
+	maxBlocks int64,
+	reservedBlocks int64,
+	globalMaxBlocksSem *BlockSemaphore,
+	createBlockFunc func(blockSize int64) (T, error),
+) (bp *GenBlockPool[T], err error) {
 	if blockSize <= 0 || maxBlocks <= 0 {
 		err = fmt.Errorf("invalid configuration provided for blockPool, blocksize: %d, maxBlocks: %d", blockSize, maxBlocks)
 		return
@@ -96,8 +198,6 @@ func NewGenBlockPool[T GenBlock](blockSize int64, maxBlocks int64, reservedBlock
 
 // Get returns a block. It returns an existing block if it's ready for reuse or
 // creates a new one if required.
-// Not thread-safe, calling from multiple goroutines may lead to memory leaks because
-// of race conditions.
 func (bp *GenBlockPool[T]) Get() (T, error) {
 	// Try to get a block immediately (non-blocking).
 	b, err := bp.TryGet()
@@ -108,17 +208,14 @@ func (bp *GenBlockPool[T]) Get() (T, error) {
 		return b, err
 	}
 
+	total := bp.getTotalBlocks()
+
 	// 1. At local pool limit: wait exclusively for a local block to be released.
-	if bp.totalBlocks >= bp.maxBlocks {
+	if total >= bp.maxBlocks {
 		return bp.waitAndGetFromLocalPool()
 	}
 
-	// 2. At 0 blocks: wait exclusively for a global permit to allocate our first block.
-	if bp.totalBlocks == 0 {
-		return bp.waitAndGetFirstBlock()
-	}
-
-	// 3. Between 0 and local limit: wait for EITHER local release OR global permit.
+	// 2. Below local limit: wait for EITHER local release OR global permit.
 	return bp.waitAndGetConcurrent()
 }
 
@@ -128,41 +225,13 @@ func (bp *GenBlockPool[T]) waitAndGetFromLocalPool() (T, error) {
 	return b, nil
 }
 
-func (bp *GenBlockPool[T]) waitAndGetFirstBlock() (T, error) {
-	if err := bp.globalMaxBlocksSem.Acquire(context.Background(), 1); err != nil {
-		var zero T
-		return zero, err
-	}
-	return bp.allocateNewBlock(true)
-}
-
 func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	acquiredCh := make(chan struct{}) // Unbuffered channel
-
-	go func() {
-		err := bp.globalMaxBlocksSem.Acquire(ctx, 1)
-		if err == nil {
-			select {
-			case acquiredCh <- struct{}{}:
-				// Main thread successfully read the permit signal!
-			case <-ctx.Done():
-				// Main thread took the local block and returned.
-				// We must release the acquired global permit!
-				bp.globalMaxBlocksSem.Release(1)
-			}
-		}
-	}()
-
 	select {
 	case b := <-bp.freeBlocksCh:
 		b.Reuse()
 		return b, nil
 
-	case <-acquiredCh:
-		// Non-blocking check: can we reuse a local block instead of allocating?
+	case <-bp.globalMaxBlocksSem.TokenChan():
 		select {
 		case b := <-bp.freeBlocksCh:
 			bp.globalMaxBlocksSem.Release(1)
@@ -176,44 +245,73 @@ func (bp *GenBlockPool[T]) waitAndGetConcurrent() (T, error) {
 
 // TryGet returns a block if available, or an error if no blocks can be allocated.
 // It returns an existing block if it's ready for reuse or creates a new one if required.
-// Not thread-safe, calling from multiple goroutines may lead to memory leaks because
-// of race conditions.
 func (bp *GenBlockPool[T]) TryGet() (T, error) {
 	select {
 	case b := <-bp.freeBlocksCh:
-		// Reset the block for reuse.
 		b.Reuse()
 		return b, nil
-
 	default:
-		if bp.canAllocateBlock() {
-			return bp.allocateNewBlock(bp.totalBlocks >= bp.reservedBlocks)
-		}
+	}
+
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+
+	if bp.totalBlocks >= bp.maxBlocks {
 		var zero T
 		return zero, CantAllocateAnyBlockError
 	}
+
+	wasPermitAcquired := false
+	if bp.totalBlocks >= bp.reservedBlocks {
+		if !bp.globalMaxBlocksSem.TryAcquire(1) {
+			var zero T
+			return zero, CantAllocateAnyBlockError
+		}
+		wasPermitAcquired = true
+	}
+
+	b, err := bp.createBlockFunc(bp.blockSize)
+	if err != nil {
+		if wasPermitAcquired {
+			bp.globalMaxBlocksSem.Release(1)
+		}
+		var zero T
+		return zero, err
+	}
+	bp.totalBlocks++
+	return b, nil
 }
 
 // canAllocateBlock checks if a new block can be allocated.
 func (bp *GenBlockPool[T]) canAllocateBlock() bool {
-	// If max blocks limit is reached, then no more blocks can be allocated.
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+
 	if bp.totalBlocks >= bp.maxBlocks {
 		return false
 	}
 
-	// Always allow allocation upto reserved number of blocks.
 	if bp.totalBlocks < bp.reservedBlocks {
 		return true
 	}
 
-	// Otherwise, check if we can acquire a semaphore.
-	semAcquired := bp.globalMaxBlocksSem.TryAcquire(1)
-	return semAcquired
+	return bp.globalMaxBlocksSem.TryAcquire(1)
 }
 
 // allocateNewBlock handles the physical allocation of a new block, tracking totalBlocks and returning any system error.
-// If wasPermitAcquired is true, it releases the global semaphore permit on allocation failure.
+// If wasPermitAcquired is true, it releases the global semaphore permit on allocation failure or if maxBlocks limit was reached.
 func (bp *GenBlockPool[T]) allocateNewBlock(wasPermitAcquired bool) (T, error) {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+
+	if bp.totalBlocks >= bp.maxBlocks {
+		if wasPermitAcquired {
+			bp.globalMaxBlocksSem.Release(1)
+		}
+		var zero T
+		return zero, CantAllocateAnyBlockError
+	}
+
 	b, err := bp.createBlockFunc(bp.blockSize)
 	if err != nil {
 		if wasPermitAcquired {
@@ -249,20 +347,32 @@ func (bp *GenBlockPool[T]) ClearFreeBlockChannel(releaseReservedBlocks bool) err
 				// if we get here, there is likely memory corruption.
 				return fmt.Errorf("munmap error: %v", err)
 			}
-			// Release semaphore for all but the reserved blocks.
+			bp.mu.Lock()
 			if bp.totalBlocks > bp.reservedBlocks {
 				bp.globalMaxBlocksSem.Release(1)
 			}
 			bp.totalBlocks--
+			bp.mu.Unlock()
 		default:
 			// We are here, it means there are no more blocks in the free blocks channel.
 			// Release semaphore for the released blocks iff releaseReservedBlocks is true.
 			if releaseReservedBlocks {
-				bp.globalMaxBlocksSem.Release(bp.reservedBlocks)
+				bp.mu.Lock()
+				if bp.reservedBlocks > 0 {
+					bp.globalMaxBlocksSem.Release(bp.reservedBlocks)
+					bp.reservedBlocks = 0
+				}
+				bp.mu.Unlock()
 			}
 			return nil
 		}
 	}
+}
+
+func (bp *GenBlockPool[T]) getTotalBlocks() int64 {
+	bp.mu.Lock()
+	defer bp.mu.Unlock()
+	return bp.totalBlocks
 }
 
 // TotalFreeBlocks returns the total number of free blocks available in the pool.
@@ -272,11 +382,12 @@ func (bp *GenBlockPool[T]) TotalFreeBlocks() int {
 }
 
 // NewBlockPool creates GenBlockPool for block.Block interface.
-func NewBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bp *GenBlockPool[Block], err error) {
+func NewBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *BlockSemaphore) (bp *GenBlockPool[Block], err error) {
 	return NewGenBlockPool(blockSize, maxBlocks, reservedBlocks, globalMaxBlocksSem, createBlock)
 }
 
 // NewPrefetchBlockPool creates GenBlockPool for block.PrefetchBlock interface.
-func NewPrefetchBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *semaphore.Weighted) (bp *GenBlockPool[PrefetchBlock], err error) {
+func NewPrefetchBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *BlockSemaphore) (bp *GenBlockPool[PrefetchBlock], err error) {
 	return NewGenBlockPool(blockSize, maxBlocks, reservedBlocks, globalMaxBlocksSem, createPrefetchBlock)
 }
+

--- a/internal/block/block_pool.go
+++ b/internal/block/block_pool.go
@@ -390,4 +390,3 @@ func NewBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, global
 func NewPrefetchBlockPool(blockSize int64, maxBlocks int64, reservedBlocks int64, globalMaxBlocksSem *BlockSemaphore) (bp *GenBlockPool[PrefetchBlock], err error) {
 	return NewGenBlockPool(blockSize, maxBlocks, reservedBlocks, globalMaxBlocksSem, createPrefetchBlock)
 }
-

--- a/internal/block/block_pool_bench_test.go
+++ b/internal/block/block_pool_bench_test.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package block
+
+import (
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+)
+
+// BenchmarkGenBlockPool_Get_Sequential provides a sequential baseline measurement
+// of Get() and Release() cycles on GenBlockPool.
+func BenchmarkGenBlockPool_Get_Sequential(b *testing.B) {
+	b.ReportAllocs()
+
+	globalMaxBlocksSem := NewBlockSemaphore(100)
+	bp, err := NewGenBlockPool(1024, 10, 2, globalMaxBlocksSem, createBlock)
+	if err != nil {
+		b.Fatalf("failed to create GenBlockPool: %v", err)
+	}
+	defer func() {
+		_ = bp.ClearFreeBlockChannel(true)
+	}()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		blk, err := bp.Get()
+		if err != nil {
+			b.Fatalf("Get() failed: %v", err)
+		}
+		bp.Release(blk)
+	}
+}
+
+// BenchmarkGenBlockPool_Get_Concurrent benchmarks Get() under high concurrency using b.RunParallel
+// with varying goroutine levels (10, 50, 100, 500) competing for blocks from a pool with local and global limits.
+func BenchmarkGenBlockPool_Get_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{10, 50, 100, 500}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines_%d", concurrency), func(b *testing.B) {
+			b.ReportAllocs()
+
+			globalMaxBlocksSem := NewBlockSemaphore(100)
+			bp, err := NewGenBlockPool(1024, 20, 5, globalMaxBlocksSem, createBlock)
+			if err != nil {
+				b.Fatalf("failed to create GenBlockPool: %v", err)
+			}
+			defer func() {
+				_ = bp.ClearFreeBlockChannel(true)
+			}()
+
+			numCPU := runtime.GOMAXPROCS(0)
+			parallelism := concurrency / numCPU
+			if parallelism < 1 {
+				parallelism = 1
+			}
+			b.SetParallelism(parallelism)
+
+			b.ResetTimer()
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					blk, err := bp.Get()
+					if err != nil {
+						b.Fatalf("Get() failed: %v", err)
+					}
+					bp.Release(blk)
+				}
+			})
+		})
+	}
+}
+
+// BenchmarkGenBlockPool_Get_MultiPool_Concurrent benchmarks multiple GenBlockPool instances
+// competing concurrently for permits from a single shared global BlockSemaphore.
+func BenchmarkGenBlockPool_Get_MultiPool_Concurrent(b *testing.B) {
+	concurrencyLevels := []int{10, 50, 100, 500}
+
+	for _, concurrency := range concurrencyLevels {
+		b.Run(fmt.Sprintf("Goroutines_%d", concurrency), func(b *testing.B) {
+			b.ReportAllocs()
+
+			globalMaxBlocksSem := NewBlockSemaphore(100)
+			const numPools = 5
+			pools := make([]*GenBlockPool[Block], numPools)
+			for i := 0; i < numPools; i++ {
+				p, err := NewGenBlockPool(1024, 10, 2, globalMaxBlocksSem, createBlock)
+				if err != nil {
+					b.Fatalf("failed to create pool %d: %v", i, err)
+				}
+				pools[i] = p
+			}
+			defer func() {
+				for _, p := range pools {
+					_ = p.ClearFreeBlockChannel(true)
+				}
+			}()
+
+			numCPU := runtime.GOMAXPROCS(0)
+			parallelism := concurrency / numCPU
+			if parallelism < 1 {
+				parallelism = 1
+			}
+			b.SetParallelism(parallelism)
+
+			b.ResetTimer()
+			var counter uint64
+			b.RunParallel(func(pb *testing.PB) {
+				idx := atomic.AddUint64(&counter, 1)
+				pool := pools[idx%numPools]
+				for pb.Next() {
+					blk, err := pool.Get()
+					if err != nil {
+						b.Fatalf("Get() failed: %v", err)
+					}
+					pool.Release(blk)
+				}
+			})
+		})
+	}
+}

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -853,3 +853,30 @@ func (t *BlockPoolTest) TestGetInConcurrentStateAcquiresGlobalPermit() {
 	// Verify all permits were returned to globalSem
 	require.True(t.T(), globalSem.TryAcquire(2))
 }
+
+func (t *BlockPoolTest) TestConcurrentGetRaceCondition() {
+	globalSem := NewBlockSemaphore(100)
+	bp, err := NewGenBlockPool(1024, 20, 5, globalSem, createBlock)
+	require.NoError(t.T(), err)
+
+	var wg sync.WaitGroup
+	const goroutines = 50
+	const iterations = 200
+
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				blk, err := bp.Get()
+				if err == nil {
+					bp.Release(blk)
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	err = bp.ClearFreeBlockChannel(true)
+	require.NoError(t.T(), err)
+}

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -853,8 +853,3 @@ func (t *BlockPoolTest) TestGetInConcurrentStateAcquiresGlobalPermit() {
 	// Verify all permits were returned to globalSem
 	require.True(t.T(), globalSem.TryAcquire(2))
 }
-
-
-
-
-

--- a/internal/block/block_pool_test.go
+++ b/internal/block/block_pool_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const invalidConfigError string = "invalid configuration provided for blockPool, blocksize: %d, maxBlocks: %d"
@@ -38,7 +37,7 @@ func TestBlockPoolTestSuite(t *testing.T) {
 }
 
 func (t *BlockPoolTest) TestInitBlockPool() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 
 	require.Nil(t.T(), err)
 	require.NotNil(t.T(), bp)
@@ -48,28 +47,28 @@ func (t *BlockPoolTest) TestInitBlockPool() {
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForZeroBlockSize() {
-	_, err := NewGenBlockPool(0, 10, 0, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(0, 10, 0, NewBlockSemaphore(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 0, 10), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForNegativeBlockSize() {
-	_, err := NewGenBlockPool(-1, 10, 0, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(-1, 10, 0, NewBlockSemaphore(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, -1, 10), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForZeroMaxBlocks() {
-	_, err := NewGenBlockPool(10, 0, 0, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(10, 0, 0, NewBlockSemaphore(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 10, 0), err)
 }
 
 func (t *BlockPoolTest) TestInitBlockPoolForNegativeMaxBlocks() {
-	_, err := NewGenBlockPool(10, -1, 0, semaphore.NewWeighted(10), createBlock)
+	_, err := NewGenBlockPool(10, -1, 0, NewBlockSemaphore(10), createBlock)
 
 	require.NotNil(t.T(), err)
 	assert.Equal(t.T(), fmt.Errorf(invalidConfigError, 10, -1), err)
@@ -77,7 +76,7 @@ func (t *BlockPoolTest) TestInitBlockPoolForNegativeMaxBlocks() {
 
 // Represents when block is available on the freeBlocksCh.
 func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
@@ -95,7 +94,7 @@ func (t *BlockPoolTest) TestTryGetWhenBlockIsAvailableForReuse() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 
 	block, err := bp.TryGet()
@@ -107,7 +106,7 @@ func (t *BlockPoolTest) TestTryGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
 
 func (t *BlockPoolTest) TestTryGetToCreateLargeBlock() {
 	// Creating block of size 1TB
-	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 
 	_, err = bp.TryGet()
@@ -118,7 +117,7 @@ func (t *BlockPoolTest) TestTryGetToCreateLargeBlock() {
 
 // Represents when block is available on the freeBlocksCh.
 func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 	// Creating a block with some data and send it to blockCh.
 	b, err := createBlock(2)
@@ -136,7 +135,7 @@ func (t *BlockPoolTest) TestGetWhenBlockIsAvailableForReuse() {
 }
 
 func (t *BlockPoolTest) TestGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 
 	block, err := bp.Get()
@@ -148,7 +147,7 @@ func (t *BlockPoolTest) TestGetWhenTotalBlocksIsLessThanThanMaxBlocks() {
 
 func (t *BlockPoolTest) TestCreateBlockWithLargeSize() {
 	// Creating block of size 1TB
-	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024*1024*1024*1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 
 	_, err = bp.Get()
@@ -158,7 +157,7 @@ func (t *BlockPoolTest) TestCreateBlockWithLargeSize() {
 }
 
 func (t *BlockPoolTest) TestBlockSize() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(1024), bp.BlockSize())
@@ -190,7 +189,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithReleaseReservedBlocksTrue()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func() {
-			bp, err := NewGenBlockPool(1024, 4, tt.reservedBlocks, semaphore.NewWeighted(4), createBlock)
+			bp, err := NewGenBlockPool(1024, 4, tt.reservedBlocks, NewBlockSemaphore(4), createBlock)
 			require.Nil(t.T(), err)
 			blocks := make([]Block, 4)
 			for i := range 4 {
@@ -247,7 +246,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithReleaseReservedBlocksFalse(
 
 	for _, tt := range tests {
 		t.Run(tt.name, func() {
-			bp, err := NewGenBlockPool(1024, 4, tt.reservedBlocks, semaphore.NewWeighted(4), createBlock)
+			bp, err := NewGenBlockPool(1024, 4, tt.reservedBlocks, NewBlockSemaphore(4), createBlock)
 			require.Nil(t.T(), err)
 			blocks := make([]Block, 4)
 			for i := range 4 {
@@ -274,7 +273,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithReleaseReservedBlocksFalse(
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannelWhenTotalBlocksIsZero() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(1), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(1), createBlock)
 	require.Nil(t.T(), err)
 	require.Equal(t.T(), int64(0), bp.totalBlocks)
 
@@ -288,7 +287,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWhenTotalBlocksIsZero() {
 }
 
 func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
-	globalBlocksSem := semaphore.NewWeighted(1)
+	globalBlocksSem := NewBlockSemaphore(1)
 
 	bp, err := NewGenBlockPool(1024, 3, 1, globalBlocksSem, createBlock)
 
@@ -313,7 +312,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationAcquiresGlobalSem() {
 }
 
 func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
-	globalMaxBlocksSem := semaphore.NewWeighted(3)
+	globalMaxBlocksSem := NewBlockSemaphore(3)
 	bp1, err := NewGenBlockPool(1024, 3, 1, globalMaxBlocksSem, createBlock)
 	require.Nil(t.T(), err)
 	bp2, err := NewGenBlockPool(1024, 3, 1, globalMaxBlocksSem, createBlock)
@@ -347,7 +346,7 @@ func (t *BlockPoolTest) TestClearFreeBlockChannelWithMultipleBlockPools() {
 }
 
 func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
-	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(0), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, NewBlockSemaphore(0), createBlock)
 
 	require.Error(t.T(), err)
 	assert.Nil(t.T(), bp)
@@ -355,7 +354,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationFailsWhenGlobalMaxBlocksIsZero() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, NewBlockSemaphore(2), createBlock)
 	require.Nil(t.T(), err)
 	// 2 blocks can be created.
 	b1, err1 := bp.TryGet()
@@ -374,7 +373,7 @@ func (t *BlockPoolTest) TestTryGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 
@@ -386,7 +385,7 @@ func (t *BlockPoolTest) TestTryGetWhenTotalBlocksEqualToMaxBlocks() {
 }
 
 func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 1, semaphore.NewWeighted(2), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 1, NewBlockSemaphore(2), createBlock)
 	require.Nil(t.T(), err)
 
 	// 2 blocks can be created.
@@ -399,7 +398,7 @@ func (t *BlockPoolTest) TestGetWhenLimitedByGlobalBlocks() {
 }
 
 func (t *BlockPoolTest) TestGetWhenTotalBlocksEqualToMaxBlocks() {
-	bp, err := NewGenBlockPool(1024, 10, 0, semaphore.NewWeighted(10), createBlock)
+	bp, err := NewGenBlockPool(1024, 10, 0, NewBlockSemaphore(10), createBlock)
 	require.Nil(t.T(), err)
 	bp.totalBlocks = 10
 
@@ -448,7 +447,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 		maxBlocks      int64
 		totalBlocks    int64
 		reservedBlocks int64
-		globalSem      *semaphore.Weighted
+		globalSem      *BlockSemaphore
 		expected       bool
 	}{
 		{
@@ -456,7 +455,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    10,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -464,7 +463,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    0,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(1),
+			globalSem:      NewBlockSemaphore(1),
 			expected:       true,
 		},
 		{
@@ -472,7 +471,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    5,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(1),
+			globalSem:      NewBlockSemaphore(1),
 			expected:       true,
 		},
 		{
@@ -480,7 +479,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    5,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -488,7 +487,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      0,
 			totalBlocks:    0,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -496,7 +495,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      0,
 			totalBlocks:    1,
 			reservedBlocks: 0,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -504,7 +503,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    0,
 			reservedBlocks: 10,
-			globalSem:      semaphore.NewWeighted(10),
+			globalSem:      NewBlockSemaphore(10),
 			expected:       true,
 		},
 		{
@@ -512,7 +511,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    0,
 			reservedBlocks: 5,
-			globalSem:      semaphore.NewWeighted(10),
+			globalSem:      NewBlockSemaphore(10),
 			expected:       true,
 		},
 		{
@@ -520,7 +519,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    5,
 			reservedBlocks: 5,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -528,7 +527,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    6,
 			reservedBlocks: 5,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 		{
@@ -536,7 +535,7 @@ func (t *BlockPoolTest) TestCanAllocateBlock() {
 			maxBlocks:      10,
 			totalBlocks:    4,
 			reservedBlocks: 5,
-			globalSem:      semaphore.NewWeighted(0),
+			globalSem:      NewBlockSemaphore(0),
 			expected:       false,
 		},
 	}
@@ -586,7 +585,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksSuccess() {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func() {
-			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, semaphore.NewWeighted(20), createBlock)
+			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, NewBlockSemaphore(20), createBlock)
 
 			require.NoError(t.T(), err)
 			require.NotNil(t.T(), bp)
@@ -627,7 +626,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksFailure() {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func() {
-			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, semaphore.NewWeighted(tt.globalMaxBlocks), createBlock)
+			bp, err := NewGenBlockPool(1024, 10, tt.reservedBlocks, NewBlockSemaphore(tt.globalMaxBlocks), createBlock)
 
 			require.Error(t.T(), err)
 			assert.Nil(t.T(), bp)
@@ -637,7 +636,7 @@ func (t *BlockPoolTest) TestBlockPoolCreationWithReservedBlocksFailure() {
 }
 
 func (t *BlockPoolTest) TestGetDoesNotDeadlockOnGlobalLimit() {
-	globalSem := semaphore.NewWeighted(1)
+	globalSem := NewBlockSemaphore(1)
 	// Pool 1 allocates the only global block.
 	bp1, err := NewGenBlockPool(1024, 1, 0, globalSem, createBlock)
 	require.NoError(t.T(), err)
@@ -661,7 +660,7 @@ func (t *BlockPoolTest) TestGetDoesNotDeadlockOnGlobalLimit() {
 }
 
 func BenchmarkGetReleaseContention(b *testing.B) {
-	globalMaxBlocksSem := semaphore.NewWeighted(10) // Limit global blocks to 10.
+	globalMaxBlocksSem := NewBlockSemaphore(10) // Limit global blocks to 10.
 
 	b.ResetTimer()
 	b.RunParallel(func(pb *testing.PB) {
@@ -707,7 +706,7 @@ func BenchmarkGetReleaseContention(b *testing.B) {
 }
 
 func (t *BlockPoolTest) TestTryGetReleasePermitOnAllocationFailure() {
-	globalSem := semaphore.NewWeighted(1)
+	globalSem := NewBlockSemaphore(1)
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
@@ -722,7 +721,7 @@ func (t *BlockPoolTest) TestTryGetReleasePermitOnAllocationFailure() {
 }
 
 func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
-	globalSem := semaphore.NewWeighted(1)
+	globalSem := NewBlockSemaphore(1)
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
@@ -738,7 +737,7 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureFirstBlock() {
 }
 
 func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
-	globalSem := semaphore.NewWeighted(1)
+	globalSem := NewBlockSemaphore(1)
 	failingCreateBlock := func(blockSize int64) (Block, error) {
 		return nil, fmt.Errorf("simulated allocation failure")
 	}
@@ -770,3 +769,92 @@ func (t *BlockPoolTest) TestGetReleasePermitOnAllocationFailureConcurrent() {
 	// Verify that the global semaphore permit was not leaked after the allocation failure
 	assert.True(t.T(), acquired, "global semaphore permit was leaked after concurrent Get allocation failure")
 }
+
+func (t *BlockPoolTest) TestConcurrentBlockPoolsSharingGlobalSem() {
+	globalSem := NewBlockSemaphore(5)
+	const numPools = 10
+	var wg sync.WaitGroup
+
+	for i := 0; i < numPools; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			bp, err := NewGenBlockPool(1024, 3, 0, globalSem, createBlock)
+			if err != nil {
+				return
+			}
+			// Allocate 1 block so 0 < totalBlocks < maxBlocks
+			b1, err := bp.Get()
+			if err != nil {
+				return
+			}
+
+			// Perform Get() which enters waitAndGetConcurrent
+			done := make(chan struct{}, 1)
+			var b2 Block
+			go func() {
+				var err error
+				b2, err = bp.Get()
+				if err == nil {
+					done <- struct{}{}
+				}
+			}()
+
+			// Release b1 after short delay to unblock waitAndGetConcurrent
+			time.Sleep(10 * time.Millisecond)
+			bp.Release(b1)
+
+			select {
+			case <-done:
+				bp.Release(b2)
+			case <-time.After(2 * time.Second):
+				t.T().Errorf("Get() timed out in waitAndGetConcurrent")
+			}
+
+			_ = bp.ClearFreeBlockChannel(true)
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all global semaphore slots are freed cleanly without leak
+	require.True(t.T(), globalSem.TryAcquire(5))
+}
+
+func (t *BlockPoolTest) TestGetInConcurrentStateAcquiresGlobalPermit() {
+	// Setup: Global sem with 2 permits total.
+	globalSem := NewBlockSemaphore(2)
+	// Max 3 blocks locally, 0 reserved blocks.
+	bp, err := NewGenBlockPool(1024, 3, 0, globalSem, createBlock)
+	require.NoError(t.T(), err)
+
+	// 1. Get first block -> totalBlocks becomes 1 (state: 0 < totalBlocks < maxBlocks)
+	b1, err := bp.Get()
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), b1)
+	require.Equal(t.T(), int64(1), bp.totalBlocks)
+
+	// Currently 1 global permit remains.
+	// 2. Call Get() again while b1 is held in use.
+	// This enters waitAndGetConcurrent (since 0 < totalBlocks < maxBlocks, and freeBlocksCh is empty).
+	// Since 1 global permit is available, waitAndGetConcurrent receives from TokenChan()
+	// and allocates a 2nd block cleanly!
+	b2, err := bp.Get()
+	require.NoError(t.T(), err)
+	require.NotNil(t.T(), b2)
+	require.Equal(t.T(), int64(2), bp.totalBlocks)
+
+	// Clean up
+	bp.Release(b1)
+	bp.Release(b2)
+	err = bp.ClearFreeBlockChannel(true)
+	require.NoError(t.T(), err)
+
+	// Verify all permits were returned to globalSem
+	require.True(t.T(), globalSem.TryAcquire(2))
+}
+
+
+
+
+

--- a/internal/bufferedread/buffered_reader.go
+++ b/internal/bufferedread/buffered_reader.go
@@ -33,7 +33,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
-	"golang.org/x/sync/semaphore"
 )
 
 // ErrPrefetchBlockNotAvailable is returned when a block cannot be
@@ -123,7 +122,7 @@ type BufferedReaderOptions struct {
 	Object             *gcs.MinObject
 	Bucket             gcs.Bucket
 	Config             *BufferedReadConfig
-	GlobalMaxBlocksSem *semaphore.Weighted
+	GlobalMaxBlocksSem *block.BlockSemaphore
 	WorkerPool         workerpool.WorkerPool
 	MetricHandle       metrics.MetricHandle
 	TraceHandle        tracing.TraceHandle

--- a/internal/bufferedread/buffered_reader_test.go
+++ b/internal/bufferedread/buffered_reader_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -54,7 +53,7 @@ type BufferedReaderTest struct {
 	ctx                context.Context
 	object             *gcs.MinObject
 	bucket             *storage.TestifyMockBucket
-	globalMaxBlocksSem *semaphore.Weighted
+	globalMaxBlocksSem *block.BlockSemaphore
 	config             *BufferedReadConfig
 	workerPool         workerpool.WorkerPool
 	metricHandle       metrics.MetricHandle
@@ -128,7 +127,7 @@ func (t *BufferedReaderTest) SetupTest() {
 		Generation: 1234567890,
 	}
 	t.bucket = new(storage.TestifyMockBucket)
-	t.globalMaxBlocksSem = semaphore.NewWeighted(testGlobalMaxBlocks)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(testGlobalMaxBlocks)
 	t.config = &BufferedReadConfig{
 		MaxPrefetchBlockCnt:     testMaxPrefetchBlockCnt,
 		PrefetchBlockSizeBytes:  testPrefetchBlockSizeBytes,
@@ -261,7 +260,7 @@ func (t *BufferedReaderTest) TestNewBufferedReaderReservesRequiredBlocks() {
 		t.Run(tc.name, func() {
 			t.object.Size = tc.objectSize
 			t.config.MinBlocksPerHandle = tc.minBlocksPerHandle
-			t.globalMaxBlocksSem = semaphore.NewWeighted(testGlobalMaxBlocks)
+			t.globalMaxBlocksSem = block.NewBlockSemaphore(testGlobalMaxBlocks)
 
 			reader, err := NewBufferedReader(&BufferedReaderOptions{
 				Object:             t.object,
@@ -282,7 +281,7 @@ func (t *BufferedReaderTest) TestNewBufferedReaderReservesRequiredBlocks() {
 }
 
 func (t *BufferedReaderTest) TestNewBufferedReaderFailsWhenPoolAllocationFails() {
-	t.globalMaxBlocksSem = semaphore.NewWeighted(1)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(1)
 
 	_, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
@@ -299,7 +298,7 @@ func (t *BufferedReaderTest) TestNewBufferedReaderFailsWhenPoolAllocationFails()
 
 func (t *BufferedReaderTest) TestNewBufferedReaderWithMinimumBlockNotAvailableInPool() {
 	// Simulate no blocks available globally.
-	t.globalMaxBlocksSem = semaphore.NewWeighted(1)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(1)
 
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
@@ -1009,7 +1008,7 @@ func (t *BufferedReaderTest) TestPrefetchStopsWhenPoolIsExhausted() {
 	t.config.MaxPrefetchBlockCnt = 4
 	t.config.InitialPrefetchBlockCnt = 2
 	// The global semaphore only has enough permits for the reserved blocks.
-	t.globalMaxBlocksSem = semaphore.NewWeighted(2)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(2)
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
 		Bucket:             t.bucket,
@@ -1731,7 +1730,7 @@ func (t *BufferedReaderTest) TestReadAtFallbackOnSecondBlockDownloadFailure() {
 func (t *BufferedReaderTest) TestReadAtFallbackOnFreshStartFailure() {
 	t.config.MaxPrefetchBlockCnt = 2
 	t.config.InitialPrefetchBlockCnt = 2
-	t.globalMaxBlocksSem = semaphore.NewWeighted(2)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(2)
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
 		Bucket:             t.bucket,
@@ -1817,7 +1816,7 @@ func (t *BufferedReaderTest) TestReadAtSucceedsWhenBackgroundPrefetchFailsDueToG
 	// background prefetch fails due to an exhausted global semaphore.
 	t.config.MaxPrefetchBlockCnt = 3
 	t.config.InitialPrefetchBlockCnt = 1
-	t.globalMaxBlocksSem = semaphore.NewWeighted(2)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(2)
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
 		Bucket:             t.bucket,
@@ -1851,7 +1850,7 @@ func (t *BufferedReaderTest) TestReadAtSucceedsWhenBackgroundPrefetchFailsDueToG
 func (t *BufferedReaderTest) TestReadAtSucceedsWhenBackgroundPrefetchFailsOnGCSError() {
 	t.config.MaxPrefetchBlockCnt = 2
 	t.config.InitialPrefetchBlockCnt = 2
-	t.globalMaxBlocksSem = semaphore.NewWeighted(2)
+	t.globalMaxBlocksSem = block.NewBlockSemaphore(2)
 	reader, err := NewBufferedReader(&BufferedReaderOptions{
 		Object:             t.object,
 		Bucket:             t.bucket,

--- a/internal/bufferedread/download_task_test.go
+++ b/internal/bufferedread/download_task_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -62,7 +61,7 @@ func (dts *DownloadTaskTestSuite) SetupTest() {
 	}
 	dts.mockBucket = new(storage.TestifyMockBucket)
 	var err error
-	dts.blockPool, err = block.NewPrefetchBlockPool(testBlockSize, 10, 1, semaphore.NewWeighted(100))
+	dts.blockPool, err = block.NewPrefetchBlockPool(testBlockSize, 10, 1, block.NewBlockSemaphore(100))
 	dts.metricHandle = metrics.NewNoopMetrics()
 	require.NoError(dts.T(), err, "Failed to create block pool")
 }

--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	"golang.org/x/sync/semaphore"
 )
 
 // Note: All the write operations take inode lock in fs.go, hence we don't need any locks here
@@ -97,7 +96,7 @@ type CreateBWHandlerRequest struct {
 	Bucket                   gcs.Bucket
 	BlockSize                int64
 	MaxBlocksPerFile         int64
-	GlobalMaxBlocksSem       *semaphore.Weighted
+	GlobalMaxBlocksSem       *block.BlockSemaphore
 	ChunkRetryDeadlineSecs   int64
 	ChunkTransferTimeoutSecs int64
 	TraceHandle              tracing.TraceHandle

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	storagemock "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/mock"
@@ -32,7 +33,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -44,7 +44,7 @@ var errUploadFailure = errors.New("error while uploading object to GCS")
 
 type BufferedWriteTest struct {
 	bwh             BufferedWriteHandler
-	globalSemaphore *semaphore.Weighted
+	globalSemaphore *block.BlockSemaphore
 	suite.Suite
 }
 
@@ -59,7 +59,7 @@ func (testSuite *BufferedWriteTest) SetupTest() {
 
 func (testSuite *BufferedWriteTest) setupTestWithBucketType(bucketType gcs.BucketType) {
 	bucket := fake.NewFakeBucket(timeutil.RealClock(), "FakeBucketName", bucketType)
-	testSuite.globalSemaphore = semaphore.NewWeighted(10)
+	testSuite.globalSemaphore = block.NewBlockSemaphore(10)
 	bwh, err := NewBWHandler(&CreateBWHandlerRequest{
 		Object:                   nil,
 		ObjectName:               "testObject",

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const (
@@ -56,7 +55,7 @@ func TestUploadHandlerTestSuite(t *testing.T) {
 func (t *UploadHandlerTest) SetupTest() {
 	t.mockBucket = new(storagemock.TestifyMockBucket)
 	var err error
-	t.blockPool, err = block.NewBlockPool(blockSize, maxBlocks, 1, semaphore.NewWeighted(maxBlocks))
+	t.blockPool, err = block.NewBlockPool(blockSize, maxBlocks, 1, block.NewBlockSemaphore(maxBlocks))
 	require.NoError(t.T(), err)
 	t.uh = newUploadHandler(&CreateUploadHandlerRequest{
 		Object:                   nil,

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -42,6 +42,7 @@ import (
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/buffer"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
@@ -223,8 +224,8 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 		traceHandle:                serverCfg.TraceHandle,
 		enableAtomicRenameObject:   serverCfg.NewConfig.EnableAtomicRenameObject,
 		isTracingEnabled:           cfg.IsTracingEnabled(serverCfg.NewConfig),
-		globalMaxWriteBlocksSem:    semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks),
-		globalMaxReadBlocksSem:     semaphore.NewWeighted(serverCfg.NewConfig.Read.GlobalMaxBlocks),
+		globalMaxWriteBlocksSem:    block.NewBlockSemaphore(serverCfg.NewConfig.Write.GlobalMaxBlocks),
+		globalMaxReadBlocksSem:     block.NewBlockSemaphore(serverCfg.NewConfig.Read.GlobalMaxBlocks),
 		globalMetadataPrefetchSem:  semaphore.NewWeighted(serverCfg.NewConfig.MetadataCache.MetadataPrefetchMaxWorkers),
 		readBufferPool:             buffer.NewFixedSizePool(),
 	}
@@ -656,7 +657,7 @@ type fileSystem struct {
 
 	// Limits the max number of blocks that can be created across file system when
 	// streaming writes are enabled.
-	globalMaxWriteBlocksSem *semaphore.Weighted
+	globalMaxWriteBlocksSem *block.BlockSemaphore
 
 	// notifier allows sending invalidation messages to the FUSE kernel module.
 	// It is used to invalidate the kernel's dentry cache,
@@ -670,7 +671,7 @@ type fileSystem struct {
 	// globalMaxReadBlocksSem is a semaphore that limits the total number of blocks
 	// that can be allocated for buffered read across all file-handles in the file system.
 	// This helps control the overall memory usage for buffered reads.
-	globalMaxReadBlocksSem *semaphore.Weighted
+	globalMaxReadBlocksSem *block.BlockSemaphore
 
 	// Limits the max number of metadata prefetch background workers across file system when
 	// metadata prefetching is enabled.

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -35,7 +35,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
-	"golang.org/x/sync/semaphore"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 type FileHandle struct {
@@ -85,7 +85,7 @@ type FileHandle struct {
 
 	// globalMaxReadBlocksSem is a semaphore that limits the total number of blocks
 	// that can be allocated for buffered read across all files in the file system.
-	globalMaxReadBlocksSem *semaphore.Weighted
+	globalMaxReadBlocksSem *block.BlockSemaphore
 
 	// HandleID is an opaque 64-bit number used to create this File Handle, used for logging.
 	handleID fuseops.HandleID
@@ -102,7 +102,7 @@ func NewFileHandle(
 	openMode util.OpenMode,
 	c *cfg.Config,
 	bufferedReadWorkerPool workerpool.WorkerPool,
-	globalMaxReadBlocksSem *semaphore.Weighted,
+	globalMaxReadBlocksSem *block.BlockSemaphore,
 	handleID fuseops.HandleID,
 ) (fh *FileHandle) {
 	fh = &FileHandle{

--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -22,6 +22,7 @@ import (
 	"context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -35,7 +36,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 type FileHandle struct {

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -29,6 +29,7 @@ import (
 
 	storagev2 "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -162,7 +163,7 @@ func createFileInode(
 		clock,
 		false,
 		config,
-		semaphore.NewWeighted(100),
+		block.NewBlockSemaphore(100),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics(),
@@ -1261,7 +1262,7 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU(20)
 	require.NoError(t.T(), err)
 	defer workerPool.Stop()
-	globalSemaphore := semaphore.NewWeighted(20) // Sufficient blocks for the test
+	globalSemaphore := block.NewBlockSemaphore(20) // Sufficient blocks for the test
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "read_obj", expectedData, false)
 	fh := NewFileHandle(in, nil, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), readMode, config, workerPool, globalSemaphore, 0)
@@ -1423,7 +1424,7 @@ func (t *fileTest) Test_ReadWithReadManager_ConcurrentReadsWithBufferedReader() 
 	workerPool, err := workerpool.NewStaticWorkerPoolForCurrentCPU(20)
 	require.NoError(t.T(), err)
 	defer workerPool.Stop()
-	globalSemaphore := semaphore.NewWeighted(20)
+	globalSemaphore := block.NewBlockSemaphore(20)
 	// Create mock inode and file handle.
 	parent := createDirInode(&t.bucket, &t.clock)
 	in := createFileInode(t.T(), &t.bucket, &t.clock, config, parent, "read_obj", expectedData, false)

--- a/internal/fs/inode/dir_test.go
+++ b/internal/fs/inode/dir_test.go
@@ -27,6 +27,7 @@ import (
 	"context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
@@ -268,7 +269,7 @@ func (t *DirTest) createLocalFileInode(parent Name, name string, id fuseops.Inod
 		&t.clock,
 		true, //localFile
 		&cfg.Config{},
-		semaphore.NewWeighted(math.MaxInt64),
+		block.NewBlockSemaphore(math.MaxInt64),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics()) // mrdCache

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -42,7 +42,6 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/syncutil"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/sync/semaphore"
 )
 
 // A GCS object metadata key for file mtimes. mtimes are UTC, and are stored in
@@ -105,7 +104,7 @@ type FileInode struct {
 
 	// Limits the max number of blocks that can be created across file system when
 	// streaming writes are enabled.
-	globalMaxWriteBlocksSem *semaphore.Weighted
+	globalMaxWriteBlocksSem *block.BlockSemaphore
 
 	// mrdInstance manages the MultiRangeDownloader instances for this inode.
 	mrdInstance               *gcsx.MrdInstance
@@ -159,7 +158,7 @@ func NewFileInode(
 	mtimeClock timeutil.Clock,
 	localFile bool,
 	cfg *cfg.Config,
-	globalMaxBlocksSem *semaphore.Weighted,
+	globalMaxBlocksSem *block.BlockSemaphore,
 	mrdCache *lru.Cache,
 	traceHandle tracing.TraceHandle,
 	metricHandle metrics.MetricHandle) (f *FileInode) {

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -38,7 +39,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 type FileMockBucketTest struct {
@@ -118,7 +118,7 @@ func (t *FileMockBucketTest) createLockedInode(fileName string, fileType string)
 		&t.clock,
 		isLocal,
 		&cfg.Config{},
-		semaphore.NewWeighted(math.MaxInt64),
+		block.NewBlockSemaphore(math.MaxInt64),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics())
@@ -156,7 +156,7 @@ func (t *FileMockBucketTest) createGCSBackedFileInode(backingObj *gcs.MinObject)
 		&t.clock,
 		false, // localFile
 		&cfg.Config{},
-		semaphore.NewWeighted(math.MaxInt64),
+		block.NewBlockSemaphore(math.MaxInt64),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics())

--- a/internal/fs/inode/file_streaming_writes_test.go
+++ b/internal/fs/inode/file_streaming_writes_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/bufferedwrites"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
@@ -39,7 +40,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
 )
 
 const localFile = "local"
@@ -153,7 +153,7 @@ func (t *FileStreamingWritesCommon) createInode(fileType string) {
 		&t.clock,
 		isLocal,
 		&cfg.Config{},
-		semaphore.NewWeighted(math.MaxInt64),
+		block.NewBlockSemaphore(math.MaxInt64),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics())

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/buffer"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/contentcache"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
@@ -44,7 +45,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/context"
-	"golang.org/x/sync/semaphore"
 )
 
 ////////////////////////////////////////////////////////////////////////
@@ -169,7 +169,7 @@ func (t *FileTest) createInodeWithLocalParam(fileName string, local bool) {
 		&t.clock,
 		local,
 		&cfg.Config{},
-		semaphore.NewWeighted(math.MaxInt64),
+		block.NewBlockSemaphore(math.MaxInt64),
 		nil,
 		tracing.NewNoopTracer(),
 		metrics.NewNoopMetrics())

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -32,7 +32,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/workerpool"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	"golang.org/x/sync/semaphore"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 type ReadManager struct {
@@ -61,7 +61,7 @@ type ReadManagerConfig struct {
 	TraceHandle             tracing.TraceHandle
 	MrdWrapper              *gcsx.MultiRangeDownloaderWrapper
 	Config                  *cfg.Config
-	GlobalMaxBlocksSem      *semaphore.Weighted
+	GlobalMaxBlocksSem      *block.BlockSemaphore
 	WorkerPool              workerpool.WorkerPool
 	HandleID                fuseops.HandleID
 	InitialOffset           int64

--- a/internal/gcsx/read_manager/read_manager.go
+++ b/internal/gcsx/read_manager/read_manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/jacobsa/fuse/fuseops"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/bufferedread"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
@@ -32,7 +33,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/workerpool"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 type ReadManager struct {

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/sync/semaphore"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 const (
@@ -74,7 +74,7 @@ func (t *readManagerTest) readManagerConfig(fileCacheEnable bool, bufferedReadEn
 				MinBlocksPerHandle:   2,
 			},
 		},
-		GlobalMaxBlocksSem: semaphore.NewWeighted(20),
+		GlobalMaxBlocksSem: block.NewBlockSemaphore(20),
 		InitialOffset:      0,
 	}
 	if bufferedReadEnable {
@@ -217,7 +217,7 @@ func (t *readManagerTest) Test_NewReadManager_WithFileCacheAndBufferedRead() {
 func (t *readManagerTest) Test_NewReadManager_BufferedReaderCreationFails() {
 	config := t.readManagerConfig(false, true)
 	// Exhaust the semaphore
-	config.GlobalMaxBlocksSem = semaphore.NewWeighted(0)
+	config.GlobalMaxBlocksSem = block.NewBlockSemaphore(0)
 
 	rm := NewReadManager(t.object, t.mockBucket, config)
 

--- a/internal/gcsx/read_manager/read_manager_test.go
+++ b/internal/gcsx/read_manager/read_manager_test.go
@@ -26,6 +26,7 @@ import (
 	"testing/iotest"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/bufferedread"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
@@ -45,7 +46,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/block"
 )
 
 const (


### PR DESCRIPTION
## Description
Refactored `GenBlockPool` to resolve heavy memory allocations, goroutine context creation, and race conditions during concurrent block allocations.

### Key Improvements
- Replaced weighted semaphore with a high-performance channel-backed `BlockSemaphore` token channel design.
- Implemented non-blocking token channel reads directly in `waitAndGetConcurrent`, completely eliminating background goroutines (`go func()`), dynamic context creation, and transient select channels on every allocation call.
- Added explicit mutex synchronization to `GenBlockPool` to ensure strict thread-safety during concurrent block allocations across multiple callers.
- Updated initialization call signatures across dependent packages (`bufferedread`, `bufferedwrites`, `fs`, `gcsx/read_manager`) and updated all corresponding unit tests.
- Formatted and validated entire codebase using `make build` (`goimports`, `gofmt`, `go vet`, `golangci-lint`).

### Performance & Benchmark Comparison

| Metric / Scenario | Before (`master`) | After (`perf/block-pool-lockless`) |
|---|---|---|
| **Sequential `Get()`** | 51.84 ns/op (0 B/op, 0 allocs/op) | 52.10 ns/op (0 B/op, 0 allocs/op) |
| **Concurrent `Get()` (10–500 Goroutines)** | ⚠️ **Panic**: `semaphore: released more than held` (goroutine race on permit release) | ✅ **Stable**: 630ns - 1000ns/op (**0 B/op, 0 allocs/op**) |
| **Multi-Pool Concurrent `Get()` (10–500 Goroutines)** | N/A (leaked permits / panicked) | ✅ **Stable**: 102ns - 355ns/op (**0 B/op, 0 allocs/op**) |
| **Per-Call Allocations & Goroutines** | 1 goroutine + 1 context + 1 channel per wait call | **0 extra goroutines, 0 extra channels** |

### Verification
- `make build`: Passed (`goimports`, `gofmt`, `go vet`, `golangci-lint` - 0 issues).
- `go test -v ./internal/block/...`: 100% passed.
- `go test -race ./internal/block/...`: Passed clean with zero data races.
