### PR TITLE
feat: Added strong consistency mode for openFile call

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -629,6 +629,8 @@ type FileSystemConfig struct {
 
 	RenameDirLimit int64 `yaml:"rename-dir-limit"`
 
+	StrongConsistencyOnOpen bool `yaml:"strong-consistency-on-open"`
+
 	TempDir ResolvedPath `yaml:"temp-dir"`
 
 	Uid int64 `yaml:"uid"`
@@ -1408,6 +1410,8 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
+	flagSet.BoolP("strong-consistency-on-open", "", false, "When enabled, during open file, GCSFuse will check with GCS if the file has been modified since it last fetched and fail with ESTALE if the file has been clobbered (externally modified).")
+
 	flagSet.StringP("temp-dir", "", "", "Path to the temporary directory where writes are staged prior to upload to Cloud Storage. (default: system default, likely /tmp)")
 
 	flagSet.StringP("token-url", "", "", "A url for getting an access token when the key-file is absent.")
@@ -2008,6 +2012,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("metadata-cache.deprecated-stat-cache-ttl", flagSet.Lookup("stat-cache-ttl")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("file-system.strong-consistency-on-open", flagSet.Lookup("strong-consistency-on-open")); err != nil {
 		return err
 	}
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -567,6 +567,15 @@ params:
         - name: "aiml-checkpointing"
           value: 200000
 
+  - config-path: "file-system.strong-consistency-on-open"
+    flag-name: "strong-consistency-on-open"
+    type: "bool"
+    usage: >-
+      When enabled, during open file, GCSFuse will check with GCS if the file has been modified since it last fetched
+      and fail with ESTALE if the file has been clobbered (externally modified).
+    default: false
+    hide-flag: false
+
   - config-path: "file-system.temp-dir"
     flag-name: "temp-dir"
     type: "resolvedPath"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -965,6 +965,7 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 		TempDir:                       "",
 		ExperimentalODirect:           false,
 		Uid:                           -1,
+		StrongConsistencyOnOpen:       false,
 	}
 	expectedAIMLCheckpointingFileSystemConfig := expectedDefaultFileSystemConfig
 	expectedAIMLCheckpointingFileSystemConfig.RenameDirLimit = 200000
@@ -1328,6 +1329,24 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 					ExperimentalODirect:  false,
 					Uid:                  -1,
 					EnableKernelReader:   false,
+				},
+			},
+		},
+		{
+			name: "Test file system strong-consistency-on-open flag enabled.",
+			args: []string{"gcsfuse", "--strong-consistency-on-open", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				FileSystem: cfg.FileSystemConfig{
+					FuseMaxRequestSizeKb:    int64(cfg.StorageClassRapid.DefaultFuseMaxRequestSizeKb()),
+					DirMode:                 0755,
+					FileMode:                0644,
+					FuseOptions:             []string{},
+					Gid:                     -1,
+					IgnoreInterrupts:        true,
+					InactiveMrdCacheSize:    1000,
+					ExperimentalODirect:     false,
+					Uid:                     -1,
+					StrongConsistencyOnOpen: true,
 				},
 			},
 		},

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -3062,6 +3062,13 @@ func (fs *fileSystem) OpenFile(
 	in.Lock()
 	defer in.Unlock()
 
+	if fs.newConfig.FileSystem.StrongConsistencyOnOpen {
+		err = in.CheckClobbered(ctx)
+		if err != nil {
+			return err
+		}
+	}
+
 	// Get the fs lock again.
 	fs.mu.Lock()
 	defer fs.mu.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -314,6 +314,7 @@ func (f *FileInode) CheckClobbered(ctx context.Context) (err error) {
 	}
 	if clobbered {
 		return &gcsfuse_errors.FileClobberedError{
+			Err:        errors.New("file was clobbered due to generation/metageneration mismatch"),
 			ObjectName: f.name.GcsObjectName(),
 		}
 	}

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -304,6 +304,22 @@ func (f *FileInode) clobbered(ctx context.Context, forceFetchFromGcs bool, inclu
 	}
 }
 
