### PR TITLE
fix(test): fix typo in test_config.yaml and remove deprecated flags.

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -750,8 +750,8 @@ stale_handle:
     test_bucket: "${BUCKET_NAME}"
     configs:
       - flags:
-          - "--metadata-cache-ttl-secs=3600,--stat-cache-size-mb=32,--type-cache-size-mb=4,--client-protocol=http1,--strong-consistency-on-open"
-          - "--metadata-cache-ttl-secs=3600,--stat-cache-size-mb=32,--type-cache-size-mb=4,--client-protocol=grpc,--strong-consistency-on-open"
+          - "--metadata-cache-ttl-secs=3600,--stat-cache-max-size-mb=32,--client-protocol=http1,--strong-consistency-on-open"
+          - "--metadata-cache-ttl-secs=3600,--stat-cache-max-size-mb=32,--client-protocol=grpc,--strong-consistency-on-open"
         compatible:
           flat: true
           hns: true


### PR DESCRIPTION
### Description
Fix typo in test_config.yaml introduced in #4920

<img width="3394" height="752" alt="image" src="https://github.com/user-attachments/assets/682e9337-53bf-42d1-9db5-24c01b4926c1" />


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
