### PR TITLE
fix: Fix the gke machine type test failure

### DIFF
--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -95,14 +95,21 @@ steps:
   - '-c'
   - |
     set -e
-    # --- Install gcloud ---
+    # --- Install gcloud and newer Docker CLI ---
     apt-get update && apt-get install -y apt-transport-https ca-certificates gnupg curl
+    
+    # Docker repo
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu focal stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    
+    # Gcloud repo
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
     echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee /etc/apt/sources.list.d/google-cloud-sdk.list
-    apt-get update && apt-get install -y google-cloud-cli kubectl
+    
+    apt-get update && apt-get install -y google-cloud-cli docker-ce-cli kubectl
 
     # --- Authenticate Docker ---
-    gcloud auth configure-docker gcr.io --quiet
+    gcloud auth configure-docker us-docker.pkg.dev --quiet
 
     # --- Download gcsfuse binaries ---
     GCSFUSE_PATH=$$(cat /workspace/bucket_name)
@@ -112,9 +119,14 @@ steps:
       STAGINGVERSION=${BUILD_ID}
       STAGINGVERSION=${_IMAGE_PREFIX}-$${STAGINGVERSION:0:8}
     fi
-    REGISTRY="gcr.io/${PROJECT_ID}/${_USER}-gcsfuse-csi"
+    REGISTRY="us-docker.pkg.dev/${PROJECT_ID}/${_USER}-gcsfuse-csi"
 
-    make build-image-and-push-multi-arch REGISTRY=$${REGISTRY} GCSFUSE_PATH=$${GCSFUSE_PATH} STAGINGVERSION=$${STAGINGVERSION} BUILD_ARM=${_BUILD_ARM}
+    make build-image-and-push-multi-arch \
+      REGISTRY=$${REGISTRY} \
+      GCSFUSE_PATH=$${GCSFUSE_PATH} \
+      STAGINGVERSION=$${STAGINGVERSION} \
+      BUILD_ARM=${_BUILD_ARM} \
+      SKIP_VAR=true
 
 # This step cleans up the GCS bucket.
 - name: 'gcr.io/cloud-builders/gcloud'

--- a/csi_driver_build.yml
+++ b/csi_driver_build.yml
@@ -100,7 +100,7 @@ steps:
     
     # Docker repo
     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu focal stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$$VERSION_CODENAME") stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
     
     # Gcloud repo
     curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
@@ -125,8 +125,7 @@ steps:
       REGISTRY=$${REGISTRY} \
       GCSFUSE_PATH=$${GCSFUSE_PATH} \
       STAGINGVERSION=$${STAGINGVERSION} \
-      BUILD_ARM=${_BUILD_ARM} \
-      SKIP_VAR=true
+      BUILD_ARM=${_BUILD_ARM}
 
 # This step cleans up the GCS bucket.
 - name: 'gcr.io/cloud-builders/gcloud'


### PR DESCRIPTION
1. Symptom
The GCSFuse CSI Driver multi-arch build was failing during the Cloud Build execution at the docker manifest create step. It threw a no such manifest error for the newly built _linux_amd64 image, despite the logs showing that the image was successfully compiled and pushed:


2. Root Cause
The issue was caused by a combination of deprecation and tool incompatibility:

GCR Deprecation: The build was originally configured to push to Container Registry (gcr.io), which is being sunset. We needed to migrate to Artifact Registry (us-docker.pkg.dev).
Docker CLI Bug in Cloud Build: The official Cloud Build step container (gcr.io/cloud-builders/docker) uses an outdated Docker version (20.10.24).
OCI Manifest Incompatibility: While buildx successfully pushed the OCI-compliant images to Artifact Registry, the older Docker CLI version in the container had known bugs that prevented it from correctly inspecting or recognizing OCI manifests in Artifact Registry, resulting in the false no such manifest error.

3. Resolution:
We modified csi_driver_build.yml to:

Migrate Registry: Point REGISTRY to Artifact Registry (us-docker.pkg.dev).
Upgrade Docker CLI: Added a step to install a modern Docker CLI version (docker-ce-cli v28.1.1) inside the builder container before running the makefile.
Update Auth: Authenticated the new Docker CLI against us-docker.pkg.dev using gcloud.

Manual run on kokoro is passing:

<img width="826" height="1466" alt="image" src="https://github.com/user-attachments/assets/e35359e3-12d7-4285-bbb5-d508f7668846" />