+// CheckClobbered checks if the file has been clobbered by making a stat call to GCS.
+//
+// LOCKS_REQUIRED(f.mu)
+func (f *FileInode) CheckClobbered(ctx context.Context) (err error) {
+	_, clobbered, err := f.clobbered(ctx, true, false)
+	if err != nil {
+		return err
+	}
+	if clobbered {
+		return &gcsfuse_errors.FileClobberedError{
+			ObjectName: f.name.GcsObjectName(),
+		}
+	}
+	return nil
+}
+
 // Open a reader for the generation of object we care about.
 func (f *FileInode) openReader(ctx context.Context) (io.ReadCloser, error) {
 	rc, err := f.bucket.NewReaderWithReadHandle(

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -395,6 +395,43 @@ func (t *FileTest) TestAttributes_Clobbered_WithClobberCheckFalse() {
 	assert.Equal(t.T(), uint32(1), attrs.Nlink)
 }
 
+func (t *FileTest) TestCheckClobbered_NotClobbered() {
+	err := t.in.CheckClobbered(t.ctx)
+
+	assert.NoError(t.T(), err)
+}
+
+func (t *FileTest) TestCheckClobbered_Clobbered() {
+	// Simulate a clobbered file by creating a new object with the same name,
+	// which will have a new generation.
+	_, err := storageutil.CreateObject(
+		t.ctx,
+		t.bucket,
+		t.in.Name().GcsObjectName(),
+		[]byte("new clobbering content"))
+	require.NoError(t.T(), err)
+
+	err = t.in.CheckClobbered(t.ctx)
+
+	var fcErr *gcsfuse_errors.FileClobberedError
+	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
+	assert.Contains(t.T(), err.Error(), "generation/metageneration mismatch")
+}
+
+func (t *FileTest) TestCheckClobbered_Deleted() {
+	// Simulate a deleted file.
+	err := t.bucket.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{
+		Name: t.in.Name().GcsObjectName(),
+	})
+	require.NoError(t.T(), err)
+
+	err = t.in.CheckClobbered(t.ctx)
+
+	var fcErr *gcsfuse_errors.FileClobberedError
+	assert.True(t.T(), errors.As(err, &fcErr), "expected FileClobberedError but got %v", err)
+	assert.Contains(t.T(), err.Error(), "generation/metageneration mismatch")
+}
+
 func (t *FileTest) TestInitialAttributes() {
 	attrs, err := t.in.Attributes(t.ctx, true)
 	require.NoError(t.T(), err)

--- a/tools/integration_tests/stale_handle/stale_file_handle_local_and_synced_file_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_local_and_synced_file_test.go
@@ -16,7 +16,9 @@ package stale_handle
 
 import (
 	"log"
+	"os"
 	"path"
+	"syscall"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -187,5 +189,65 @@ func TestStaleHandleStreamingWritesDisabled(t *testing.T) {
 		log.Printf("Running empty GCS file tests with flags: %s", sEmptyGCS.flags)
 		sEmptyGCS.isStreamingWritesEnabled = false
 		suite.Run(t, sEmptyGCS)
+	}
+}
+
+type staleFileHandleOpenFileWhenClobbered struct {
+	staleFileHandleCommon
+}
+
+func (s *staleFileHandleOpenFileWhenClobbered) SetupTest() {
+	s.fileName = path.Base(s.T().Name()) + setup.GenerateRandomString(5)
+	err := CreateObjectOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, s.fileName), "")
+	assert.NoError(s.T(), err)
+	s.f1 = operations.OpenFileWithODirect(s.T(), path.Join(testEnv.testDirPath, s.fileName))
+}
+
+func (s *staleFileHandleOpenFileWhenClobbered) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+func (s *staleFileHandleOpenFileWhenClobbered) TestOpenFileWhenClobbered() {
+	// 1. Get old inode ID.
+	fi1, err := os.Stat(s.f1.Name())
+	assert.NoError(s.T(), err)
+	stat1 := fi1.Sys().(*syscall.Stat_t)
+	oldInodeId := stat1.Ino
+
+	// 2. Clobber the file on GCS.
+	err = WriteToObject(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, s.fileName), FileContents, storage.Conditions{})
+	assert.NoError(s.T(), err)
+
+	// 3. Open the file again. It should succeed (VFS retry).
+	fh2, err := os.OpenFile(path.Join(testEnv.testDirPath, s.fileName), os.O_RDWR|syscall.O_DIRECT, 0)
+	assert.NoError(s.T(), err)
+	defer fh2.Close()
+
+	// 4. Get new inode ID.
+	fi2, err := fh2.Stat()
+	assert.NoError(s.T(), err)
+	stat2 := fi2.Sys().(*syscall.Stat_t)
+	newInodeId := stat2.Ino
+
+	// 5. Verify they are different.
+	assert.NotEqual(s.T(), oldInodeId, newInodeId)
+
+	// 6. Verify we can write to the new fd.
+	_, err = fh2.Write([]byte("chips"))
+	assert.NoError(s.T(), err)
+}
+
+func TestStaleHandleOpenFileWhenClobbered(t *testing.T) {
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		suite.Run(t, new(staleFileHandleOpenFileWhenClobbered))
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		s := new(staleFileHandleOpenFileWhenClobbered)
+		s.flags = flags
+		log.Printf("Running OpenFileWhenClobbered tests with flags: %s", s.flags)
+		suite.Run(t, s)
 	}
 }

