### PR TITLE
feat: Making write-block-size-mb to accept fractional values

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -813,7 +813,7 @@ type WorkloadInsightConfig struct {
 }
 
 type WriteConfig struct {
-	BlockSizeMb int64 `yaml:"block-size-mb"`
+	BlockSizeMb float64 `yaml:"block-size-mb"`
 
 	CreateEmptyFile bool `yaml:"create-empty-file"`
 
@@ -1464,7 +1464,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.IntP("write-block-size-mb", "", 32, "Specifies the block size for streaming writes. The value should be more than 0.")
+	flagSet.Float64P("write-block-size-mb", "", 32, "Specifies the block size for streaming writes. The value should be more than 0.")
 
 	if err := flagSet.MarkHidden("write-block-size-mb"); err != nil {
 		return err

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1464,7 +1464,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 		return err
 	}
 
-	flagSet.Float64P("write-block-size-mb", "", 32, "Specifies the block size for streaming writes. The value should be more than 0.")
+	flagSet.Float64P("write-block-size-mb", "", 32, "Specifies the block size for streaming writes. The value must be greater than 0 and a multiple of 0.25 MiB (256 KiB) to align with GCS upload chunk size requirements.")
 
 	if err := flagSet.MarkHidden("write-block-size-mb"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1279,8 +1279,9 @@ params:
     flag-name: "write-block-size-mb"
     type: "float64"
     usage: >-
-      Specifies the block size for streaming writes. The value should be more
-      than 0.
+      Specifies the block size for streaming writes. The value must be greater than
+      0 and a multiple of 0.25 MiB (256 KiB) to align with GCS upload chunk size
+      requirements.
     default: 32
     hide-flag: true
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1277,7 +1277,7 @@ params:
 
   - config-path: "write.block-size-mb"
     flag-name: "write-block-size-mb"
-    type: "int"
+    type: "float64"
     usage: >-
       Specifies the block size for streaming writes. The value should be more
       than 0.

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -484,7 +484,7 @@ func TestRationalize_WriteConfig(t *testing.T) {
 		config                   *Config
 		expectedCreateEmptyFile  bool
 		expectedMaxBlocksPerFile int64
-		expectedBlockSizeMB      int64
+		expectedBlockSizeMB      float64
 	}{
 		{
 			name: "valid_config_streaming_writes_enabled",

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -206,6 +206,13 @@ func isValidWriteStreamingConfig(wc *WriteConfig) error {
 	if wc.BlockSizeMb <= 0 || wc.BlockSizeMb > float64(util.MaxMiBsInInt64) {
 		return fmt.Errorf("invalid value of write-block-size-mb; must be greater than 0 and less than or equal to %d", util.MaxMiBsInInt64)
 	}
+	// BlockSizeMb must be a multiple of 0.25 MiB (256 KiB) to align with the
+	// GCS Go SDK's ChunkSize requirements. While the SDK rounds up the
+	// ChunkSize to a multiple of 256 KiB internally, keeping them aligned
+	// for simplicity.
+	if math.Mod(wc.BlockSizeMb, 0.25) != 0 {
+		return fmt.Errorf("invalid value of write-block-size-mb; must be a multiple of 0.25")
+	}
 	if !(wc.MaxBlocksPerFile == -1 || wc.MaxBlocksPerFile >= 1) {
 		return fmt.Errorf("invalid value of write-max-blocks-per-file: %d; should be >=1 or -1 (for infinite)", wc.MaxBlocksPerFile)
 	}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -203,8 +203,8 @@ func isValidWriteStreamingConfig(wc *WriteConfig) error {
 		return nil
 	}
 
-	if wc.BlockSizeMb <= 0 || wc.BlockSizeMb > util.MaxMiBsInInt64 {
-		return fmt.Errorf("invalid value of write-block-size-mb; can't be less than 1 or more than %d", util.MaxMiBsInInt64)
+	if wc.BlockSizeMb <= 0 || wc.BlockSizeMb > float64(util.MaxMiBsInInt64) {
+		return fmt.Errorf("invalid value of write-block-size-mb; must be greater than 0 and less than or equal to %d", util.MaxMiBsInInt64)
 	}
 	if !(wc.MaxBlocksPerFile == -1 || wc.MaxBlocksPerFile >= 1) {
 		return fmt.Errorf("invalid value of write-max-blocks-per-file: %d; should be >=1 or -1 (for infinite)", wc.MaxBlocksPerFile)

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -743,6 +743,20 @@ func Test_isValidWriteStreamingConfig_ErrorScenarios(t *testing.T) {
 			GlobalMaxBlocks:       -1,
 			MaxBlocksPerFile:      -1,
 		}},
+		{"block_size_not_multiple_of_0_25_1", WriteConfig{
+			BlockSizeMb:           0.1,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       -1,
+			MaxBlocksPerFile:      -1,
+		}},
+		{"block_size_not_multiple_of_0_25_2", WriteConfig{
+			BlockSizeMb:           0.3,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       -1,
+			MaxBlocksPerFile:      -1,
+		}},
 		{"very_large_block_size", WriteConfig{
 			BlockSizeMb:           float64(util.MaxMiBsInInt64) + 1,
 			CreateEmptyFile:       false,

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -744,7 +744,7 @@ func Test_isValidWriteStreamingConfig_ErrorScenarios(t *testing.T) {
 			MaxBlocksPerFile:      -1,
 		}},
 		{"very_large_block_size", WriteConfig{
-			BlockSizeMb:           util.MaxMiBsInInt64 + 1,
+			BlockSizeMb:           float64(util.MaxMiBsInInt64) + 1,
 			CreateEmptyFile:       false,
 			EnableStreamingWrites: true,
 			GlobalMaxBlocks:       -1,
@@ -947,6 +947,13 @@ func Test_isValidWriteStreamingConfig_SuccessScenarios(t *testing.T) {
 			EnableStreamingWrites: false,
 			GlobalMaxBlocks:       -10,
 			MaxBlocksPerFile:      -10,
+		}},
+		{"valid_write_config_fractional", WriteConfig{
+			BlockSizeMb:           0.5,
+			CreateEmptyFile:       false,
+			EnableStreamingWrites: true,
+			GlobalMaxBlocks:       -1,
+			MaxBlocksPerFile:      -1,
 		}},
 		{"valid_write_config_1", WriteConfig{
 			BlockSizeMb:           1,

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -279,7 +279,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 		expectedCreateEmptyFile       bool
 		expectedEnableStreamingWrites bool
 		expectedEnableRapidAppends    bool
-		expectedWriteBlockSizeMB      int64
+		expectedWriteBlockSizeMB      float64
 		expectedWriteGlobalMaxBlocks  int64
 		expectedWriteMaxBlocksPerFile int64
 		expectedEnableRapidWrites     bool
@@ -352,6 +352,16 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedEnableStreamingWrites: true,
 			expectedEnableRapidAppends:    true,
 			expectedWriteBlockSizeMB:      10,
+			expectedWriteGlobalMaxBlocks:  4,
+			expectedWriteMaxBlocksPerFile: 1,
+		},
+		{
+			name:                          "Test fractional write-block-size-mb flag.",
+			args:                          []string{"gcsfuse", "--enable-streaming-writes", "--write-block-size-mb=0.5", "abc", "pqr"},
+			expectedCreateEmptyFile:       false,
+			expectedEnableStreamingWrites: true,
+			expectedEnableRapidAppends:    true,
+			expectedWriteBlockSizeMB:      0.5,
 			expectedWriteGlobalMaxBlocks:  4,
 			expectedWriteMaxBlocksPerFile: 1,
 		},

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -1261,7 +1261,7 @@ func (f *FileInode) InitBufferedWriteHandlerIfEligible(ctx context.Context, open
 			Object:                   latestGcsObj,
 			ObjectName:               f.name.GcsObjectName(),
 			Bucket:                   f.bucket,
-			BlockSize:                writeCtx.Config.Write.BlockSizeMb * util.MiB,
+			BlockSize:                int64(writeCtx.Config.Write.BlockSizeMb * float64(util.MiB)),
 			MaxBlocksPerFile:         writeCtx.Config.Write.MaxBlocksPerFile,
 			GlobalMaxBlocksSem:       writeCtx.GlobalMaxBlocksSem,
 			ChunkRetryDeadlineSecs:   writeCtx.Config.GcsRetries.ChunkRetryDeadlineSecs,

--- a/tools/integration_tests/streaming_writes/buffer_size_test.go
+++ b/tools/integration_tests/streaming_writes/buffer_size_test.go
@@ -47,6 +47,11 @@ func TestWritesWithDifferentConfig(t *testing.T) {
 		fileSize int64
 	}{
 		{
+			name:     "FractionalBlockSize",
+			flags:    []string{"--write-block-size-mb=0.5", "--write-max-blocks-per-file=5"},
+			fileSize: 1 * 1024 * 1024,
+		},
+		{
 			name:     "BlockSizeGreaterThanFileSize",
 			flags:    []string{"--write-block-size-mb=5", "--write-max-blocks-per-file=2"},
 			fileSize: 2 * 1024 * 1024,


### PR DESCRIPTION
changing write-block-size-mb to accept fractional values so users can specify the size in kb. This helps in reducing the memory size for small files. 

Today the same size buffer is created on go-sdk also. So effectively we are creating 2MB buffers even when 1K file is written. Changing this flag to parse fractional values will help users configure values in KB also.


### Testing details
1. Manual - done
2. Unit tests - added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
