### PR TITLE
test: Remove flat bucket test configurations for Pirlo

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1703,8 +1703,6 @@ monitoring:
           zonal: false
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
-        run: "TestPromBufferedReadSuite"
-        run_on_gke: false
       - flags:
           - "--prometheus-port=10191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
         compatible:
@@ -1727,8 +1725,6 @@ monitoring:
           flat: true
           hns: false
           zonal: false
-        run: "TestPromGrpcMetricsSuite"
-        run_on_gke: false
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -24,16 +24,6 @@ explicit_dir:
           hns: false
           zonal: false
         run_on_gke: true
-      - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
-          hns:
-            same_zone: false
-            different_zone: false
-        run_on_gke: true
 
 implicit_dir:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -49,9 +39,6 @@ implicit_dir:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -80,9 +67,6 @@ list_large_dir:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--stat-cache-ttl=0,--kernel-list-cache-ttl-secs=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -100,9 +84,6 @@ list_large_dir:
       - flags:
           - "--experimental-enable-pirlo,--enable-metadata-prefetch,--implicit-dirs,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -127,9 +108,6 @@ operations:
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -167,9 +145,6 @@ write_large_files:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--write-max-blocks-per-file=2,--write-global-max-blocks=5,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: true
           hns:
             same_zone: true
             different_zone: true