--- a/tools/integration_tests/stale_handle/stale_file_handle_local_and_synced_file_test.go
+++ b/tools/integration_tests/stale_handle/stale_file_handle_local_and_synced_file_test.go
@@ -208,6 +208,8 @@ func (s *staleFileHandleOpenFileWhenClobbered) TearDownTest() {
 }
 
 func (s *staleFileHandleOpenFileWhenClobbered) TestOpenFileWhenClobbered() {
+	defer func() { _ = s.f1.Close() }()
+
 	// 1. Get old inode ID.
 	fi1, err := os.Stat(s.f1.Name())
 	assert.NoError(s.T(), err)
@@ -221,7 +223,7 @@ func (s *staleFileHandleOpenFileWhenClobbered) TestOpenFileWhenClobbered() {
 	// 3. Open the file again. It should succeed (VFS retry).
 	fh2, err := os.OpenFile(path.Join(testEnv.testDirPath, s.fileName), os.O_RDWR|syscall.O_DIRECT, 0)
 	assert.NoError(s.T(), err)
-	defer fh2.Close()
+	defer operations.CloseFileShouldNotThrowError(s.T(), fh2)
 
 	// 4. Get new inode ID.
 	fi2, err := fh2.Stat()

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -750,6 +750,15 @@ stale_handle:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
+          - "--metadata-cache-ttl-secs=3600,--stat-cache-size-mb=32,--type-cache-size-mb=4,--client-protocol=http1,--strong-consistency-on-open"
+          - "--metadata-cache-ttl-secs=3600,--stat-cache-size-mb=32,--type-cache-size-mb=4,--client-protocol=grpc,--strong-consistency-on-open"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run: "TestStaleHandleOpenFileWhenClobbered"
+        run_on_gke: true
+      - flags:
           - "--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1,--client-protocol=http1"
           - "--metadata-cache-ttl-secs=0,--write-block-size-mb=1,--write-max-blocks-per-file=1,--client-protocol=grpc"
         compatible:


### PR DESCRIPTION
OpenFile today doesn't make any GCS call and relies on inode created prior to file open. Because of this, if any changes are made on GCS after metadata is cached, we dont get that latest information. 

Now we added a mode when enabled, we check with GCS if the file is clobbered, if yes return ESTALE to the kernel. 
upon getting ESTALE, kernel will repeat the same cycle i.e, lookupinode, openFile.
When the openFile is called 2nd time, we will again check with GCS and now that we have the latest data we return succesful handleID to the kernel.

Note: If we return ESTALE in openFile, kernel makes a fresh lookupinode call to get latest inodeId and then calls openFile. If we return ESTALE in 2nd openFile it will return the error to application. It only retries once on ESTALE error.



### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Added

### Any backward incompatible change? If so, please explain.
