### PR TITLE
feat(integration_tests): support skip field in test_config.yaml

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -631,6 +631,20 @@ func BucketType(ctx context.Context, testBucket string) (bucketType string, err 
 	return FlatBucket, nil
 }
 
+func shouldSkipConfig(testName, configRun, configSkip string) bool {
+	if testName != "" && testName != configRun {
+		return true
+	}
+	if configSkip != "" && configRun != "" {
+		for _, skipItem := range strings.Split(configSkip, ",") {
+			if strings.TrimSpace(skipItem) == configRun {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // BuildFlagSets dynamically builds a list of flag sets based on bucket compatibility.
 // bucketType should be "flat", "hns", "zonal", "flat_pirlo", or "hns_pirlo".
 // The run parameter filters flag sets based on the 'Run' field in the test
@@ -665,7 +679,7 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, run string) [][
 			}
 		}
 		tpcRun := (TestOnTPCEndPoint() == testCase.TPC)
-		if isCompatible && tpcRun && (run == "" || run == testCase.Run) {
+		if isCompatible && tpcRun && !shouldSkipConfig(run, testCase.Run, testCase.Skip) {
 			// 3. If compatible, process its flags and add them to the result.
 			for _, flagString := range testCase.Flags {
 				flagString = strings.ReplaceAll(flagString, ",", " ")

--- a/tools/integration_tests/util/test_suite/config.go
+++ b/tools/integration_tests/util/test_suite/config.go
@@ -60,6 +60,7 @@ type ConfigItem struct {
 	SecondaryFlags []string         `yaml:"secondary_flags"`
 	Compatible     map[string]bool  `yaml:"compatible"`
 	Run            string           `yaml:"run,omitempty"`
+	Skip           string           `yaml:"skip,omitempty"`
 	RunOnGKE       bool             `yaml:"run_on_gke"`
 	RunOnPirlo     RunOnPirloConfig `yaml:"run_on_pirlo"`
 	TPC            bool             `yaml:"tpc,omitempty"`


### PR DESCRIPTION
### Description
This PR adds support for a `skip` field in `test_config.yaml` (`ConfigItem`) for integration tests, allowing test configurations to skip specific test cases. Comma-separated values (e.g. `skip: "TestA, TestB"`) are also supported.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No