@@ -178,9 +153,6 @@ write_large_files:
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--write-max-blocks-per-file=2,--write-global-max-blocks=5,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -201,9 +173,6 @@ gzip:
       - flags:
           - "--experimental-enable-pirlo,--sequential-read-size-mb=1,--implicit-dirs,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -238,9 +207,6 @@ read_large_files:
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/read_large_files,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -265,9 +231,6 @@ readonly:
           - "--experimental-enable-pirlo,--file-mode=544,--dir-mode=544,--implicit-dirs,--client-protocol=http1"
           - "--experimental-enable-pirlo,--o=ro,--implicit-dirs,--cache-dir=/gcsfuse-tmp/readonly,--file-cache-max-size-mb=3,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -295,22 +258,8 @@ rename_dir_limit:
           zonal: true
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--rename-dir-limit=3,--implicit-dirs,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--rename-dir-limit=3,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
-          hns:
-            same_zone: false
-            different_zone: false
-        run_on_gke: true
-      - flags:
           - "--experimental-enable-pirlo,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: false
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -346,9 +295,6 @@ local_file:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -370,9 +316,6 @@ streaming_writes:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--rename-dir-limit=3,--write-block-size-mb=1,--write-max-blocks-per-file=2,--write-global-max-blocks=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -393,9 +336,6 @@ cloud_profiler:
       - flags:
           - "--experimental-enable-pirlo,--enable-cloud-profiler,--cloud-profiler-cpu,--cloud-profiler-heap,--cloud-profiler-goroutines,--cloud-profiler-mutex,--cloud-profiler-allocated-heap,--cloud-profiler-label=${PROFILE_LABEL},--cloud-profiler-service-name=${PROFILE_SERVICE_NAME},--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -437,9 +377,6 @@ read_cache:
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -466,9 +403,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--o=ro,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--o=ro,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -486,9 +420,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -506,9 +437,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest,--log-file=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -529,9 +457,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -552,9 +477,6 @@ read_cache:
           - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -578,9 +500,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -612,9 +531,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -644,9 +560,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseWithParallelDownloads.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -675,9 +588,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestJobChunkTest,--log-file=/gcsfuse-tmp/TestJobChunkTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -705,9 +615,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=9,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=48,--file-cache-enable-parallel-downloads,--file-cache-parallel-downloads-per-file=4,--file-cache-max-parallel-downloads=2,--file-cache-download-chunk-size-mb=4,--file-cache-enable-crc,--cache-dir=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads,--log-file=/gcsfuse-tmp/TestJobChunkTestWithParallelDownloads.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -735,9 +642,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-exclude-regex=^${BUCKET_NAME}/,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/,--file-cache-exclude-regex=^${BUCKET_NAME}/,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -758,9 +662,6 @@ read_cache:
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -781,9 +682,6 @@ read_cache:
           - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-include-regex=^${BUCKET_NAME}/.*ReadCacheTest.*/foo*,--file-cache-exclude-regex=invalid,--file-cache-max-size-mb=9,--cache-dir=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest,--log-file=/gcsfuse-tmp/TestCacheFileForIncludeRegexTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -800,9 +698,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheTest,--log-file=/gcsfuse-tmp/TestChunkCacheTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -819,9 +714,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestChunkCacheDisabledTest,--log-file=/gcsfuse-tmp/TestChunkCacheDisabledTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -838,9 +730,6 @@ read_cache:
       - flags:
           - "--experimental-enable-pirlo,--file-cache-experimental-enable-chunk-cache=true,--file-cache-download-chunk-size-mb=10,--file-cache-max-size-mb=15,--cache-dir=/gcsfuse-tmp/TestChunkCacheEviction,--log-file=/gcsfuse-tmp/TestChunkCacheEviction.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -864,9 +753,6 @@ stale_handle:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -885,9 +771,6 @@ stale_handle:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -910,9 +793,6 @@ readdirplus:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-readdirplus,--experimental-enable-dentry-cache,--log-file=/gcsfuse-tmp/TestReaddirplusWithDentryCacheTest.log,--log-severity=TRACE,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -930,9 +810,6 @@ readdirplus:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-readdirplus,--log-file=/gcsfuse-tmp/TestReaddirplusWithoutDentryCacheTest.log,--log-severity=TRACE,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -955,9 +832,6 @@ inactive_stream_timeout:
       - flags:
           - "--experimental-enable-pirlo,--read-inactive-stream-timeout=1s,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutEnabledSuite.log,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -974,9 +848,6 @@ inactive_stream_timeout:
       - flags:
           - "--experimental-enable-pirlo,--read-inactive-stream-timeout=0s,--log-format=json,--log-file=/gcsfuse-tmp/TestTimeoutDisabledSuite.log,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1000,9 +871,6 @@ benchmarking:
       - flags:
           - "--experimental-enable-pirlo,--stat-cache-ttl=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1020,9 +888,6 @@ benchmarking:
       - flags:
           - "--experimental-enable-pirlo,--stat-cache-ttl=0,--enable-atomic-rename-object,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1040,9 +905,6 @@ benchmarking:
       - flags:
           - "--experimental-enable-pirlo,--stat-cache-ttl=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1065,9 +927,6 @@ dentry_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=2,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1085,9 +944,6 @@ dentry_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1105,9 +961,6 @@ dentry_cache:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--experimental-enable-dentry-cache,--metadata-cache-ttl-secs=1000,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1130,9 +983,6 @@ read_gcs_algo:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1155,9 +1005,6 @@ unfinalized_object:
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=-1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=-1,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1176,9 +1023,6 @@ unfinalized_object:
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--client-protocol=http1"
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1197,9 +1041,6 @@ unfinalized_object:
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=2,--client-protocol=http1"
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=2,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1237,9 +1078,6 @@ interrupt:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--ignore-interrupts=false,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--ignore-interrupts=false,--enable-streaming-writes=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1261,9 +1099,6 @@ log_rotation:
           - "--experimental-enable-pirlo,--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress=false,--log-severity=trace,--client-protocol=http1"
           - "--experimental-enable-pirlo,--log-file=/gcsfuse-tmp/TestLogRotation.log,--log-rotate-max-file-size-mb=2,--log-rotate-backup-file-count=2,--log-rotate-compress,--log-severity=trace,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1287,9 +1122,6 @@ readonly_creds:
           - "--experimental-enable-pirlo,--implicit-dirs=true,--client-protocol=http1"
           - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1309,9 +1141,6 @@ mount_timeout:
       - flags:
           - "--experimental-enable-pirlo,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1343,9 +1172,6 @@ mounting:
       - flags:
           - "--experimental-enable-pirlo,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1367,9 +1193,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--profile=unknown-profile,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1385,10 +1208,6 @@ flag_optimizations:
       - run: TestImplicitDirsNotEnabled
         flags:
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
         run_on_gke: true
       - run: TestRenameDirLimitNotSet
         flags:
@@ -1405,10 +1224,6 @@ flag_optimizations:
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--client-protocol=http1"
           - "--experimental-enable-pirlo,--profile=aiml-training,--client-protocol=http1"
           - "--experimental-enable-pirlo,--profile=aiml-serving,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
         run_on_gke: true
       - run: TestImplicitDirsEnabled
         flags:
@@ -1433,10 +1248,6 @@ flag_optimizations:
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-training,--client-protocol=http1"
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-serving,--client-protocol=http1"
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-checkpointing,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
         run_on_gke: true
       - run: TestRenameDirLimitSet
         flags:
@@ -1453,10 +1264,6 @@ flag_optimizations:
           - "--experimental-enable-pirlo,--machine-type=a3-highgpu-8g,--client-protocol=http1"
           - "--experimental-enable-pirlo,--profile=aiml-checkpointing,--client-protocol=http1"
           - "--experimental-enable-pirlo,--machine-type=low-end-machine,--profile=aiml-checkpointing,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
         run_on_gke: true
       - run: TestZonalBucketOptimizations
         flags:
@@ -1470,9 +1277,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--log-severity=trace,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1489,9 +1293,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--max-read-ahead-kb=2048,--max-background=50,--congestion-threshold=30,--log-severity=trace,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1508,9 +1309,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--log-severity=trace,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1534,9 +1332,6 @@ flag_optimizations:
           - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-buffered-read=true,--client-protocol=http1"
           - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-buffered-read=true,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestKernelReader_DefaultAndPrecedence_Both,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1554,9 +1349,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/TestFileCache_KernelReaderDisabled,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1574,9 +1366,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--enable-kernel-reader=false,--enable-buffered-read,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1593,9 +1382,6 @@ flag_optimizations:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--log-severity=trace,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1622,9 +1408,6 @@ unsupported_path:
       - flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--enable-unsupported-path-support,--rename-dir-limit=200,--metadata-cache-negative-ttl-secs=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1647,9 +1430,6 @@ kernel_list_cache:
       - flags:
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1669,9 +1449,6 @@ kernel_list_cache:
       - flags:
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--metadata-cache-ttl-secs=0,--metadata-cache-negative-ttl-secs=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1689,9 +1466,6 @@ kernel_list_cache:
       - flags:
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=5,--rename-dir-limit=10,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1709,9 +1483,6 @@ kernel_list_cache:
       - flags:
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=0,--stat-cache-ttl=0,--rename-dir-limit=10,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1735,9 +1506,6 @@ rapid_operations:
         flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1758,9 +1526,6 @@ rapid_operations:
         secondary_flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1791,9 +1556,6 @@ rapid_operations:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache,--metadata-cache-ttl-secs=0,--enable-kernel-reader=false,--client-protocol=http1" # FileCacheWithoutKernelReader
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=70,--file-cache-max-size-mb=-1,--cache-dir=/gcsfuse-tmp/cache,--enable-kernel-reader=false,--client-protocol=http1" # MetadataAndFileCacheWithoutKernelReader
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1826,9 +1588,6 @@ rapid_operations:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1861,9 +1620,6 @@ rapid_operations:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--write-block-size-mb=1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1882,9 +1638,6 @@ rapid_operations:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=true"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1901,9 +1654,6 @@ rapid_operations:
         flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false,--metadata-cache-ttl-secs=0"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1912,9 +1662,6 @@ rapid_operations:
         flags:
           - "--experimental-enable-pirlo"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: true
           hns:
             same_zone: true
             different_zone: true
@@ -1933,17 +1680,6 @@ monitoring:
         run: "TestPromOTELSuite"
         run_on_gke: false
       - flags:
-          - "--experimental-enable-pirlo,--prometheus-port=11190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
-          hns:
-            same_zone: false
-            different_zone: false
-        run: "TestPromOTELSuite"
-        run_on_gke: false
-      - flags:
           - "--prometheus-port=10190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
         compatible:
           flat: false
@@ -1954,9 +1690,6 @@ monitoring:
       - flags:
           - "--experimental-enable-pirlo,--prometheus-port=12190,--cache-dir=/gcsfuse-tmp/PromOTELSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromOTELSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: false
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -1970,15 +1703,6 @@ monitoring:
           zonal: false
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
-      - flags:
-          - "--experimental-enable-pirlo,--prometheus-port=11191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
-          hns:
-            same_zone: false
-            different_zone: false
         run: "TestPromBufferedReadSuite"
         run_on_gke: false
       - flags:
