### PR TITLE
docs: add documentation for the radix tree implementations

### DIFF
--- a/internal/cache/lru/ARENA-RADIX.md
+++ b/internal/cache/lru/ARENA-RADIX.md
@@ -1,0 +1,78 @@
+# Arena-based Radix Cache (LRU)
+
+This document provides a comprehensive overview of the **Arena-based Radix Cache** implemented in the `internal/cache/lru` package of GCSFuse (`radix_arena.go` and `radix_arena_lru.go`). It is designed to help new contributors understand the memory optimizations and performance benefits of this implementation compared to the standard pointer-based radix cache.
+
+## Overview
+
+The `arenaRadix` is an advanced LRU (Least Recently Used) cache backed by a Radix Tree. While it logically behaves exactly like the pointer-based radix tree (using a Left-Child Right-Sibling structure), it is physically stored in a contiguous array (an **Arena**) instead of dynamically allocated heap objects. 
+
+This design completely eliminates pointer chasing, vastly reduces Go garbage collection (GC) overhead, improves CPU cache locality, and uses a secondary Hash Map to achieve **O(1) lookups** while preserving the prefix-deletion benefits of a Radix Tree.
+
+## Core Architecture & Optimizations
+
+### 1. Arena (Slice-backed) Allocation
+
+Instead of allocating memory on the heap for every tree node using pointers (`*arenaRadixNode`), all nodes are stored in a pre-allocated slice: `nodes []arenaRadixNode`. 
+
+Links between nodes are represented by `uint32` indices rather than 64-bit pointers. The constant `nilNode` (`math.MaxUint32`) is used to represent a null reference.
+
+**Benefits:**
+- **Zero Heap Allocations per node**: Node creation simply involves appending to the slice or reusing a freed index.
+- **Smaller Node Size**: `uint32` indices take half the space of 64-bit pointers.
+- **Cache Locality**: Nodes are packed tightly in contiguous memory, minimizing CPU cache misses during tree traversal.
+
+### 2. Node Structure (`arenaRadixNode`)
+
+```go
+type arenaRadixNode struct {
+	prefix  string
+	value   ValueType
+	
+	// Tree relationships (indices in the `nodes` slice)
+	parent  uint32
+	child   uint32
+	sibling uint32
+	
+	// LRU Linked list (indices in the `nodes` slice)
+	prev    uint32
+	next    uint32
+}
+```
+
+### 3. Fast Lookups with `nodeMap`
+
+A standard Radix Tree requires traversing down the tree character-by-character for a lookup. The Arena Radix Cache optimizes this by maintaining a secondary index:
+`nodeMap map[uint64]uint32`
+
+- **Hashing**: The full string key is hashed using an extremely fast, allocation-free **FNV-1a 64-bit** hash (`hashString`).
+- **O(1) Retrieval**: The hash is used to instantly look up the `uint32` node index from the `nodeMap`.
+- **Collision Safety (`verifyKey`)**: Because hash collisions are possible, `verifyKey` takes the retrieved node and walks *upwards* to the root using the `parent` index, comparing the key backwards to perfectly verify it against the search key. This upward traversal is allocation-free.
+
+### 4. Memory Reuse (The Free List)
+
+When a node is deleted (e.g., during eviction or prefix deletion), we cannot easily shrink the `nodes` slice. Instead, the Arena uses a **Free List**.
+
+- The `arenaRadix` struct maintains a `freeHead uint32` index.
+- When `freeNode` is called, the node's fields are zeroed out, and its `next` index is pointed to the current `freeHead`. `freeHead` is then updated to this node's index.
+- When `allocateNode` is called, it pops from `freeHead`. If `freeHead` is empty (`nilNode`), it appends a new node to the `nodes` slice.
+
+## Key Operations
+
+### Tree and LRU Operations
+
+The logical tree operations (Insertion, Splitting, Deletion) and LRU operations (MoveToFront, Evict) are structurally identical to the pointer-based radix tree, but strictly manipulate `uint32` indices instead of pointers.
+- **Insertion**: May create new nodes from the free list, manipulating `child` and `sibling` indices. It inserts the node ID into the `nodeMap` once constructed.
+- **Eviction/Erasure**: Removes the node from the `nodes` array by placing it in the free list, unlinks it from the LRU via `prev`/`next` indices, and deletes the hash from `nodeMap`.
+
+### Prefix Deletion (`EraseEntriesWithGivenPrefix`)
+
+This cache achieves the best of both worlds:
+1. Lookups are O(1) thanks to the `nodeMap`.
+2. Prefix deletions are highly efficient because the hierarchical tree structure is maintained.
+
+When deleting by prefix, the tree is traversed downwards to find the boundary node. The subtree is detached by removing its link from its parent's sibling chain. Finally, we call `freeSubtree` which iterates through the detached subtree, removing each child's hash from `nodeMap` and returning the node indices back to the free list.
+
+## Invariant Checking
+
+Like the pointer radix, `checkInvariants()` ensures the tree hierarchy (measured via traversal) perfectly aligns with the elements physically present in the LRU linked list. Due to the array structure, these traversals happen entirely via index jumps across the contiguous memory slice, preventing panic-inducing nil-pointer dereferences common in corrupted pointer-based linked lists.
+

