### PR TITLE
feat: make retry pattern consistent in control client similar to storage client with number of attempts.

### DIFF
--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -260,7 +260,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled
 
 	assert.Error(t.T(), err)
 	assert.Nil(t.T(), layout)
-	assert.ErrorIs(t.T(), err, context.DeadlineExceeded)
+	assert.Contains(t.T(), err.Error(), mountErr.Error())
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
@@ -338,8 +338,9 @@ func (t *StorageLayoutRetryWrapperTest) TestRenameFolder_IsNotRetried() {
 func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient StorageControlClient, retryDeadline, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool) StorageControlClient {
 	t.T().Helper()
 	clientConfig := &storageutil.StorageClientConfig{
-		MaxRetrySleep:   maxRetrySleep,
-		RetryMultiplier: backoffMultiplier,
+		MaxRetrySleep:    maxRetrySleep,
+		RetryMultiplier:  backoffMultiplier,
+		MaxRetryAttempts: 3,
 	}
 	var opts []ControlClientOption
 	if retryFolderAPIs {
@@ -369,6 +370,7 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(co
 		MaxRetrySleep:      maxRetrySleep,
 		RetryMultiplier:    backoffMultiplier,
 		EnableMountRetries: enableRetriesOnMount,
+		MaxRetryAttempts:   3,
 	}
 	var opts []ControlClientOption
 	if retryFolderAPIs {

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -152,7 +152,7 @@ func (t *AllApiRetryWrapperTest) SetupTest() {
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
@@ -168,7 +168,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttem
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
@@ -187,7 +187,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_RetryableErrorThenS
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
@@ -206,7 +206,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_NonRetryableError()
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut() {
 	// Arrange
 	// This test requires different retry parameters, so we create a new client.
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	// Set stall time to be longer than the attempt timeout.
 	t.stallDurationForGetStorageLayout = 6000 * time.Microsecond
@@ -220,7 +220,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut(
 }
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_Retry404ThenSuccess() {
-	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
 	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
@@ -235,7 +235,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled
 }
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesDisabled_404FailsImmediately() {
-	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, 1000*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, false)
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 100*time.Millisecond, time.Microsecond, 10*time.Microsecond, 2, false, false)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr).Once()
@@ -251,7 +251,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesDisable
 }
 
 func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled_AllAttemptsTimeOut() {
-	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
+	client := t.newHelperRetryWrapperWithMountRetries(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	mountErr := status.Error(codes.NotFound, "The specified bucket does not exist.")
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, mountErr)
@@ -266,7 +266,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetStorageLayout_MountRetriesEnabled
 
 func (t *StorageLayoutRetryWrapperTest) TestGetFolder_IsNotRetried() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.GetFolderRequest{Name: "some/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
 	// Mock the raw client to return a retryable error once.
@@ -284,7 +284,7 @@ func (t *StorageLayoutRetryWrapperTest) TestGetFolder_IsNotRetried() {
 
 func (t *StorageLayoutRetryWrapperTest) TestDeleteFolder_IsNotRetried() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
 	// Mock the raw client to return a retryable error once.
@@ -301,7 +301,7 @@ func (t *StorageLayoutRetryWrapperTest) TestDeleteFolder_IsNotRetried() {
 
 func (t *StorageLayoutRetryWrapperTest) TestCreateFolder_IsNotRetried() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
 	// Mock the raw client to return a retryable error once.
@@ -319,7 +319,7 @@ func (t *StorageLayoutRetryWrapperTest) TestCreateFolder_IsNotRetried() {
 
 func (t *StorageLayoutRetryWrapperTest) TestRenameFolder_IsNotRetried() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, false)
 	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
 	// Mock the raw client to return a retryable error once.
@@ -335,7 +335,7 @@ func (t *StorageLayoutRetryWrapperTest) TestRenameFolder_IsNotRetried() {
 	t.mockRawClient.AssertExpectations(t.T())
 }
 
-func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient StorageControlClient, retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool) StorageControlClient {
+func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient StorageControlClient, retryDeadline, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool) StorageControlClient {
 	t.T().Helper()
 	clientConfig := &storageutil.StorageClientConfig{
 		MaxRetrySleep:   maxRetrySleep,
@@ -354,7 +354,6 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 	if retryClient != nil {
 		retryClient.retryConfig = storageutil.NewRetryConfigForTesting(
 			retryDeadline,
-			totalRetryBudget,
 			initialBackoff,
 			maxRetrySleep,
 			backoffMultiplier,
@@ -364,7 +363,7 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapper(controlClient Stor
 	return scc
 }
 
-func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(controlClient StorageControlClient, retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool, enableRetriesOnMount bool) StorageControlClient {
+func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(controlClient StorageControlClient, retryDeadline, initialBackoff, maxRetrySleep time.Duration, backoffMultiplier float64, retryFolderAPIs bool, enableRetriesOnMount bool) StorageControlClient {
 	t.T().Helper()
 	clientConfig := &storageutil.StorageClientConfig{
 		MaxRetrySleep:      maxRetrySleep,
@@ -384,7 +383,6 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(co
 	if retryClient != nil {
 		retryClient.retryConfig = storageutil.NewRetryConfigForTesting(
 			retryDeadline,
-			totalRetryBudget,
 			initialBackoff,
 			maxRetrySleep,
 			backoffMultiplier,
@@ -396,7 +394,7 @@ func (t *ControlClientRetryWrapperTest) newHelperRetryWrapperWithMountRetries(co
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(expectedLayout, nil).Once()
@@ -412,7 +410,7 @@ func (t *AllApiRetryWrapperTest) TestGetStorageLayout_SuccessOnFirstAttempt() {
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	expectedLayout := &controlpb.StorageLayout{Location: "some-location"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
@@ -431,7 +429,7 @@ func (t *AllApiRetryWrapperTest) TestGetStorageLayout_RetryableErrorThenSuccess(
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("GetStorageLayout", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
@@ -449,7 +447,7 @@ func (t *AllApiRetryWrapperTest) TestGetStorageLayout_NonRetryableError() {
 
 func (t *AllApiRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetStorageLayoutRequest{Name: "some/bucket"}
 	// Set stall time to be longer than the attempt timeout.
 	t.stallDurationForGetStorageLayout = 6000 * time.Microsecond
@@ -464,7 +462,7 @@ func (t *AllApiRetryWrapperTest) TestGetStorageLayout_AllAttemptsTimeOut() {
 
 func (t *AllApiRetryWrapperTest) TestDeleteFolder_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
 	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nil).Once()
 
@@ -478,7 +476,7 @@ func (t *AllApiRetryWrapperTest) TestDeleteFolder_SuccessOnFirstAttempt() {
 
 func (t *AllApiRetryWrapperTest) TestDeleteFolder_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
 	// First call fails, second succeeds.
@@ -495,7 +493,7 @@ func (t *AllApiRetryWrapperTest) TestDeleteFolder_RetryableErrorThenSuccess() {
 
 func (t *AllApiRetryWrapperTest) TestDeleteFolder_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("DeleteFolder", mock.Anything, req, mock.Anything).Return(nonRetryableErr).Once()
@@ -512,7 +510,7 @@ func (t *AllApiRetryWrapperTest) TestDeleteFolder_NonRetryableError() {
 
 func (t *AllApiRetryWrapperTest) TestDeleteFolder_AllAttemptsTimeOut() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.DeleteFolderRequest{Name: "some/folder"}
 	// Set stall time to be longer than the attempt timeout.
 	t.stallDurationForFolderAPIs = 6000 * time.Microsecond
@@ -528,7 +526,7 @@ func (t *AllApiRetryWrapperTest) TestDeleteFolder_AllAttemptsTimeOut() {
 
 func (t *AllApiRetryWrapperTest) TestGetFolder_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetFolderRequest{Name: "some/folder"}
 	expectedFolder := &controlpb.Folder{Name: "some/folder"}
 	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
@@ -544,7 +542,7 @@ func (t *AllApiRetryWrapperTest) TestGetFolder_SuccessOnFirstAttempt() {
 
 func (t *AllApiRetryWrapperTest) TestGetFolder_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetFolderRequest{Name: "some/folder"}
 	expectedFolder := &controlpb.Folder{Name: "some/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
@@ -563,7 +561,7 @@ func (t *AllApiRetryWrapperTest) TestGetFolder_RetryableErrorThenSuccess() {
 
 func (t *AllApiRetryWrapperTest) TestGetFolder_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetFolderRequest{Name: "some/folder"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("GetFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
@@ -581,7 +579,7 @@ func (t *AllApiRetryWrapperTest) TestGetFolder_NonRetryableError() {
 
 func (t *AllApiRetryWrapperTest) TestGetFolder_AllAttemptsTimeOut() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.GetFolderRequest{Name: "some/folder"}
 	// Set execution time to be longer than the attempt timeout.
 	t.stallDurationForFolderAPIs = 6000 * time.Microsecond
@@ -597,7 +595,7 @@ func (t *AllApiRetryWrapperTest) TestGetFolder_AllAttemptsTimeOut() {
 
 func (t *AllApiRetryWrapperTest) TestRenameFolder_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
 	expectedOp := &control.RenameFolderOperation{}
 	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(expectedOp, nil).Once()
@@ -613,7 +611,7 @@ func (t *AllApiRetryWrapperTest) TestRenameFolder_SuccessOnFirstAttempt() {
 
 func (t *AllApiRetryWrapperTest) TestRenameFolder_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
 	expectedOp := &control.RenameFolderOperation{}
 	retryableErr := status.Error(codes.Unavailable, "try again")
@@ -632,7 +630,7 @@ func (t *AllApiRetryWrapperTest) TestRenameFolder_RetryableErrorThenSuccess() {
 
 func (t *AllApiRetryWrapperTest) TestRenameFolder_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("RenameFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
@@ -650,7 +648,7 @@ func (t *AllApiRetryWrapperTest) TestRenameFolder_NonRetryableError() {
 
 func (t *AllApiRetryWrapperTest) TestRenameFolder_AllAttemptsTimeOut() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.RenameFolderRequest{Name: "some/folder", DestinationFolderId: "new/folder"}
 	// Set execution time to be longer than the attempt timeout.
 	t.stallDurationForFolderAPIs = 6000 * time.Microsecond
@@ -666,7 +664,7 @@ func (t *AllApiRetryWrapperTest) TestRenameFolder_AllAttemptsTimeOut() {
 
 func (t *AllApiRetryWrapperTest) TestCreateFolder_SuccessOnFirstAttempt() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
 	expectedFolder := &controlpb.Folder{Name: "some/folder"}
 	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(expectedFolder, nil).Once()
@@ -682,7 +680,7 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_SuccessOnFirstAttempt() {
 
 func (t *AllApiRetryWrapperTest) TestCreateFolder_RetryableErrorThenSuccess() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
 	expectedFolder := &controlpb.Folder{Name: "some/folder"}
 	retryableErr := status.Error(codes.Unavailable, "try again")
@@ -701,7 +699,7 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_RetryableErrorThenSuccess() {
 
 func (t *AllApiRetryWrapperTest) TestCreateFolder_NonRetryableError() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 100*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
 	nonRetryableErr := status.Error(codes.NotFound, "does not exist")
 	t.mockRawClient.On("CreateFolder", mock.Anything, req, mock.Anything).Return(nil, nonRetryableErr).Once()
@@ -719,7 +717,7 @@ func (t *AllApiRetryWrapperTest) TestCreateFolder_NonRetryableError() {
 
 func (t *AllApiRetryWrapperTest) TestCreateFolder_AllAttemptsTimeOut() {
 	// Arrange
-	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, 10000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
+	client := t.newHelperRetryWrapper(t.stallingClient, 1000*time.Microsecond, time.Microsecond, 10*time.Microsecond, 2, true)
 	req := &controlpb.CreateFolderRequest{Parent: "some/", FolderId: "folder"}
 	// Set execution time to be longer than the attempt timeout.
 	t.stallDurationForFolderAPIs = 6000 * time.Microsecond

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -61,7 +61,6 @@ const (
 	directPathDetectionMaxAttempts      = 5
 	directPathDetectionTimeout          = 15 * time.Second
 	directPathDetectionMaxBackoff       = 5 * time.Second
-	directPathDetectionMaxRetryDuration = 1 * time.Minute
 
 	// nonExistentObjectName is the object name used for bucket existence/access check when HNS feature is disabled by providing "--enable-hns:false". E.g. Using Regional Endpoints which do not support GRPC protocol.
 	nonExistentObjectName = "gcsfuse-nonexistent-object-check"
@@ -244,7 +243,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		RetryMultiplier:  clientConfig.RetryMultiplier,
 		MaxRetryAttempts: directPathDetectionMaxAttempts,
 	}
-	retryConfig := storageutil.NewCustomRetryConfig(dpClientConfig, directPathDetectionTimeout, directPathDetectionMaxRetryDuration)
+	retryConfig := storageutil.NewCustomRetryConfig(dpClientConfig, directPathDetectionTimeout)
 
 	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
 		return bucketHandle.Object(testObject).Attrs(attemptCtx)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -58,9 +58,9 @@ const (
 	zonalLocationType = "zone"
 
 	// DirectPath detection parameters - used for fast-fail detection during client creation
-	directPathDetectionMaxAttempts      = 5
-	directPathDetectionTimeout          = 15 * time.Second
-	directPathDetectionMaxBackoff       = 5 * time.Second
+	directPathDetectionMaxAttempts = 5
+	directPathDetectionTimeout     = 15 * time.Second
+	directPathDetectionMaxBackoff  = 5 * time.Second
 
 	// nonExistentObjectName is the object name used for bucket existence/access check when HNS feature is disabled by providing "--enable-hns:false". E.g. Using Regional Endpoints which do not support GRPC protocol.
 	nonExistentObjectName = "gcsfuse-nonexistent-object-check"

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -26,8 +26,8 @@ import (
 
 const (
 	// Default retry parameters.
-	DefaultRetryDeadline    = 30 * time.Second
-	DefaultInitialBackoff   = 1 * time.Second
+	DefaultRetryDeadline  = 30 * time.Second
+	DefaultInitialBackoff = 1 * time.Second
 )
 
 // exponentialBackoffConfig is config parameters
@@ -101,8 +101,8 @@ type RetryConfig struct {
 // NewCustomRetryConfig creates a new RetryConfig with custom retry timeout parameters.
 func NewCustomRetryConfig(clientConfig *StorageClientConfig, retryDeadline time.Duration) *RetryConfig {
 	return &RetryConfig{
-		RetryDeadline:    retryDeadline,
-		MaxAttempts:      clientConfig.MaxRetryAttempts,
+		RetryDeadline: retryDeadline,
+		MaxAttempts:   clientConfig.MaxRetryAttempts,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    DefaultInitialBackoff,
 			max:        clientConfig.MaxRetrySleep,
@@ -121,8 +121,8 @@ func NewRetryConfig(clientConfig *StorageClientConfig) *RetryConfig {
 // It is intended for use in tests of other packages (like package storage) to avoid slow tests.
 func NewRetryConfigForTesting(retryDeadline, initialBackoff, maxRetrySleep time.Duration, retryMultiplier float64, maxAttempts int) *RetryConfig {
 	return &RetryConfig{
-		RetryDeadline:    retryDeadline,
-		MaxAttempts:      maxAttempts,
+		RetryDeadline: retryDeadline,
+		MaxAttempts:   maxAttempts,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    initialBackoff,
 			max:        maxRetrySleep,

--- a/internal/storage/storageutil/retry.go
+++ b/internal/storage/storageutil/retry.go
@@ -27,7 +27,6 @@ import (
 const (
 	// Default retry parameters.
 	DefaultRetryDeadline    = 30 * time.Second
-	DefaultTotalRetryBudget = 5 * time.Minute
 	DefaultInitialBackoff   = 1 * time.Second
 )
 
@@ -93,8 +92,6 @@ func (b *exponentialBackoff) waitWithJitter(ctx context.Context) error {
 type RetryConfig struct {
 	// Time-limit on every individual retry attempt.
 	RetryDeadline time.Duration
-	// Total duration allowed across all the attempts.
-	TotalRetryBudget time.Duration
 	// Max attempts to make for the operation.
 	MaxAttempts int
 	// Config for managing backoff durations in-between retry attempts.
@@ -102,10 +99,9 @@ type RetryConfig struct {
 }
 
 // NewCustomRetryConfig creates a new RetryConfig with custom retry timeout parameters.
-func NewCustomRetryConfig(clientConfig *StorageClientConfig, retryDeadline, totalRetryBudget time.Duration) *RetryConfig {
+func NewCustomRetryConfig(clientConfig *StorageClientConfig, retryDeadline time.Duration) *RetryConfig {
 	return &RetryConfig{
 		RetryDeadline:    retryDeadline,
-		TotalRetryBudget: totalRetryBudget,
 		MaxAttempts:      clientConfig.MaxRetryAttempts,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    DefaultInitialBackoff,
@@ -116,17 +112,16 @@ func NewCustomRetryConfig(clientConfig *StorageClientConfig, retryDeadline, tota
 }
 
 // NewRetryConfig creates a new RetryConfig using the standard defaults for
-// deadline and total budget, combined with the user-provided clientConfig.
+// deadline, combined with the user-provided clientConfig.
 func NewRetryConfig(clientConfig *StorageClientConfig) *RetryConfig {
-	return NewCustomRetryConfig(clientConfig, DefaultRetryDeadline, DefaultTotalRetryBudget)
+	return NewCustomRetryConfig(clientConfig, DefaultRetryDeadline)
 }
 
 // NewRetryConfigForTesting creates a RetryConfig with custom parameters for testing.
 // It is intended for use in tests of other packages (like package storage) to avoid slow tests.
-func NewRetryConfigForTesting(retryDeadline, totalRetryBudget, initialBackoff, maxRetrySleep time.Duration, retryMultiplier float64, maxAttempts int) *RetryConfig {
+func NewRetryConfigForTesting(retryDeadline, initialBackoff, maxRetrySleep time.Duration, retryMultiplier float64, maxAttempts int) *RetryConfig {
 	return &RetryConfig{
 		RetryDeadline:    retryDeadline,
-		TotalRetryBudget: totalRetryBudget,
 		MaxAttempts:      maxAttempts,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    initialBackoff,
@@ -159,14 +154,11 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 		return zero, err
 	}
 
-	parentCtx, cancel := context.WithTimeout(ctx, config.TotalRetryBudget)
-	defer cancel()
-
 	// Create a new backoff controller specific to this api call.
 	backoff := newExponentialBackoff(&config.BackoffConfig)
 	var lastErr error
 	for attemptNum := 1; ; attemptNum++ {
-		attemptCtx, attemptCancel := context.WithTimeout(parentCtx, config.RetryDeadline)
+		attemptCtx, attemptCancel := context.WithTimeout(ctx, config.RetryDeadline)
 		if attemptNum == 1 {
 			logger.GetLogFHandler(logLevel)("Calling %s for %q: InvocationID: %s, Attempt: %d, with deadline=%v", operationName, reqDescription, requestID, attemptNum, config.RetryDeadline)
 		} else {
@@ -191,15 +183,15 @@ func ExecuteWithCustomShouldRetryAtLogLevel[T any](
 			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, with error: %w", operationName, reqDescription, requestID, attemptNum, err)
 		}
 
-		// If the parent context is cancelled/timed-out, we should stop retrying.
-		if parentCtx.Err() != nil {
-			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, parentCtx.Err())
+		// If the context is cancelled/timed-out, we should stop retrying.
+		if ctx.Err() != nil {
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, ctx.Err())
 		}
 
 		// Do a jittery backoff after each retry.
-		parentCtxErr := backoff.waitWithJitter(parentCtx)
-		if parentCtxErr != nil {
-			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, parentCtxErr)
+		ctxErr := backoff.waitWithJitter(ctx)
+		if ctxErr != nil {
+			return zero, fmt.Errorf("%s for %q failed: InvocationID: %s, Attempt: %d, (last server/client error = %v), with error: %w", operationName, reqDescription, requestID, attemptNum, err, ctxErr)
 		}
 	}
 }

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -226,15 +226,13 @@ func (t *RetryConfigTestSuite) TestNewCustomRetryConfig() {
 		RetryMultiplier: 2.5,
 	}
 	retryDeadline := 5 * time.Second
-	totalRetryBudget := 30 * time.Second
 
 	// Act
-	retryConfig := NewCustomRetryConfig(clientConfig, retryDeadline, totalRetryBudget)
+	retryConfig := NewCustomRetryConfig(clientConfig, retryDeadline)
 
 	// Assert
 	assert.NotNil(t.T(), retryConfig)
 	assert.Equal(t.T(), retryDeadline, retryConfig.RetryDeadline)
-	assert.Equal(t.T(), totalRetryBudget, retryConfig.TotalRetryBudget)
 	assert.Equal(t.T(), DefaultInitialBackoff, retryConfig.BackoffConfig.initial)
 	assert.Equal(t.T(), clientConfig.MaxRetrySleep, retryConfig.BackoffConfig.max)
 	assert.Equal(t.T(), clientConfig.RetryMultiplier, retryConfig.BackoffConfig.multiplier)
@@ -253,7 +251,6 @@ func (t *RetryConfigTestSuite) TestNewRetryConfig() {
 	// Assert
 	assert.NotNil(t.T(), retryConfig)
 	assert.Equal(t.T(), DefaultRetryDeadline, retryConfig.RetryDeadline)
-	assert.Equal(t.T(), DefaultTotalRetryBudget, retryConfig.TotalRetryBudget)
 	assert.Equal(t.T(), DefaultInitialBackoff, retryConfig.BackoffConfig.initial)
 	assert.Equal(t.T(), clientConfig.MaxRetrySleep, retryConfig.BackoffConfig.max)
 	assert.Equal(t.T(), clientConfig.RetryMultiplier, retryConfig.BackoffConfig.multiplier)
@@ -267,7 +264,6 @@ type ExecuteWithRetryTestSuite struct {
 func (t *ExecuteWithRetryTestSuite) SetupTest() {
 	t.retryConfig = &RetryConfig{
 		RetryDeadline:    50 * time.Millisecond,
-		TotalRetryBudget: 200 * time.Millisecond,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    1 * time.Millisecond,
 			max:        10 * time.Millisecond,
@@ -379,31 +375,11 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
 		"take longer than the per-attempt deadline.")
 }
 
-func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_TotalRetryBudgetExceeded() {
-	// Arrange
-	var callCount int
-	// Set a short total retry budget.
-	t.retryConfig.TotalRetryBudget = 30 * time.Millisecond
-	t.retryConfig.RetryDeadline = 10 * time.Millisecond
-	t.retryConfig.BackoffConfig.initial = 2 * time.Millisecond // Ensure backoff pushes it over the edge.
-	apiCall := func(ctx context.Context) (string, error) {
-		callCount++
-		return "", status.Error(codes.Unavailable, "server unavailable")
-	}
-
-	// Act
-	_, err := ExecuteWithRetry(context.Background(), t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
-
-	// Assert
-	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from the total retry budget timeout")
-	assert.Greater(t.T(), callCount, 1)
-}
 
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutShorterThanRetryDeadline() {
 	// Arrange
 	var callCount int
 	t.retryConfig.RetryDeadline = 100 * time.Millisecond
-	t.retryConfig.TotalRetryBudget = 1000 * time.Millisecond
 	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
 	// Set a parent context timeout that is shorter than the total retry budget.
 	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.RetryDeadline-50*time.Millisecond)
@@ -458,27 +434,6 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutBet
 	assert.Greater(t.T(), callCount, 0, "apiCall should have been called at least once")
 }
 
-func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutLongerThanBudget() {
-	// Arrange
-	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
-	parentCtx, cancel := context.WithTimeout(context.Background(), t.retryConfig.TotalRetryBudget+100*time.Millisecond)
-	defer cancel()
-	apiCall := func(ctx context.Context) (string, error) {
-		select {
-		case <-time.After(stallDuration):
-		case <-ctx.Done():
-			return "", ctx.Err()
-		}
-		return "", status.Error(codes.Unavailable, "server unavailable")
-	}
-
-	// Act
-	result, err := ExecuteWithRetry(parentCtx, t.retryConfig, "testOp", "testReq", "test-request-id", apiCall)
-
-	// Assert
-	assert.ErrorIs(t.T(), err, context.DeadlineExceeded, "The error should be from context created in ExecuteWithRetry")
-	assert.Empty(t.T(), result)
-}
 
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextAlreadyCancelled() {
 	// Arrange

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -350,8 +350,9 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_RetryableThenNonRetryab
 	assert.Equal(t.T(), 2, callCount)
 }
 
-func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
+func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_AllAttemptsTimeOut() {
 	// Arrange
+	t.retryConfig.MaxAttempts = 3
 	stallDuration := t.retryConfig.RetryDeadline + 100*time.Millisecond
 	var callCount int
 	apiCall := func(ctx context.Context) (string, error) {

--- a/internal/storage/storageutil/retry_test.go
+++ b/internal/storage/storageutil/retry_test.go
@@ -263,7 +263,7 @@ type ExecuteWithRetryTestSuite struct {
 
 func (t *ExecuteWithRetryTestSuite) SetupTest() {
 	t.retryConfig = &RetryConfig{
-		RetryDeadline:    50 * time.Millisecond,
+		RetryDeadline: 50 * time.Millisecond,
 		BackoffConfig: exponentialBackoffConfig{
 			initial:    1 * time.Millisecond,
 			max:        10 * time.Millisecond,
@@ -375,7 +375,6 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_Timeout() {
 		"take longer than the per-attempt deadline.")
 }
 
-
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutShorterThanRetryDeadline() {
 	// Arrange
 	var callCount int
@@ -433,7 +432,6 @@ func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextTimeoutBet
 	assert.Empty(t.T(), result)
 	assert.Greater(t.T(), callCount, 0, "apiCall should have been called at least once")
 }
-
 
 func (t *ExecuteWithRetryTestSuite) TestExecuteWithRetry_ParentContextAlreadyCancelled() {
 	// Arrange


### PR DESCRIPTION
### Description
This PR simplifies the storage retry framework by completely removing the `TotalRetryBudget` (previously defaulting to a 5-minute timeout) across the codebase. GCSFuse retry loops will now rely purely on the number of attempts (`MaxAttempts`) and per-attempt deadlines, making retry behaviors more deterministic and eliminating arbitrary timeouts.
## Key Changes
* **`internal/storage/storageutil/retry.go`**: 
  * Removed the `TotalRetryBudget` field from `RetryConfig` and its associated default values.
  * Simplified `ExecuteWithCustomShouldRetryAtLogLevel` by dropping redundant parent context bindings (`context.WithCancel` and `context.WithTimeout` wrappers) since a global budget enforcement is no longer needed. The attempt execution and jitter backoff now act directly on the provided `ctx`.
* **`internal/storage/storage_handle.go`**:
  * Removed the unused `directPathDetectionMaxRetryDuration` (1 minute). The DirectPath connectivity stat call now relies strictly on its 5-attempt maximum limit (`directPathDetectionMaxAttempts`).
* **Test Cleanup (`retry_test.go`, `control_client_wrapper_test.go`)**:
  * Removed tests that specifically validated the exhaustion of the 5-minute global budget.
  * Cleaned up test helper function signatures (e.g. `newHelperRetryWrapper`) to stop propagating the budget duration argument across the test suite.


### Link to the issue in case of a bug fix.
b/441413941

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Part of pre-submit

### Any backward incompatible change? If so, please explain.
