### PR TITLE
ci(perf-tests): utilize louhi custom commit variable

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -27,13 +27,23 @@ cd "${KOKORO_ARTIFACTS_DIR}/github/gcsfuse"
 
 # Get the branch name that was cloned by Kokoro
 branchName=$(git branch --format='%(refname:short)' | grep -v 'HEAD' | head -n 1)
-# Get the commitId. Build gcsfuse and run.
-# - Automated daily runs (initiated by Kokoro scheduler) will run on the last commit of yesterday on the master branch.
-# - Manual runs (initiated by users) will run on the latest commit of the branch (master or feature branch) provided in the manual trigger.
-if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
-  commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+
+# Utilize Louhi custom commit checkouts if provided
+if [[ -n "${_COMMIT_HASH:-}" ]]; then
+  echo "Louhi environment variable _COMMIT_HASH detected: ${_COMMIT_HASH}"
+  echo "Checking out custom commit..."
+  git checkout "${_COMMIT_HASH}"
+  commitId="${_COMMIT_HASH}"
 else
-  commitId=$(git log -n 1 --pretty=%H)
+  echo "No _COMMIT_HASH detected. Proceeding with default branch checkout logic."
+  # Get the commitId. Build gcsfuse and run.
+  # - Automated daily runs (initiated by Kokoro scheduler) will run on the last commit of yesterday on the master branch.
+  # - Manual runs (initiated by users) will run on the latest commit of the branch (master or feature branch) provided in the manual trigger.
+  if [[ "${KOKORO_BUILD_INITIATOR:-}" == "kokoro" ]]; then
+    commitId=$(git log --before='yesterday 23:59:59' --max-count=1 --pretty=%H)
+  else
+    commitId=$(git log -n 1 --pretty=%H)
+  fi
 fi
 echo "Running tests on branch: ${branchName} at commit ID: ${commitId}"
 


### PR DESCRIPTION
### Description
This pull request updates the continuous test build script for GCP Ubuntu to support custom commit checkouts using the Louhi-provided environment variable `_COMMIT_HASH`. 

If `_COMMIT_HASH` is detected in the environment, the script will check out that specific commit to run performance tests. If the variable is absent, the script falls back to the default branch checkout logic used by Kokoro (selecting either yesterday's last commit for automated runs or the latest commit of the branch for manual runs).

### Link to the issue in case of a bug fix.
b/535254203

### Testing details
1. Manual - N/A
2. Unit tests - N/A
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
None. This change adds backward-compatible support for custom commit checkouts without altering default Kokoro execution paths when `_COMMIT_HASH` is not supplied.