--- a/internal/cache/lru/RADIX.md
+++ b/internal/cache/lru/RADIX.md
@@ -1,0 +1,99 @@
+# Pointer-based Radix Cache (LRU)
+
+This document provides a comprehensive overview of the **Pointer-based Radix Cache** implemented in the `internal/cache/lru` package of GCSFuse (`radix.go`). It is designed to help new contributors understand the architecture, data structures, and algorithms used in this cache implementation.
+
+## Overview
+
+The `radixCache` is an implementation of an LRU (Least Recently Used) cache backed by a custom Radix Tree. It is specifically designed to efficiently store and retrieve prefix-based string keys while maintaining a strict memory bound (`maxSize`). 
+
+By combining a radix tree with a doubly linked list, the cache achieves fast prefix lookups, insertions, and deletions, while efficiently evicting the least recently used entries.
+
+## Core Data Structures
+
+### 1. Left-Child Right-Sibling (LCRS) Representation
+
+Standard radix trees or tries often use an array or a hash map to store children (e.g., `map[byte]*Node` or `[256]*Node`). This approach incurs heavy memory overhead and frequent slice allocations. 
+
+To avoid these allocations, this implementation uses the **Left-Child Right-Sibling (LCRS)** representation.
+Every node has exactly three tree-related pointers:
+- `parent`: Pointer to the parent node.
+- `child`: Pointer to the **first** child node.
+- `sibling`: Pointer to the **next** sibling node.
+
+In this structure, the children of a node are represented as a linked list. To find a specific child, the tree iterates through the `child` and its `sibling` chain. The siblings are maintained in lexicographical order (sorted by the first byte of their prefix), allowing for early exits during search.
+
+### 2. `radixNode` Struct
+
+The `radixNode` structure encapsulates both the tree hierarchy and the LRU doubly linked list:
+
+```go
+type radixNode struct {
+	prefix  string      // The string segment matched at this node
+	value   ValueType   // The cached value (nil for routing nodes)
+	
+	// Tree pointers
+	parent  *radixNode
+	child   *radixNode
+	sibling *radixNode
+	
+	// LRU Doubly Linked List pointers
+	prev *radixNode
+	next *radixNode
+}
+```
+
+- **Routing Nodes vs. Value Nodes**: A node may just be a "routing node" holding a common prefix for its children, in which case its `value` is `nil`. If it holds a cache entry, `value` is non-nil.
+
+### 3. `radixCache` Struct
+
+The `radixCache` struct holds the state of the cache:
+
+```go
+type radixCache struct {
+	maxSize     uint64       // Maximum allowed size of all values combined
+	currentSize uint64       // Current sum of all value sizes
+	
+	root        *radixNode   // Root of the radix tree
+	
+	head        *radixNode   // MRU (Most Recently Used) end of the list
+	tail        *radixNode   // LRU (Least Recently Used) end of the list
+	len         int          // Number of elements in the LRU list
+	
+	mu          locker.RWLocker // Read-Write lock for concurrency safety
+}
+```
+
+## Key Operations
+
+### Tree Operations
+
+1.  **Insertion (`insertNode`)**:
+    When inserting a key, the tree is traversed character by character. 
+    - If a matching prefix is partially found, the existing node is **split** into two nodes. The common prefix becomes the parent, and the remaining parts become children.
+    - If no child matches the next byte, a new leaf node is created and added to the sibling list.
+2.  **Lookup (`getNode`)**:
+    Traverses the tree by matching the search key with node prefixes. Because siblings are ordered lexicographically, the search is highly efficient.
+3.  **Deletion & Compression (`compressPathUpwards`)**:
+    When an entry is removed, its value is set to `nil`. If the node becomes a leaf (no children) and has no value, it is removed. To prevent the tree from becoming deep and sparse, `compressPathUpwards` walks up the tree. If it finds a routing node with only one child, it merges the node with its child, concatenating their prefixes.
+
+### LRU Operations
+
+The LRU cache is managed by updating the `prev` and `next` pointers of `radixNode` when values are accessed or inserted.
+-   **`pushFront`**: Inserts a new node at the MRU end (`head`).
+-   **`moveToFront`**: Moves an accessed node to the MRU end.
+-   **`evictOne`**: Removes the node at the LRU end (`tail`) from both the linked list and the tree.
+
+### Prefix Deletion (`EraseEntriesWithGivenPrefix`)
+
+One of the main benefits of using a Radix Tree over a flat Hash Map is the ability to efficiently delete all entries sharing a specific prefix. 
+Instead of iterating through all keys, the cache traverses down to the node representing the prefix. It severs that subtree entirely and recursively sweeps it to free memory, update `currentSize`, and unlink the nodes from the LRU list.
+
+## Invariant Checking
+
+For robust concurrency and memory safety, the cache maintains strict invariants verified by `checkInvariants()`:
+- `currentSize` must never exceed `maxSize`.
+- Every element in the LRU list must have a non-nil value.
+- The number of value-bearing nodes in the tree must exactly match the length of the LRU list.
+
+These invariants ensure the tree structure and the LRU linked list are perfectly synchronized.
+


### PR DESCRIPTION
### Description
Added documentation for the Radix Trie Based LRU Cache and its Arena Based implementation.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
