### PR TITLE
test(emulator_tests): remove deprecated experimental-nonrapid-folder-api-stall-retry flag

### DIFF
--- a/tools/integration_tests/emulator_tests/control_client_stall/control_client_stall_test.go
+++ b/tools/integration_tests/emulator_tests/control_client_stall/control_client_stall_test.go
@@ -197,9 +197,8 @@ func (c *getStorageLayoutStallSuite) TestGetStorageLayoutStallInducedShouldCompl
 func TestControlClientStall(t *testing.T) {
 	flags := []string{
 		"--client-protocol=grpc",
-		"--rename-dir-limit=0",                                // Force use of Control API for folders instead of legacy workarounds
-		"--experimental-nonrapid-folder-api-stall-retry=true", // Enable the new flag we are testing!
-		"--metadata-cache-ttl-secs=0",                         // Disable cache so calls definitely hit the backend
+		"--rename-dir-limit=0",        // Force use of Control API for folders instead of legacy workarounds
+		"--metadata-cache-ttl-secs=0", // Disable cache so calls definitely hit the backend
 	}
 
 	suites := []suite.TestingSuite{


### PR DESCRIPTION
### Description
PR #4907 ("extend control client stall retries to regional buckets and remove experimental flag") deprecated the `experimental-nonrapid-folder-api-stall-retry` flag and removed it from `gcsfuse`. However, the flag remained in `tools/integration_tests/emulator_tests/control_client_stall/control_client_stall_test.go`, causing emulator tests to fail with `unknown flag: --experimental-nonrapid-folder-api-stall-retry`.

This PR removes the deprecated flag from the emulator test flags.


### Testing details
1. Manual - Executed `control_client_stall` emulator test suite against local `storage-testbench` emulator and verified all tests pass cleanly.
2. Unit tests - NA
3. Integration tests - Executed `go test ./tools/integration_tests/emulator_tests/control_client_stall/...`.

### Any backward incompatible change? If so, please explain.
No