@@ -1992,9 +1716,6 @@ monitoring:
       - flags:
           - "--experimental-enable-pirlo,--prometheus-port=12191,--enable-buffered-read,--read-block-size-mb=4,--read-random-seek-threshold=2,--read-global-max-blocks=5,--read-min-blocks-per-handle=2,--read-start-blocks-per-handle=2,--log-file=/gcsfuse-tmp/TestPromBufferedReadSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: false
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2008,15 +1729,6 @@ monitoring:
           zonal: false
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
-      - flags:
-          - "--experimental-enable-pirlo,--experimental-enable-grpc-metrics,--prometheus-port=11192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
-        run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
-          hns:
-            same_zone: false
-            different_zone: false
         run: "TestPromGrpcMetricsSuite"
         run_on_gke: false
       - flags:
@@ -2030,9 +1742,6 @@ monitoring:
       - flags:
           - "--experimental-enable-pirlo,--experimental-enable-grpc-metrics,--prometheus-port=12192,--cache-dir=/gcsfuse-tmp/TestPromGrpcMetricsSuite,--file-cache-max-size-mb=-1,--log-file=/gcsfuse-tmp/TestPromGrpcMetricsSuite.log,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: false
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2049,9 +1758,6 @@ monitoring:
       - flags:
           - "--experimental-enable-pirlo,--prometheus-port=12193,--log-file=/gcsfuse-tmp/TestPromKernelReaderSuite.log,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2075,9 +1781,6 @@ symlink_handling:
         flags:
           - "--experimental-enable-pirlo,--enable-standard-symlinks=true,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2095,9 +1798,6 @@ symlink_handling:
         flags:
           - "--experimental-enable-pirlo,--enable-standard-symlinks=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2120,9 +1820,6 @@ buffered_read:
           - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=1,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestBufferedReadSuite.log,--log-severity=TRACE,--client-protocol=http1"
         run: TestSequentialReadSuite
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2139,9 +1836,6 @@ buffered_read:
       - flags:
           - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-min-blocks-per-handle=2,--read-global-max-blocks=1,--read-max-blocks-per-handle=10,--read-start-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestInsufficientPoolCreationSuite.log,--log-severity=TRACE,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2159,9 +1853,6 @@ buffered_read:
       - flags:
           - "--experimental-enable-pirlo,--enable-buffered-read,--read-block-size-mb=8,--read-max-blocks-per-handle=20,--read-start-blocks-per-handle=2,--read-min-blocks-per-handle=2,--enable-kernel-reader=false,--log-file=/gcsfuse-tmp/TestRandomReadFallbackSuite.log,--log-severity=TRACE,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2185,9 +1876,6 @@ negative_stat_cache:
       - flags:
           - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2205,9 +1893,6 @@ negative_stat_cache:
       - flags:
           - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=5,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2225,9 +1910,6 @@ negative_stat_cache:
       - flags:
           - "--experimental-enable-pirlo,--metadata-cache-negative-ttl-secs=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2251,9 +1933,6 @@ managed_folders:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=3,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2270,9 +1949,6 @@ managed_folders:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--enable-empty-managed-folders,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2289,9 +1965,6 @@ managed_folders:
         flags:
           - "--experimental-enable-pirlo,--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=5,--stat-cache-ttl=0,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2325,9 +1998,6 @@ concurrent_operations:
           - "--experimental-enable-pirlo,--enable-buffered-read,--enable-kernel-reader=false,--enable-metadata-prefetch,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false
@@ -2348,9 +2018,6 @@ concurrent_operations:
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=0,--enable-metadata-prefetch,--client-protocol=http1"
           - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--client-protocol=http1"
         run_on_pirlo:
-          flat:
-            same_zone: true
-            different_zone: false
           hns:
             same_zone: true
             different_zone: false


### PR DESCRIPTION
### Description
This PR removes the flat bucket test configurations for Pirlo in tools/integration_tests/test_config.yaml. Pirlo currently does not support flat buckets, so these test scenarios are no longer applicable and are being removed.

### Link to the issue in case of a bug fix.
b/536789480

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
