### PR TITLE
perf: Optimize folder UpdateTime timestamp by using int64 instead of time.Time

### DIFF
--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -272,7 +272,7 @@ func (b *bucket) mintObject(
 func (b *bucket) mintFolder(folderName string) (f gcs.Folder) {
 	f = gcs.Folder{
 		Name:       folderName,
-		UpdateTime: b.clock.Now(),
+		UpdateTime: b.clock.Now().UnixNano(),
 	}
 
 	return
@@ -1212,6 +1212,9 @@ func (b *bucket) CreateFolder(ctx context.Context, folderName string) (*gcs.Fold
 }
 
 func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinationFolderId string) (*gcs.Folder, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
 	// Check that the destination name is legal.
 	err := checkName(destinationFolderId)
 	if err != nil {
@@ -1231,7 +1234,7 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 	for i := range b.folders {
 		if strings.HasPrefix(b.folders[i].Name, folderName) {
 			b.folders[i].Name = strings.Replace(b.folders[i].Name, folderName, destinationFolderId, 1)
-			b.folders[i].UpdateTime = time.Now()
+			b.folders[i].UpdateTime = b.clock.Now().UnixNano()
 		}
 	}
 
@@ -1252,7 +1255,7 @@ func (b *bucket) RenameFolder(ctx context.Context, folderName string, destinatio
 	// Return the updated folder.
 	folder := &gcs.Folder{
 		Name:       destinationFolderId,
-		UpdateTime: time.Now(),
+		UpdateTime: b.clock.Now().UnixNano(),
 	}
 
 	return folder, nil

--- a/internal/storage/gcs/folder.go
+++ b/internal/storage/gcs/folder.go
@@ -16,21 +16,25 @@ package gcs
 
 import (
 	"strings"
-	"time"
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 )
 
 type Folder struct {
 	Name       string
-	UpdateTime time.Time
+	UpdateTime int64
 }
 
 func GCSFolder(bucketName string, attrs *controlpb.Folder) *Folder {
 	// Setting the parameters in Folder and doing conversions as necessary.
+	var updateTime int64
+	if ts := attrs.GetUpdateTime(); ts != nil {
+		updateTime = ts.GetSeconds()*1e9 + int64(ts.GetNanos())
+	}
+
 	return &Folder{
 		Name:       getFolderName(bucketName, attrs.Name),
-		UpdateTime: attrs.GetUpdateTime().AsTime(),
+		UpdateTime: updateTime,
 	}
 }
 

--- a/internal/storage/gcs/folder_test.go
+++ b/internal/storage/gcs/folder_test.go
@@ -16,7 +16,6 @@ package gcs
 
 import (
 	"testing"
-	"time"
 
 	"cloud.google.com/go/storage/control/apiv2/controlpb"
 	"github.com/stretchr/testify/assert"
@@ -36,8 +35,8 @@ func TestGetFolderName(t *testing.T) {
 
 func TestGCSFolder(t *testing.T) {
 	timestamp := &timestamppb.Timestamp{
-		Seconds: time.Now().Unix(),              // Number of seconds since Unix epoch (1970-01-01T00:00:00Z)
-		Nanos:   int32(time.Now().Nanosecond()), // Nanoseconds (0 to 999,999,999)
+		Seconds: 123456789,
+		Nanos:   987654321,
 	}
 	attrs := controlpb.Folder{
 		Name:           TestFolderName,
@@ -47,6 +46,34 @@ func TestGCSFolder(t *testing.T) {
 
 	gcsFolder := GCSFolder(TestBucketName, &attrs)
 
-	assert.Equal(t, attrs.Name, gcsFolder.Name)
-	assert.Equal(t, attrs.UpdateTime.AsTime(), gcsFolder.UpdateTime)
+	assert.Equal(t, TestFolderName, gcsFolder.Name)
+	assert.Equal(t, int64(123456789987654321), gcsFolder.UpdateTime)
+}
+
+func TestGCSFolder_UninitializedTime(t *testing.T) {
+	attrs := controlpb.Folder{
+		Name:           TestFolderName,
+		Metageneration: 10,
+	}
+
+	gcsFolder := GCSFolder(TestBucketName, &attrs)
+
+	assert.EqualValues(t, int64(0), gcsFolder.UpdateTime)
+}
+
+func BenchmarkGCSFolder(b *testing.B) {
+	timestamp := &timestamppb.Timestamp{
+		Seconds: 1234567890,
+	}
+	attrs := controlpb.Folder{
+		Name:       "projects/_/buckets/testBucket/folders/testFolder",
+		UpdateTime: timestamp,
+	}
+
+	for b.Loop() {
+		// this triggers 2 allocations
+		// the string creation inside getFolderName()
+		// and the &Folder{} heap allocation
+		_ = GCSFolder("testBucket", &attrs)
+	}
 }


### PR DESCRIPTION
### Description
By default,`Folder.UpdateTime` was stored as a `time.Time` value, which occupies 24 bytes. By converting this field to a Unix nanosecond `int64` representation which uses 8 bytes, we can safely reduce the structural footprint of every `Folder` object .

#### Changes Made
- Changed `Folder.UpdateTime` from time.Time to `int64`.
- Added a zero-value check `!t.IsZero()` in `GCSFolder` to ensure that uninitialized folder timestamps default to 0 instead of a negative value.
- Updated the mock bucket generation and FUSE assertions to compare the equivalent `UnixNano()` values.

#### Benchmarking results
Using `time.Time`
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkGCSFolder-48           12818931                94.74 ns/op      96 B/op          2 allocs/op
```

Using `int64`
```
goos: linux
goarch: amd64
pkg: github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs
cpu: Intel(R) Xeon(R) CPU @ 2.60GHz
BenchmarkGCSFolder-48           14288154                87.04 ns/op      72 B/op          2 allocs/op
```

All existing tests pass successfully.

### Link to the issue in case of a bug fix.
[b/538385450](B/538385450)

### Testing details
1. Manual - NA
2. Unit tests - Added a `BenchmarkGCSFolder` benchmark in `folder_test.go` to compare memory and CPU performance.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
