### PR TITLE
fix(integration_tests): clean up GCS objects on test completion in implicit_and_explicit_dir_setup

### DIFF
--- a/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
+++ b/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup/implicit_and_explicit_dir_setup.go
@@ -118,6 +118,14 @@ func CreateImplicitDirectoryStructureUsingStorageClient(ctx context.Context, t *
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 	// testBucket/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 
+	// Clean up implicit objects on GCS when the test completes
+	t.Cleanup(func() {
+		err := client.DeleteAllObjectsWithPrefix(context.Background(), storageClient, testDir)
+		if err != nil {
+			t.Logf("DeleteAllObjectsWithPrefix failed for %q: %v", testDir, err)
+		}
+	})
+
 	// Create implicit directory in bucket for testing.
 	testdataCreateObjects(ctx, t, storageClient, testDir)
 }
@@ -180,6 +188,14 @@ func CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(ctx c
 	// testBucket/testDir/explicitDirectory/implicitDirectory/fileInImplicitDir1                              -- File
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 	// testBucket/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
+
+	// Clean up implicit objects on GCS when the test completes
+	t.Cleanup(func() {
+		err := client.DeleteAllObjectsWithPrefix(context.Background(), storageClient, testDir)
+		if err != nil {
+			t.Logf("DeleteAllObjectsWithPrefix failed for %q: %v", testDir, err)
+		}
+	})
 
 	// CreateExplicitDirectoryStructure writes files using GCSFuse.
 	CreateExplicitDirectoryStructure(testDir, t)


### PR DESCRIPTION
### Description
When running `explicit_dir` or `implicit_dir` integration tests against persistent test buckets, `CreateImplicitDirectoryStructureUsingStorageClient` and `CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient` leave test objects in GCS after test completion.

Because GCSFuse runs few tests with `--implicit-dirs=false`, mount-level directory setup (`os.RemoveAll` on the mounted FUSE directory) does not discover or delete implicit GCS objects. Consequently, when subsequent test cases or flag combinations (e.g. `--client-protocol=grpc`) run in the test suite, `client.CreateObjectOnGCS` attempts to write objects with precondition `storage.Conditions{DoesNotExist: true}` (`If-Generation-Match: 0`), failing with:
`googleapi: Error 412: At least one of the pre-conditions you specified did not hold., conditionNotMet`

This PR registers `t.Cleanup()` handlers in both `CreateImplicitDirectoryStructureUsingStorageClient` and `CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient` within `implicit_and_explicit_dir_setup.go` to automatically invoke `setup.CleanupDirectoryOnGCS()` upon test completion.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No
