### PR TITLE
feat(metrics): Support custom resource attributes on OTel exporter

### DIFF
--- a/internal/monitor/otelexporters.go
+++ b/internal/monitor/otelexporters.go
@@ -29,6 +29,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.opentelemetry.io/contrib/detectors/gcp"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/exemplar"
@@ -45,7 +46,7 @@ const cloudMonitoringMetricPrefix = "custom.googleapis.com/gcsfuse/"
 var allowedMetricPrefixes = []string{"fs/", "gcs/", "file_cache/", "buffered_read/", "grpc.", "read/"}
 
 // SetupOTelMetricExporters sets up the metrics exporters
-func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config, mountID string) (shutdownFn common.ShutdownFn) {
+func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config, mountID string, extraAttrs ...attribute.KeyValue) (shutdownFn common.ShutdownFn) {
 	var shutdownFns []common.ShutdownFn
 	options := make([]metric.Option, 0)
 
@@ -56,7 +57,7 @@ func SetupOTelMetricExporters(ctx context.Context, c *cfg.Config, mountID string
 	opts = setupCloudMonitoring(c.Metrics.CloudMetricsExportIntervalSecs)
 	options = append(options, opts...)
 
-	res, err := getResource(ctx, mountID)
+	res, err := getResource(ctx, mountID, extraAttrs...)
 	if err != nil {
 		logger.Errorf("Error while fetching resource: %v", err)
 	} else {
@@ -193,15 +194,18 @@ func serveMetrics(port int64, shutdownCh <-chan context.Context, done chan<- any
 	logger.Info("Prometheus collector exporter started")
 }
 
-func getResource(ctx context.Context, mountID string) (*resource.Resource, error) {
+func getResource(ctx context.Context, mountID string, extraAttrs ...attribute.KeyValue) (*resource.Resource, error) {
+	attrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(common.GetVersion()),
+		semconv.ServiceInstanceID(mountID),
+	}
+	attrs = append(attrs, extraAttrs...)
+
 	return resource.New(ctx,
 		// Use the GCP resource detector to detect information about the GCP platform
 		resource.WithDetectors(gcp.NewDetector()),
 		resource.WithTelemetrySDK(),
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(common.GetVersion()),
-			semconv.ServiceInstanceID(mountID),
-		),
+		resource.WithAttributes(attrs...),
 	)
 }

--- a/internal/monitor/otelexporters_test.go
+++ b/internal/monitor/otelexporters_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"google.golang.org/grpc/codes"
@@ -88,4 +89,21 @@ func TestPermissionAwareExporter_ExportOtherError(t *testing.T) {
 
 	assert.Error(t, err)
 	assert.False(t, exporter.disabled.Load())
+}
+
+func TestGetResource_ExtraAttributes(t *testing.T) {
+	ctx := context.Background()
+	res, err := getResource(ctx, "test-mount-id", attribute.String("volume_name", "vol-1"), attribute.String("bucket_name", "my-bucket"))
+	require.NoError(t, err)
+	require.NotNil(t, res)
+
+	attrs := res.Attributes()
+	attrMap := make(map[string]string)
+	for _, a := range attrs {
+		attrMap[string(a.Key)] = a.Value.AsString()
+	}
+
+	assert.Equal(t, "vol-1", attrMap["volume_name"])
+	assert.Equal(t, "my-bucket", attrMap["bucket_name"])
+	assert.Equal(t, "test-mount-id", attrMap["service.instance.id"])
 }


### PR DESCRIPTION
## Description
Support passing variadic extraAttrs to `SetupOTelMetricExporters` and `getResource` to attach `volume_name` and `bucket_name` as OpenTelemetry resource attributes for the new `gke.googleapis.com/GcsFuse` monitored resource.

## Link to Design Doc
https://docs.google.com/document/d/1Mtyg1NdjLkyhv3Je7sferZcCLExlUf3YA7xRzM1yDto/edit

## Testing
- Extended `internal/monitor/otelexporters_test.go` with `TestGetResource_ExtraAttributes` verifying custom resource attributes.
- Unit tests passed: `go test ./internal/monitor/... ./metrics/...`