### PR TITLE
test(integration): integrate shared chunk cache tests

### DIFF
--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -359,6 +359,7 @@ TEST_PACKAGES_COMMON=(
   "buffered_read"
   "flag_optimizations"
   "symlink_handling"
+  "shared_chunk_cache"
 )
 
 # filter_array: Filters an array in place keeping only elements matching the regex.

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -18,11 +18,9 @@ import (
 	"log"
 	"os"
 	"path"
-	"slices"
+	"strings"
 	"testing"
 	"time"
-
-	"strings"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
@@ -205,40 +203,7 @@ func (t *BaseSuite) isMetadataCacheEnabled() bool {
 }
 
 func RunTests(t *testing.T, testName string, factory func(primaryFlags, secondaryFlags []string) suite.TestingSuite) {
-	for _, testConfig := range testEnv.cfg.Configs {
-		isBucketCompatible := false
-		switch testEnv.bucketType {
-		case setup.FlatPirloBucket:
-			isBucketCompatible = testConfig.RunOnPirlo.Flat.SameZone || testConfig.RunOnPirlo.Flat.DifferentZone
-		case setup.HNSPirloBucket:
-			isBucketCompatible = testConfig.RunOnPirlo.Hns.SameZone || testConfig.RunOnPirlo.Hns.DifferentZone
-		default:
-			isBucketCompatible = testConfig.Compatible[testEnv.bucketType]
-		}
-		isTPCCompatible := (setup.TestOnTPCEndPoint() == testConfig.TPC)
-		if !isBucketCompatible || !isTPCCompatible {
-			continue
-		}
-
-		// The skip field is intended for function-level test suites where testName is specified (e.g. t.Name()).
-		// Package-level test executions (where testName is empty) do not support skip in test_config.yaml.
-		if testName == "" && len(testConfig.Skip) > 0 {
-			log.Fatalf("Invalid configuration: skip field is not supported when testName is empty in test_config.yaml")
-		}
-
-		if slices.Contains(testConfig.Skip, testName) || (testConfig.Run != "" && testName != testConfig.Run) {
-			continue
-		}
-
-		for i, flagStr := range testConfig.Flags {
-			flagStr = strings.ReplaceAll(flagStr, ",", " ")
-			primaryFlags := strings.Fields(flagStr)
-			var secondaryFlags []string
-			if len(testConfig.SecondaryFlags) > i {
-				secFlagStr := strings.ReplaceAll(testConfig.SecondaryFlags[i], ",", " ")
-				secondaryFlags = strings.Fields(secFlagStr)
-			}
-			suite.Run(t, factory(primaryFlags, secondaryFlags))
-		}
+	for _, flags := range setup.BuildDualMountFlagSets(*testEnv.cfg, testEnv.bucketType, testName) {
+		suite.Run(t, factory(flags.Primary, flags.Secondary))
 	}
 }

--- a/tools/integration_tests/shared_chunk_cache/setup_test.go
+++ b/tools/integration_tests/shared_chunk_cache/setup_test.go
@@ -92,6 +92,6 @@ func TestMain(m *testing.M) {
 
 	successCode := m.Run()
 
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/shared_chunk_cache/setup_test.go
+++ b/tools/integration_tests/shared_chunk_cache/setup_test.go
@@ -57,15 +57,11 @@ func TestMain(m *testing.M) {
 	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, testEnv.cfg)
 
 	// 2. Create storage client before running tests.
-	var err error
-	testEnv.storageClient, err = client.CreateStorageClient(testEnv.ctx)
-	if err != nil {
-		log.Printf("Error creating storage client: %v\n", err)
-		os.Exit(1)
-	}
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
-		if err := testEnv.storageClient.Close(); err != nil {
-			log.Printf("Error closing storage client: %v\n", err)
+		err := closeStorageClient()
+		if err != nil {
+			log.Fatalf("closeStorageClient failed: %v", err)
 		}
 	}()
 
@@ -93,5 +89,8 @@ func TestMain(m *testing.M) {
 	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
+	if err := closeStorageClient(); err != nil {
+		log.Printf("closeStorageClient failed: %v\n", err)
+	}
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/shared_chunk_cache/setup_test.go
+++ b/tools/integration_tests/shared_chunk_cache/setup_test.go
@@ -89,8 +89,5 @@ func TestMain(m *testing.M) {
 	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
-	if err := closeStorageClient(); err != nil {
-		log.Printf("closeStorageClient failed: %v\n", err)
-	}
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
+++ b/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
@@ -107,7 +107,7 @@ func (t *BaseSuite) TearDownTest() {
 
 	if testEnv.cfg.GKEMountedDirectory != "" {
 		// GKE Mode: Just cleanup files
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	} else {
 		// GCE Mode: Unmount and clean up
 		t.unmountAndCleanupMount(t.primaryMount, "primary")
@@ -144,7 +144,7 @@ func (t *BaseSuite) mountGcsfuse(mnt mountPoint, mountType string, flags []strin
 func (t *BaseSuite) unmountAndCleanupMount(m mountPoint, name string) {
 	setup.UnmountGCSFuse(m.mntDir)
 	// Cleaning up the intermediate generated test files.
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 }
 
 func (t *BaseSuite) createTestFile(fileName string, fileSize int) {
@@ -350,10 +350,10 @@ func RunTests(t *testing.T, runName string, factory func(primaryFlags, secondary
 	for _, cfg := range testEnv.cfg.Configs {
 		if cfg.Run == runName {
 			for i, flagStr := range cfg.Flags {
-				primaryFlags := strings.Fields(flagStr)
+				primaryFlags := strings.Split(flagStr, ",")
 				var secondaryFlags []string
 				if len(cfg.SecondaryFlags) > i {
-					secondaryFlags = strings.Fields(cfg.SecondaryFlags[i])
+					secondaryFlags = strings.Split(cfg.SecondaryFlags[i], ",")
 				}
 				suite.Run(t, factory(primaryFlags, secondaryFlags))
 			}

--- a/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
+++ b/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
@@ -201,11 +201,11 @@ func (t *BaseSuite) getCacheFileModTimes() map[string]os.FileInfo {
 // Reading 2MB starting at 10MB offset will download and cache the entire 10MB chunk (2nd chunk).
 func (t *SharedChunkCacheTestSuite) TestCacheMiss() {
 	const (
-		testFileName = "test_cache_miss.txt"
-		fileSize     = 30 * util.MiB
-		readSize     = 2 * util.MiB  // Read only 2MB
-		readOffset   = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
+		fileSize   = 30 * util.MiB
+		readSize   = 2 * util.MiB  // Read only 2MB
+		readOffset = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
 	)
+	testFileName := "test_cache_miss_" + setup.GenerateRandomString(5) + ".txt"
 
 	// Arrange: Set up test file and verify initial cache state
 	t.createTestFile(testFileName, fileSize)
@@ -232,11 +232,11 @@ func (t *SharedChunkCacheTestSuite) TestCacheMiss() {
 // This test verifies cache hits by checking that cache files are not modified.
 func (t *SharedChunkCacheTestSuite) TestCacheHit() {
 	const (
-		testFileName = "test_cache_hit.txt"
-		fileSize     = 30 * util.MiB
-		readSize     = 2 * util.MiB  // Read only 2MB
-		readOffset   = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
+		fileSize   = 30 * util.MiB
+		readSize   = 2 * util.MiB  // Read only 2MB
+		readOffset = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
 	)
+	testFileName := "test_cache_hit_" + setup.GenerateRandomString(5) + ".txt"
 
 	// Arrange: Set up test file and populate cache via primary mount
 	t.createTestFile(testFileName, fileSize)
@@ -292,11 +292,11 @@ func (t *SharedChunkCacheTestSuite) TestCacheHit() {
 // Subsequent read of the same chunk should be a cache hit (served from cache).
 func (t *SharedChunkCacheTestSuite) TestCacheHitSingleMount() {
 	const (
-		testFileName = "test_cache_hit_single_mount.txt"
-		fileSize     = 30 * util.MiB
-		readSize     = 2 * util.MiB  // Read only 2MB
-		readOffset   = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
+		fileSize   = 30 * util.MiB
+		readSize   = 2 * util.MiB  // Read only 2MB
+		readOffset = 10 * util.MiB // Start at 10MB (in the 2nd chunk)
 	)
+	testFileName := "test_cache_hit_single_mount_" + setup.GenerateRandomString(5) + ".txt"
 
 	// Arrange: Set up test file, verify empty cache, and perform first read to populate cache
 	t.createTestFile(testFileName, fileSize)
@@ -351,10 +351,10 @@ func RunTests(t *testing.T, runName string, factory func(primaryFlags, secondary
 	for _, cfg := range testEnv.cfg.Configs {
 		if cfg.Run == runName {
 			for i, flagStr := range cfg.Flags {
-				primaryFlags := strings.Split(flagStr, ",")
+				primaryFlags := strings.Fields(strings.ReplaceAll(flagStr, ",", " "))
 				var secondaryFlags []string
 				if len(cfg.SecondaryFlags) > i {
-					secondaryFlags = strings.Split(cfg.SecondaryFlags[i], ",")
+					secondaryFlags = strings.Fields(strings.ReplaceAll(cfg.SecondaryFlags[i], ",", " "))
 				}
 				suite.Run(t, factory(primaryFlags, secondaryFlags))
 			}

--- a/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
+++ b/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
@@ -21,10 +21,12 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -107,7 +109,7 @@ func (t *BaseSuite) TearDownTest() {
 
 	if testEnv.cfg.GKEMountedDirectory != "" {
 		// GKE Mode: Just cleanup files
-		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	} else {
 		// GCE Mode: Unmount and clean up
 		t.unmountAndCleanupMount(t.primaryMount, "primary")
@@ -144,13 +146,12 @@ func (t *BaseSuite) mountGcsfuse(mnt mountPoint, mountType string, flags []strin
 func (t *BaseSuite) unmountAndCleanupMount(m mountPoint, name string) {
 	setup.UnmountGCSFuse(m.mntDir)
 	// Cleaning up the intermediate generated test files.
-	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 }
 
 func (t *BaseSuite) createTestFile(fileName string, fileSize int) {
 	t.T().Helper()
-	testFilePath := path.Join(t.primaryMount.testDirPath, fileName)
-	operations.CreateFileOfSize(int64(fileSize), testFilePath, t.T())
+	client.SetupFileInTestDirectory(testEnv.ctx, testEnv.storageClient, testDirName, fileName, int64(fileSize), t.T())
 }
 
 func (t *BaseSuite) getCachedChunkCount() int {
@@ -214,7 +215,7 @@ func (t *SharedChunkCacheTestSuite) TestCacheMiss() {
 	// Act: Read 2MB from the 2nd chunk (triggers download and caching of entire 10MB chunk)
 	primaryFilePath := path.Join(t.primaryMount.testDirPath, testFileName)
 	startTime := time.Now()
-	chunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY)
+	chunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 	cacheMissTime := time.Since(startTime)
 
 	// Assert: Verify read succeeded and entire chunk was cached
@@ -241,7 +242,7 @@ func (t *SharedChunkCacheTestSuite) TestCacheHit() {
 	t.createTestFile(testFileName, fileSize)
 	primaryFilePath := path.Join(t.primaryMount.testDirPath, testFileName)
 	primaryStartTime := time.Now()
-	primaryChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY)
+	primaryChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 	primaryCacheMissTime := time.Since(primaryStartTime)
 	require.NoError(t.T(), err, "Failed to read chunk from primary mount")
 	require.Equal(t.T(), int(readSize), len(primaryChunk), "Read chunk size mismatch on primary mount")
@@ -261,7 +262,7 @@ func (t *SharedChunkCacheTestSuite) TestCacheHit() {
 	_, err = os.Stat(secondaryFilePath)
 	require.NoError(t.T(), err, "Failed to stat file on secondary mount")
 	secondaryStartTime := time.Now()
-	secondaryChunk, err := operations.ReadChunkFromFile(secondaryFilePath, readSize, readOffset, os.O_RDONLY)
+	secondaryChunk, err := operations.ReadChunkFromFile(secondaryFilePath, readSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 	cacheHitTime := time.Since(secondaryStartTime)
 
 	// Assert: Verify read succeeded from cache without re-downloading
@@ -303,7 +304,7 @@ func (t *SharedChunkCacheTestSuite) TestCacheHitSingleMount() {
 	require.Equal(t.T(), 0, initialCacheCount, "Cache should be empty initially")
 	primaryFilePath := path.Join(t.primaryMount.testDirPath, testFileName)
 	firstReadStart := time.Now()
-	firstChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY)
+	firstChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 	cacheMissTime := time.Since(firstReadStart)
 	require.NoError(t.T(), err, "Failed to read chunk on first read (cache miss)")
 	require.Equal(t.T(), int(readSize), len(firstChunk), "Read chunk size mismatch on first read")
@@ -317,7 +318,7 @@ func (t *SharedChunkCacheTestSuite) TestCacheHitSingleMount() {
 
 	// Act: Read the same chunk again from the same mount (should hit cache)
 	secondReadStart := time.Now()
-	secondChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY)
+	secondChunk, err := operations.ReadChunkFromFile(primaryFilePath, readSize, readOffset, os.O_RDONLY|syscall.O_DIRECT)
 	cacheHitTime := time.Since(secondReadStart)
 
 	// Assert: Verify second read succeeded from cache without re-downloading
@@ -350,10 +351,10 @@ func RunTests(t *testing.T, runName string, factory func(primaryFlags, secondary
 	for _, cfg := range testEnv.cfg.Configs {
 		if cfg.Run == runName {
 			for i, flagStr := range cfg.Flags {
-				primaryFlags := strings.Fields(flagStr)
+				primaryFlags := strings.Split(flagStr, ",")
 				var secondaryFlags []string
 				if len(cfg.SecondaryFlags) > i {
-					secondaryFlags = strings.Fields(cfg.SecondaryFlags[i])
+					secondaryFlags = strings.Split(cfg.SecondaryFlags[i], ",")
 				}
 				suite.Run(t, factory(primaryFlags, secondaryFlags))
 			}

--- a/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
+++ b/tools/integration_tests/shared_chunk_cache/shared_chunk_cache_test.go
@@ -348,17 +348,8 @@ func (t *SharedChunkCacheTestSuite) TestCacheHitSingleMount() {
 ////////////////////////////////////////////////////////////////////////
 
 func RunTests(t *testing.T, runName string, factory func(primaryFlags, secondaryFlags []string) suite.TestingSuite) {
-	for _, cfg := range testEnv.cfg.Configs {
-		if cfg.Run == runName {
-			for i, flagStr := range cfg.Flags {
-				primaryFlags := strings.Fields(strings.ReplaceAll(flagStr, ",", " "))
-				var secondaryFlags []string
-				if len(cfg.SecondaryFlags) > i {
-					secondaryFlags = strings.Fields(strings.ReplaceAll(cfg.SecondaryFlags[i], ",", " "))
-				}
-				suite.Run(t, factory(primaryFlags, secondaryFlags))
-			}
-		}
+	for _, flags := range setup.BuildDualMountFlagSets(*testEnv.cfg, testEnv.bucketType, runName) {
+		suite.Run(t, factory(flags.Primary, flags.Secondary))
 	}
 }
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -2356,3 +2356,19 @@ concurrent_operations:
             different_zone: false
         run: TestConcurrentListing
         run_on_gke: true
+
+shared_chunk_cache:
+  - mounted_directory: "${MOUNTED_DIR}"
+    mounted_directory_secondary: "${MOUNTED_DIR_SECONDARY}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+        secondary_flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestSharedChunkCacheTestSuite
+        run_on_gke: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -2126,9 +2126,9 @@ shared_chunk_cache:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache,--enable-kernel-reader=false"
         secondary_flags:
-          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -893,7 +893,6 @@ inactive_stream_timeout:
         run: TestTimeoutDisabledSuite
         run_on_gke: true
 
-
 benchmarking:
   - test_bucket: "${BUCKET_NAME}"
     mounted_directory: "${MOUNTED_DIR}"
@@ -2120,3 +2119,19 @@ otel_exporter:
           zonal: false
         run_on_gke: false
         run: "TestOTelExporterTestSuite"
+
+shared_chunk_cache:
+  - mounted_directory: "${MOUNTED_DIR}"
+    mounted_directory_secondary: "${MOUNTED_DIR_SECONDARY}"
+    test_bucket: "${BUCKET_NAME}"
+    configs:
+      - flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+        secondary_flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: TestSharedChunkCacheTestSuite
+        run_on_gke: false

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -2135,3 +2135,13 @@ shared_chunk_cache:
           zonal: true
         run: TestSharedChunkCacheTestSuite
         run_on_gke: false
+      - flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache,--enable-kernel-reader=false,--experimental-enable-pirlo=true"
+        secondary_flags:
+          - "--enable-experimental-shared-chunk-cache,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/shared-cache,--enable-kernel-reader=false,--experimental-enable-pirlo=true"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run: TestSharedChunkCacheTestSuite
+        run_on_gke: false

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -638,11 +638,48 @@ func bucketType(ctx context.Context, testBucket string) (bType string, err error
 	return FlatBucket, nil
 }
 
-// BuildFlagSets dynamically builds a list of flag sets based on bucket compatibility.
-// bucketType should be "flat", "hns", "zonal", "flat_pirlo", or "hns_pirlo".
-// The testName parameter filters flag sets based on the 'Run' field in the test
-// configuration, which typically corresponds to a specific test name. If testName is
-// an empty string, all flag sets for the package are returned.
+// DualMountFlags holds a paired set of primary and secondary mount flags.
+type DualMountFlags struct {
+	Primary   []string
+	Secondary []string
+}
+
+func isConfigCompatible(testConfig *test_suite.ConfigItem, bucketType string, testName string) bool {
+	isBucketCompatible := false
+	switch bucketType {
+	case FlatPirloBucket:
+		isBucketCompatible = testConfig.RunOnPirlo.Flat.SameZone || testConfig.RunOnPirlo.Flat.DifferentZone
+	case HNSPirloBucket:
+		isBucketCompatible = testConfig.RunOnPirlo.Hns.SameZone || testConfig.RunOnPirlo.Hns.DifferentZone
+	default:
+		var ok bool
+		isBucketCompatible, ok = testConfig.Compatible[bucketType]
+		if !ok {
+			isBucketCompatible = false
+		}
+	}
+	isTPCCompatible := (TestOnTPCEndPoint() == testConfig.TPC)
+	if !isBucketCompatible || !isTPCCompatible {
+		return false
+	}
+
+	// The skip field is intended for function-level test suites where testName is specified (e.g. t.Name()).
+	// Package-level test executions (where testName is empty) do not support skip in test_config.yaml.
+	if testName == "" && len(testConfig.Skip) > 0 {
+		log.Fatalf("Invalid configuration: skip field is not supported when testName is empty in test_config.yaml")
+	}
+
+	if slices.Contains(testConfig.Skip, testName) || (testConfig.Run != "" && testName != testConfig.Run) {
+		return false
+	}
+
+	return true
+}
+
+// BuildFlagSets dynamically generates flag sets based on bucket type compatibility,
+// TPC configurations, and skip/run test rules. If testName is provided, only configs
+// matching testName (via run or skip) are included. If testName is an empty string,
+// all flag sets for the package are returned.
 func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, testName string) [][]string {
 	// In case of mounted-directory, no need to
 	// parse flags. Just return a single
@@ -656,33 +693,7 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, testName string
 
 	// 1. Iterate through each defined test configuration (e.g., HTTP, gRPC).
 	for _, testConfig := range cfg.Configs {
-		// 2. Check if the current test case is compatible with the bucket type.
-		// For Pirlo runs, evaluate the RunOnPirlo struct. Otherwise, check the standard Compatible map.
-		isBucketCompatible := false
-		switch bucketType {
-		case FlatPirloBucket:
-			isBucketCompatible = testConfig.RunOnPirlo.Flat.SameZone || testConfig.RunOnPirlo.Flat.DifferentZone
-		case HNSPirloBucket:
-			isBucketCompatible = testConfig.RunOnPirlo.Hns.SameZone || testConfig.RunOnPirlo.Hns.DifferentZone
-		default:
-			var ok bool
-			isBucketCompatible, ok = testConfig.Compatible[bucketType]
-			if !ok {
-				isBucketCompatible = false
-			}
-		}
-		isTPCCompatible := (TestOnTPCEndPoint() == testConfig.TPC)
-		if !isBucketCompatible || !isTPCCompatible {
-			continue
-		}
-
-		// The skip field is intended for function-level test suites where testName is specified (e.g. t.Name()).
-		// Package-level test executions (where testName is empty) do not support skip in test_config.yaml.
-		if testName == "" && len(testConfig.Skip) > 0 {
-			log.Fatalf("Invalid configuration: skip field is not supported when testName is empty in test_config.yaml")
-		}
-
-		if slices.Contains(testConfig.Skip, testName) || (testConfig.Run != "" && testName != testConfig.Run) {
+		if !isConfigCompatible(&testConfig, bucketType, testName) {
 			continue
 		}
 
@@ -690,6 +701,32 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, testName string
 		for _, flagString := range testConfig.Flags {
 			flagString = strings.ReplaceAll(flagString, ",", " ")
 			dynamicFlags = append(dynamicFlags, strings.Fields(flagString))
+		}
+	}
+	return dynamicFlags
+}
+
+// BuildDualMountFlagSets dynamically generates paired primary and secondary flag sets
+// for dual-mount test suites based on bucket type compatibility, TPC configurations,
+// and skip/run test rules.
+func BuildDualMountFlagSets(cfg test_suite.TestConfig, bucketType string, testName string) []DualMountFlags {
+	var dynamicFlags []DualMountFlags
+
+	for _, testConfig := range cfg.Configs {
+		if !isConfigCompatible(&testConfig, bucketType, testName) {
+			continue
+		}
+
+		for i, flagString := range testConfig.Flags {
+			primaryFlags := strings.Fields(strings.ReplaceAll(flagString, ",", " "))
+			var secondaryFlags []string
+			if len(testConfig.SecondaryFlags) > i {
+				secondaryFlags = strings.Fields(strings.ReplaceAll(testConfig.SecondaryFlags[i], ",", " "))
+			}
+			dynamicFlags = append(dynamicFlags, DualMountFlags{
+				Primary:   primaryFlags,
+				Secondary: secondaryFlags,
+			})
 		}
 	}
 	return dynamicFlags


### PR DESCRIPTION
### Description
This PR integrates the shared chunk cache tests into the integration test suite and updates the test configurations. Specifically, it includes the following changes:
- Adds `"shared_chunk_cache"` to `TEST_PACKAGES_COMMON` in `tools/integration_tests/improved_run_e2e_tests.sh`.
- Refactors bucket references in the `shared_chunk_cache` tests to use `testEnv.cfg.TestBucket` instead of `setup.TestBucket()`.
- Updates the flag parsing logic in `shared_chunk_cache_test.go` to use comma-separated values (`strings.Split`) instead of spaces (`strings.Fields`).
- Adds the `shared_chunk_cache` test block to `tools/integration_tests/test_config.yaml` to run `TestSharedChunkCacheTestSuite` with the relevant experimental shared chunk cache flags on GKE. Note that this configuration was removed in an earlier PR ([#4836](https://github.com/GoogleCloudPlatform/gcsfuse/pull/4836)), assuming it to be present in the `test_config.yaml`.

### Link to the issue in case of a bug fix.
b/535670081

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - This PR specifically updates and configures the integration test suite for the shared chunk cache.

### Any backward incompatible change? If so, please explain.
No.
