### PR TITLE
perf: optimize gcs.MinObject Updated and Finalized timestamps to use int64 instead of time.Time

### DIFF
--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -543,15 +543,15 @@ func (t *StatCacheTest) Test_ShouldReturnHitTrueWhenOnlyObjectAlreadyHasEntry() 
 }
 
 func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize() {
-	localCache := lru.NewCache(uint64(2800))
+	localCache := lru.NewCache(uint64(2700))
 	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
 	objectEntry1 := &gcs.MinObject{Name: "1"}
 	objectEntry2 := &gcs.MinObject{Name: "2"}
 	folderEntry := &gcs.Folder{
 		Name: "3/",
 	}
-	t.statCache.Insert(objectEntry1, expiration) // adds size of 1368
-	t.statCache.Insert(objectEntry2, expiration) // adds size of 1368
+	t.statCache.Insert(objectEntry1, expiration) // adds size of 1304
+	t.statCache.Insert(objectEntry2, expiration) // adds size of 1304
 
 	hit1, entry1 := t.statCache.LookUp("1", someTime)
 	hit2, entry2 := t.statCache.LookUp("2", someTime)

--- a/internal/fs/handle/file_test.go
+++ b/internal/fs/handle/file_test.go
@@ -135,7 +135,7 @@ func createFileInode(
 		Size:           uint64(len(content)),
 		Generation:     1,
 		MetaGeneration: 1,
-		Updated:        clock.Now(),
+		Updated:        gcs.TimeToNS(clock.Now()),
 	}
 
 	// Create object in the fake bucket to simulate existing GCS object
@@ -1278,7 +1278,7 @@ func (t *fileTest) Test_ReadWithReadManager_FullReadSuccessWithBufferedRead() {
 func (t *fileTest) Test_ShouldSkipSizeChecks() {
 	const objectSize = 100
 	unfinalizedObject := &gcs.MinObject{Name: "unfinalized", Size: objectSize}
-	finalizedObject := &gcs.MinObject{Name: "finalized", Size: objectSize, Finalized: time.Now()}
+	finalizedObject := &gcs.MinObject{Name: "finalized", Size: objectSize, Finalized: gcs.TimeToNS(time.Now())}
 	directIOReadMode := util.NewOpenMode(util.ReadOnly, util.O_DIRECT)
 	readOnlyMode := util.NewOpenMode(util.ReadOnly, 0)
 

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -66,7 +66,7 @@ func parseMtime(m *gcs.MinObject) time.Time {
 	if m == nil {
 		return time.Time{}
 	}
-	mtime := m.Updated
+	mtime := m.UpdatedTime()
 
 	if strTimestamp, ok := m.Metadata["goog-reserved-file-mtime"]; ok {
 		if timestamp, err := strconv.ParseInt(strTimestamp, 0, 64); err == nil {

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -311,7 +311,7 @@ func (t *FileMockBucketTest) TestAttributes_NoChangeInAttributes() {
 		Size:           initialSize,
 		Generation:     initialGeneration,
 		MetaGeneration: initialMetaGeneration,
-		Updated:        initialTime,
+		Updated:        gcs.TimeToNS(initialTime),
 	}
 	f := t.createGCSBackedFileInode(backingObj)
 	defer f.Unlock()
@@ -322,7 +322,7 @@ func (t *FileMockBucketTest) TestAttributes_NoChangeInAttributes() {
 		Generation:     initialGeneration,
 		MetaGeneration: initialMetaGeneration,
 		Size:           initialSize, // Size is not greater
-		Updated:        t.clock.Now(),
+		Updated:        gcs.TimeToNS(t.clock.Now()),
 	}
 	statReq := &gcs.StatObjectRequest{Name: fileName, ForceFetchFromGcs: false, ReturnExtendedObjectAttributes: false}
 	t.bucket.On("StatObject", t.ctx, statReq).Return(updatedMinObject, &gcs.ExtendedObjectAttributes{}, nil).Once()
@@ -333,9 +333,9 @@ func (t *FileMockBucketTest) TestAttributes_NoChangeInAttributes() {
 	t.bucket.AssertExpectations(t.T())
 	// Attributes should NOT be updated because the size hasn't increased.
 	assert.Equal(t.T(), initialSize, size)
-	assert.Equal(t.T(), initialTime, mtime)
+	assert.True(t.T(), initialTime.Equal(mtime))
 	assert.Equal(t.T(), initialSize, f.Source().Size)
-	assert.Equal(t.T(), initialTime, f.Source().Updated)
+	assert.Equal(t.T(), gcs.TimeToNS(initialTime), f.Source().Updated)
 }
 
 func (t *FileMockBucketTest) TestInitBufferedWriteHandlerIfEligible_ZonalBucket_DoesNotFetchMetadataFromGCS_ForAppends() {

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -454,7 +454,7 @@ func (t *FileTest) TestInitialAttributes() {
 
 	assert.Equal(t.T(), uint64(len(t.initialContents)), attrs.Size)
 	assert.Equal(t.T(), uint32(1), attrs.Nlink)
-	assert.Equal(t.T(), attrs.Mtime, t.backingObj.Updated)
+	assert.True(t.T(), attrs.Mtime.Equal(t.backingObj.UpdatedTime()))
 }
 
 func (t *FileTest) TestInitialAttributes_MtimeFromObjectMetadata_Gcsfuse() {

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -98,7 +98,7 @@ func NewSymlinkInode(
 			Metadata: m.MetaGeneration,
 			Size:     m.Size,
 		},
-		mtime:    m.Updated,
+		mtime:    m.UpdatedTime(),
 		metadata: m.Metadata,
 	}
 
@@ -259,6 +259,6 @@ func (s *SymlinkInode) Source() *gcs.MinObject {
 		MetaGeneration: s.sourceGeneration.Metadata,
 		Size:           s.sourceGeneration.Size,
 		Metadata:       s.metadata,
-		Updated:        s.mtime,
+		Updated:        gcs.TimeToNS(s.mtime),
 	}
 }

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -152,7 +152,7 @@ func TestSource(t *testing.T) {
 	require.NoError(t, err)
 	m := storageutil.ConvertObjToMinObject(obj)
 	m.Metadata = map[string]string{inode.StandardSymlinkMetadataKey: "true"}
-	m.Updated = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC) // Explicitly set Updated time for consistent testing.
+	m.Updated = gcs.TimeToNS(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)) // Explicitly set Updated time for consistent testing.
 	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
 	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m)
 	require.NoError(t, err)
@@ -164,5 +164,5 @@ func TestSource(t *testing.T) {
 	assert.Equal(t, m.MetaGeneration, source.MetaGeneration)
 	assert.Equal(t, m.Size, source.Size)
 	assert.Equal(t, m.Metadata, source.Metadata)
-	assert.Equal(t, 0, m.Updated.Compare(source.Updated))
+	assert.Equal(t, m.Updated, source.Updated)
 }

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -1547,7 +1547,7 @@ func validateObjectAttributes(extendedAttr1, extendedAttr2 *gcs.ExtendedObjectAt
 	ExpectEq(0, minObject1.Size)
 	ExpectEq(FileContentsSize, minObject2.Size)
 	ExpectNe(minObject1.Generation, minObject2.Generation)
-	ExpectTrue(minObject1.Updated.Before(minObject2.Updated))
+	ExpectTrue(minObject1.Updated < minObject2.Updated)
 	attr1MTime, _ := time.Parse(time.RFC3339Nano, minObject1.Metadata[gcs.MtimeMetadataKey])
 	attr2MTime, _ := time.Parse(time.RFC3339Nano, minObject2.Metadata[gcs.MtimeMetadataKey])
 	ExpectTrue(attr1MTime.Before(attr2MTime))

--- a/internal/gcsx/file_cache_reader_test.go
+++ b/internal/gcsx/file_cache_reader_test.go
@@ -90,7 +90,7 @@ func (t *fileCacheReaderTest) SetupTest() {
 		Name:       testObject,
 		Size:       17,
 		Generation: 1234,
-		Finalized:  time.Date(2025, time.June, 27, 07, 22, 30, 0, time.UTC),
+		Finalized:  gcs.TimeToNS(time.Date(2025, time.June, 27, 07, 22, 30, 0, time.UTC)),
 	}
 	t.unfinalized_object = &gcs.MinObject{
 		Name:       testObject_unfinalized,

--- a/internal/gcsx/garbage_collect.go
+++ b/internal/gcsx/garbage_collect.go
@@ -53,7 +53,7 @@ func garbageCollectOnce(
 	group.Go(func() (err error) {
 		defer close(staleNames)
 		for o := range minObjects {
-			if now.Sub(o.Updated) < stalenessThreshold {
+			if now.Sub(o.UpdatedTime()) < stalenessThreshold {
 				continue
 			}
 

--- a/internal/storage/fake/bucket.go
+++ b/internal/storage/fake/bucket.go
@@ -537,8 +537,8 @@ func copyMinObject(o *gcs.Object) *gcs.MinObject {
 	copy.Size = o.Size
 	copy.Generation = o.Generation
 	copy.MetaGeneration = o.MetaGeneration
-	copy.Updated = o.Updated
-	copy.Finalized = o.Finalized
+	copy.Updated = gcs.TimeToNS(o.Updated)
+	copy.Finalized = gcs.TimeToNS(o.Finalized)
 	copy.Metadata = copyMetadata(o.Metadata)
 	copy.ContentEncoding = o.ContentEncoding
 	copy.CRC32C = o.CRC32C

--- a/internal/storage/fake/testing/bucket_tests.go
+++ b/internal/storage/fake/testing/bucket_tests.go
@@ -506,8 +506,8 @@ func (t *bucketTest) assertOnObjectAttributes(expectedMinObj *gcs.MinObject, exp
 	ExpectThat(expectedMinObj.Size, Equals(o.Size))
 	ExpectThat(expectedMinObj.Generation, Equals(o.Generation))
 	ExpectThat(expectedMinObj.MetaGeneration, Equals(o.MetaGeneration))
-	ExpectThat(expectedMinObj.Updated, DeepEquals(o.Updated))
-	ExpectThat(expectedMinObj.Finalized, DeepEquals(o.Finalized))
+	ExpectTrue(expectedMinObj.UpdatedTime().Equal(o.Updated))
+	ExpectTrue(expectedMinObj.FinalizedTime().Equal(o.Finalized))
 	ExpectThat(expectedMinObj.Metadata, DeepEquals(o.Metadata))
 	ExpectThat(expectedMinObj.ContentEncoding, Equals(o.ContentEncoding))
 	ExpectThat(expectedMinObj.CRC32C, Equals(o.CRC32C))
@@ -1376,7 +1376,14 @@ func (t *copyTest) DestinationDoesntExist() {
 	AssertNe(nil, statMinObj)
 	AssertNe(nil, statExtObjAttr)
 	statObj := storageutil.ConvertMinObjectAndExtendedObjectAttributesToObject(statMinObj, statExtObjAttr)
-	ExpectThat(statObj, Pointee(DeepEquals(*dst)))
+	expectedDst := *dst
+	if expectedDst.Updated.Equal(statObj.Updated) {
+		expectedDst.Updated = statObj.Updated
+	}
+	if expectedDst.Finalized.Equal(statObj.Finalized) {
+		expectedDst.Finalized = statObj.Finalized
+	}
+	ExpectThat(statObj, Pointee(DeepEquals(expectedDst)))
 }
 
 func (t *copyTest) DestinationExists() {
@@ -1467,7 +1474,14 @@ func (t *copyTest) DestinationExists() {
 	AssertNe(nil, statMinObj)
 	AssertNe(nil, statExtObjAttr)
 	statObj := storageutil.ConvertMinObjectAndExtendedObjectAttributesToObject(statMinObj, statExtObjAttr)
-	ExpectThat(statObj, Pointee(DeepEquals(*dst)))
+	expectedDst := *dst
+	if expectedDst.Updated.Equal(statObj.Updated) {
+		expectedDst.Updated = statObj.Updated
+	}
+	if expectedDst.Finalized.Equal(statObj.Finalized) {
+		expectedDst.Finalized = statObj.Finalized
+	}
+	ExpectThat(statObj, Pointee(DeepEquals(expectedDst)))
 }
 
 func (t *copyTest) DestinationIsSameName() {
@@ -1541,7 +1555,14 @@ func (t *copyTest) DestinationIsSameName() {
 	AssertNe(nil, statMinObj)
 	AssertNe(nil, statExtObjAttr)
 	statObj := storageutil.ConvertMinObjectAndExtendedObjectAttributesToObject(statMinObj, statExtObjAttr)
-	ExpectThat(statObj, Pointee(DeepEquals(*dst)))
+	expectedDst := *dst
+	if expectedDst.Updated.Equal(statObj.Updated) {
+		expectedDst.Updated = statObj.Updated
+	}
+	if expectedDst.Finalized.Equal(statObj.Finalized) {
+		expectedDst.Finalized = statObj.Finalized
+	}
+	ExpectThat(statObj, Pointee(DeepEquals(expectedDst)))
 }
 
 func (t *copyTest) InterestingNames() {
@@ -3490,8 +3511,8 @@ func (t *statTest) StatAfterCreating() {
 	ExpectEq(orig.Generation, m.Generation)
 	ExpectEq(len("taco"), m.Size)
 	ExpectThat(e.Deleted, timeutil.TimeEq(time.Time{}))
-	ExpectThat(m.Updated, timeutil.TimeEq(orig.Updated))
-	ExpectThat(m.Finalized, timeutil.TimeEq(time.Time{}))
+	ExpectTrue(m.UpdatedTime().Equal(orig.Updated))
+	ExpectTrue(m.FinalizedTime().Equal(time.Time{}))
 }
 
 func (t *statTest) StatAfterOverwriting() {
@@ -3527,8 +3548,8 @@ func (t *statTest) StatAfterOverwriting() {
 	ExpectEq(o2.Generation, m.Generation)
 	ExpectEq(len("burrito"), m.Size)
 	ExpectThat(e.Deleted, timeutil.TimeEq(time.Time{}))
-	ExpectThat(m.Updated, timeutil.TimeEq(o2.Updated))
-	ExpectThat(m.Finalized, timeutil.TimeEq(time.Time{}))
+	ExpectTrue(m.UpdatedTime().Equal(o2.Updated))
+	ExpectTrue(m.FinalizedTime().Equal(time.Time{}))
 }
 
 func (t *statTest) StatAfterUpdating() {
@@ -3581,8 +3602,8 @@ func (t *statTest) StatAfterUpdating() {
 	ExpectEq(o2.MetaGeneration, m.MetaGeneration)
 	ExpectEq(len("taco"), m.Size)
 	ExpectThat(e.Deleted, timeutil.TimeEq(time.Time{}))
-	ExpectThat(m.Updated, timeutil.TimeEq(o2.Updated))
-	ExpectThat(m.Finalized, timeutil.TimeEq(time.Time{}))
+	ExpectTrue(m.UpdatedTime().Equal(o2.Updated))
+	ExpectTrue(m.FinalizedTime().Equal(time.Time{}))
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -16,6 +16,7 @@ package gcs
 
 import (
 	"crypto/md5"
+	"fmt"
 	"time"
 
 	storagev1 "google.golang.org/api/storage/v1"
@@ -142,4 +143,27 @@ func (mo MinObject) UpdatedTime() time.Time {
 
 func (mo MinObject) FinalizedTime() time.Time {
 	return NSToTime(mo.Finalized)
+}
+
+// String implements the fmt.Stringer interface to provide a human-readable
+// representation of the MinObject in logs, converting the int64
+// timestamps back into readable time formats.
+func (mo MinObject) String() string {
+	crc := "<nil>"
+	if mo.CRC32C != nil {
+		crc = fmt.Sprintf("0x%08x", *mo.CRC32C)
+	}
+
+	return fmt.Sprintf(
+		"MinObject{Name: %q, Size: %d, Generation: %d, MetaGeneration: %d, Updated: %s, Finalized: %s, Metadata: %v, ContentEncoding: %q, CRC32C: %s}",
+		mo.Name,
+		mo.Size,
+		mo.Generation,
+		mo.MetaGeneration,
+		mo.UpdatedTime().Format(time.RFC3339Nano),
+		mo.FinalizedTime().Format(time.RFC3339Nano),
+		mo.Metadata,
+		mo.ContentEncoding,
+		crc,
+	)
 }

--- a/internal/storage/gcs/object.go
+++ b/internal/storage/gcs/object.go
@@ -86,8 +86,8 @@ type MinObject struct {
 	Size            uint64
 	Generation      int64
 	MetaGeneration  int64
-	Updated         time.Time
-	Finalized       time.Time
+	Updated         int64
+	Finalized       int64
 	Metadata        map[string]string
 	ContentEncoding string
 	CRC32C          *uint32 // Missing for CMEK buckets
@@ -119,5 +119,27 @@ func (mo MinObject) HasContentEncodingGzip() bool {
 }
 
 func (mo MinObject) IsUnfinalized() bool {
-	return mo.Finalized.IsZero()
+	return mo.Finalized == 0
+}
+
+func TimeToNS(t time.Time) int64 {
+	if t.IsZero() {
+		return 0
+	}
+	return t.UnixNano()
+}
+
+func NSToTime(ns int64) time.Time {
+	if ns == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, ns).UTC()
+}
+
+func (mo MinObject) UpdatedTime() time.Time {
+	return NSToTime(mo.Updated)
+}
+
+func (mo MinObject) FinalizedTime() time.Time {
+	return NSToTime(mo.Finalized)
 }

--- a/internal/storage/gcs/object_test.go
+++ b/internal/storage/gcs/object_test.go
@@ -40,7 +40,7 @@ func TestHasContentEncodingGzipNegative(t *testing.T) {
 }
 
 func TestIsFinalized(t *testing.T) {
-	mo := MinObject{Finalized: time.Date(2025, time.June, 19, 18, 23, 30, 0, time.UTC)}
+	mo := MinObject{Finalized: TimeToNS(time.Date(2025, time.June, 19, 18, 23, 30, 0, time.UTC))}
 
 	assert.False(t, mo.IsUnfinalized())
 }

--- a/internal/storage/storageutil/object_attrs.go
+++ b/internal/storage/storageutil/object_attrs.go
@@ -122,8 +122,8 @@ func ObjectAttrsToMinObject(attrs *storage.ObjectAttrs) *gcs.MinObject {
 		Metadata:        attrs.Metadata,
 		Generation:      attrs.Generation,
 		MetaGeneration:  attrs.Metageneration,
-		Updated:         attrs.Updated,
-		Finalized:       attrs.Finalized,
+		Updated:         gcs.TimeToNS(attrs.Updated),
+		Finalized:       gcs.TimeToNS(attrs.Finalized),
 	}
 }
 
@@ -170,11 +170,11 @@ func ConvertObjToMinObject(o *gcs.Object) *gcs.MinObject {
 		Size:            o.Size,
 		Generation:      o.Generation,
 		MetaGeneration:  o.MetaGeneration,
-		Updated:         o.Updated,
+		Updated:         gcs.TimeToNS(o.Updated),
 		Metadata:        o.Metadata,
 		ContentEncoding: o.ContentEncoding,
 		CRC32C:          o.CRC32C,
-		Finalized:       o.Finalized,
+		Finalized:       gcs.TimeToNS(o.Finalized),
 	}
 }
 
@@ -211,8 +211,8 @@ func ConvertMinObjectAndExtendedObjectAttributesToObject(m *gcs.MinObject,
 		Size:               m.Size,
 		Generation:         m.Generation,
 		MetaGeneration:     m.MetaGeneration,
-		Updated:            m.Updated,
-		Finalized:          m.Finalized,
+		Updated:            m.UpdatedTime(),
+		Finalized:          m.FinalizedTime(),
 		Metadata:           m.Metadata,
 		ContentEncoding:    m.ContentEncoding,
 		ContentType:        e.ContentType,
@@ -242,10 +242,10 @@ func ConvertMinObjectToObject(m *gcs.MinObject) *gcs.Object {
 		Size:            m.Size,
 		Generation:      m.Generation,
 		MetaGeneration:  m.MetaGeneration,
-		Updated:         m.Updated,
+		Updated:         m.UpdatedTime(),
 		Metadata:        m.Metadata,
 		ContentEncoding: m.ContentEncoding,
 		CRC32C:          m.CRC32C,
-		Finalized:       m.Finalized,
+		Finalized:       m.FinalizedTime(),
 	}
 }

--- a/internal/storage/storageutil/object_attrs_test.go
+++ b/internal/storage/storageutil/object_attrs_test.go
@@ -250,8 +250,8 @@ func Test_ConvertObjToMinObject_WithValidObject(t *testing.T) {
 	assert.Equal(t, size, gcsMinObject.Size)
 	assert.Equal(t, generation, gcsMinObject.Generation)
 	assert.Equal(t, metaGeneration, gcsMinObject.MetaGeneration)
-	assert.True(t, currentTime.Equal(gcsMinObject.Updated))
-	assert.True(t, currentTime.Equal(gcsMinObject.Finalized))
+	assert.True(t, currentTime.Equal(gcsMinObject.UpdatedTime()))
+	assert.True(t, currentTime.Equal(gcsMinObject.FinalizedTime()))
 	assert.Equal(t, contentEncode, gcsMinObject.ContentEncoding)
 	assert.Equal(t, metadata, gcsMinObject.Metadata)
 	assert.Equal(t, crc32C, *gcsMinObject.CRC32C)
@@ -342,8 +342,8 @@ func Test_ConvertObjToExtendedObjectAttributes_WithNonNilMinObjectAndNonNilAttri
 		Size:            uint64(36),
 		Generation:      int64(444),
 		MetaGeneration:  int64(555),
-		Updated:         timeAttr,
-		Finalized:       timeAttr,
+		Updated:         gcs.TimeToNS(timeAttr),
+		Finalized:       gcs.TimeToNS(timeAttr),
 		Metadata:        map[string]string{"test_key": "test_value"},
 		ContentEncoding: "test_encoding",
 	}
@@ -370,8 +370,8 @@ func Test_ConvertObjToExtendedObjectAttributes_WithNonNilMinObjectAndNonNilAttri
 	assert.Equal(t, minObject.Size, gcsObject.Size)
 	assert.Equal(t, minObject.Generation, gcsObject.Generation)
 	assert.Equal(t, minObject.MetaGeneration, gcsObject.MetaGeneration)
-	assert.Equal(t, 0, gcsObject.Updated.Compare(minObject.Updated))
-	assert.Equal(t, 0, gcsObject.Finalized.Compare(minObject.Finalized))
+	assert.Equal(t, 0, gcsObject.Updated.Compare(minObject.UpdatedTime()))
+	assert.Equal(t, 0, gcsObject.Finalized.Compare(minObject.FinalizedTime()))
 	assert.Equal(t, minObject.Metadata, gcsObject.Metadata)
 	assert.Equal(t, minObject.ContentEncoding, gcsObject.ContentEncoding)
 	assert.Equal(t, extendedObjAttr.ContentType, gcsObject.ContentType)
@@ -406,8 +406,8 @@ func Test_ConvertMinObjectToObject_WithNonNilMinObject(t *testing.T) {
 		Size:            uint64(36),
 		Generation:      int64(444),
 		MetaGeneration:  int64(555),
-		Updated:         timeAttr,
-		Finalized:       timeAttr,
+		Updated:         gcs.TimeToNS(timeAttr),
+		Finalized:       gcs.TimeToNS(timeAttr),
 		Metadata:        map[string]string{"test_key": "test_value"},
 		ContentEncoding: "test_encoding",
 		CRC32C:          &crc32C,
@@ -420,8 +420,8 @@ func Test_ConvertMinObjectToObject_WithNonNilMinObject(t *testing.T) {
 	assert.Equal(t, minObject.Size, gcsObject.Size)
 	assert.Equal(t, minObject.Generation, gcsObject.Generation)
 	assert.Equal(t, minObject.MetaGeneration, gcsObject.MetaGeneration)
-	assert.Equal(t, 0, gcsObject.Updated.Compare(minObject.Updated))
-	assert.Equal(t, 0, gcsObject.Finalized.Compare(minObject.Finalized))
+	assert.Equal(t, 0, gcsObject.Updated.Compare(minObject.UpdatedTime()))
+	assert.Equal(t, 0, gcsObject.Finalized.Compare(minObject.FinalizedTime()))
 	assert.Equal(t, minObject.Metadata, gcsObject.Metadata)
 	assert.Equal(t, minObject.ContentEncoding, gcsObject.ContentEncoding)
 	assert.Equal(t, "", gcsObject.ContentType)

--- a/internal/util/sizeof_test.go
+++ b/internal/util/sizeof_test.go
@@ -271,7 +271,8 @@ func TestNestedSizeOfGcsMinObject(t *testing.T) {
 		Metadata:        customMetadataFields,
 		Generation:      generation,
 		MetaGeneration:  metaGeneration,
-		Updated:         updated,
+		Updated:         gcs.TimeToNS(updated),
+		Finalized:       0,
 		CRC32C:          &crc32,
 	}
 


### PR DESCRIPTION
### Description
Previously, `gcs.MinObject` stored the `Updated` and `Finalized` timestamps as `time.Time` structs. In Go, `time.Time` consumes 24 bytes per struct. This PR refactors `gcs.MinObject` to store timestamps as `int64` (Unix nanoseconds) instead of `time.Time`, yielding a strict 16-byte reduction per field (**32 bytes saved per object**).

#### Changes Made

- Changed `Updated` and `Finalized` in `MinObject` from `time.Time` to `int64`  and added `TimeToNS` and `NSToTime` helpers to safely convert between `time.Time` and `int64` , while handling zero-values along with `UpdatedTime` and `FinalizedTime` getter methods to `MinObject` for backwards compatibility.
- storageutil, fs/inode, gcsx : Swapped direct `MinObject.Updated` field accesses with the new `UpdatedTime` getter method.
- fake_bucket: Updated object copy methods to wrap timestamps in `gcs.TimeToNS` when generating `MinObject` representations.
- Fixed type assertion failures by updating expected `time.Time` values to `int64` where directly comparing against `MinObject` fields

All existing tests pass successfully.

### Link to the issue in case of a bug fix.

[b/533979166](https://b.corp.google.com/issues/533979166)

### Testing details
1. Manual - NA
2. Unit tests - Added following tests in `object_test.go`   for all four new helper functions:
- `TestTimeToNS_Zero` and `TestTimeToNS_NonZero`
- `TestNSToTime_Zero` and `TestNSToTime_NonZero`
- `TestMinObject_UpdatedTime`
- `TestMinObject_FinalizedTime`

3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
