### PR TITLE
fix(inode): report symlink size as the length of its target

### DIFF
--- a/internal/fs/caching_test.go
+++ b/internal/fs/caching_test.go
@@ -395,7 +395,7 @@ func (t *CachingWithImplicitDirsTest) SymlinksWork() {
 	AssertEq(nil, err)
 
 	ExpectEq("bar", fi.Name())
-	ExpectEq(0, fi.Size())
+	ExpectEq(len("foo"), fi.Size())
 	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
 
 	// Stat the target via the link.

--- a/internal/fs/foreign_modifications_test.go
+++ b/internal/fs/foreign_modifications_test.go
@@ -895,7 +895,7 @@ func (t *ForeignModsTest) Symlink() {
 	AssertEq(nil, err)
 
 	ExpectEq("foo", fi.Name())
-	ExpectEq(0, fi.Size())
+	ExpectEq(len("bar/baz"), fi.Size())
 	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
 
 	// Read the link.

--- a/internal/fs/inode/symlink.go
+++ b/internal/fs/inode/symlink.go
@@ -232,6 +232,10 @@ func (s *SymlinkInode) Destroy() (err error) {
 
 func (s *SymlinkInode) Attributes(
 	ctx context.Context, clobberedCheck bool) (size uint64, mtime time.Time, nlink uint32, err error) {
+	// POSIX requires st_size of a symlink to be the length of the target path,
+	// excluding the terminating null byte. It is not the size of the backing GCS
+	// object, which is zero for legacy symlinks that keep the target in metadata.
+	size = uint64(len(s.target))
 	mtime = s.mtime
 	nlink = 1
 	return

--- a/internal/fs/inode/symlink_test.go
+++ b/internal/fs/inode/symlink_test.go
@@ -118,9 +118,86 @@ func TestAttributes(t *testing.T) {
 			// Check expected values
 			require.NoError(t, err)
 			assert.Equal(t, uint32(1), nlink)
-			assert.Equal(t, uint64(0), size)
+			assert.Equal(t, uint64(len("target")), size)
 		})
 	}
+}
+
+func TestAttributesSizeIsTargetLength(t *testing.T) {
+	tests := []struct {
+		name     string
+		target   string
+		metadata map[string]string
+		// objectSize is the size of the backing GCS object, which must not be
+		// what Attributes reports.
+		objectSize uint64
+	}{
+		{
+			name:     "LegacySymlink",
+			target:   "/some/fairly/long/target/path",
+			metadata: map[string]string{inode.SymlinkMetadataKey: "/some/fairly/long/target/path"},
+		},
+		{
+			name:       "LegacySymlinkWithNonZeroObjectSize",
+			target:     "target",
+			metadata:   map[string]string{inode.SymlinkMetadataKey: "target"},
+			objectSize: 100,
+		},
+		{
+			name:     "EmptyTarget",
+			target:   "",
+			metadata: map[string]string{inode.SymlinkMetadataKey: ""},
+		},
+		{
+			name:     "MultiByteTarget",
+			target:   "/tmp/ünïcödé",
+			metadata: map[string]string{inode.SymlinkMetadataKey: "/tmp/ünïcödé"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Arrange.
+			bucket := setupSymlinkTest(t)
+			m := &gcs.MinObject{
+				Name:     "test",
+				Size:     tt.objectSize,
+				Metadata: tt.metadata,
+			}
+			name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
+			s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m)
+			require.NoError(t, err)
+
+			// Act.
+			size, _, _, err := s.Attributes(context.Background(), false)
+
+			// Assert.
+			require.NoError(t, err)
+			assert.Equal(t, uint64(len(tt.target)), size)
+			assert.Equal(t, tt.target, s.Target())
+		})
+	}
+}
+
+func TestAttributesSizeForStandardSymlink(t *testing.T) {
+	// Arrange. A standard symlink keeps its target in the object's content, so
+	// here the backing object size and the target length coincide.
+	const target = "/path/to/target"
+	bucket := setupSymlinkTest(t)
+	obj, err := storageutil.CreateObject(context.Background(), bucket, "test", []byte(target))
+	require.NoError(t, err)
+	m := storageutil.ConvertObjToMinObject(obj)
+	m.Metadata = map[string]string{inode.StandardSymlinkMetadataKey: "true"}
+	name := inode.NewFileName(inode.NewRootName("some-bucket"), m.Name)
+	s, err := inode.NewSymlinkInode(context.Background(), fuseops.InodeID(42), name, bucket, m)
+	require.NoError(t, err)
+
+	// Act.
+	size, _, _, err := s.Attributes(context.Background(), false)
+
+	// Assert.
+	require.NoError(t, err)
+	assert.Equal(t, uint64(len(target)), size)
 }
 
 func TestUpdateSize(t *testing.T) {

--- a/internal/fs/local_modifications_test.go
+++ b/internal/fs/local_modifications_test.go
@@ -2404,12 +2404,13 @@ func (t *SymlinkTest) CreateLink() {
 	AssertEq(nil, err)
 	ExpectEq("foo", target)
 
-	// Stat the link.
+	// Stat the link. Per POSIX the size of a symlink is the length of its
+	// target, not the size of the backing object (which is zero here).
 	fi, err = os.Lstat(symlinkName)
 	AssertEq(nil, err)
 
 	ExpectEq("bar", fi.Name())
-	ExpectEq(0, fi.Size())
+	ExpectEq(len("foo"), fi.Size())
 	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
 
 	// Read the parent directory.
@@ -2419,7 +2420,7 @@ func (t *SymlinkTest) CreateLink() {
 
 	fi = entries[0]
 	ExpectEq("bar", fi.Name())
-	ExpectEq(0, fi.Size())
+	ExpectEq(len("foo"), fi.Size())
 	ExpectEq(filePerms|os.ModeSymlink, fi.Mode())
 
 	// Stat the target via the link.
@@ -2429,6 +2430,31 @@ func (t *SymlinkTest) CreateLink() {
 	ExpectEq("bar", fi.Name())
 	ExpectEq(len(contents), fi.Size())
 	ExpectEq(filePerms, fi.Mode())
+}
+
+func (t *SymlinkTest) LinkSizeIsTargetLength() {
+	// stat(2) requires st_size of a symlink to be the length of the pathname it
+	// contains, without a terminating null byte. The object backing a legacy
+	// symlink is empty, so the size must come from the target instead.
+	testCases := []struct {
+		name   string
+		target string
+	}{
+		{"relative", "foo"},
+		{"absolute", "/some/fairly/long/target/path"},
+		{"multi_byte", "/tmp/ünïcödé"},
+	}
+
+	for _, tc := range testCases {
+		symlinkName := path.Join(mntDir, tc.name)
+		err := os.Symlink(tc.target, symlinkName)
+		AssertEq(nil, err, "target: %q", tc.target)
+
+		fi, err := os.Lstat(symlinkName)
+		AssertEq(nil, err, "target: %q", tc.target)
+
+		ExpectEq(len(tc.target), fi.Size(), "target: %q", tc.target)
+	}
 }
 
 func (t *SymlinkTest) CreateLink_Exists() {


### PR DESCRIPTION
### Description

`SymlinkInode.Attributes` never assigned its `size` return value, so it returned the zero value and `stat` reported a size of 0 for every symlink.

```go
func (s *SymlinkInode) Attributes(
	ctx context.Context, clobberedCheck bool) (size uint64, mtime time.Time, nlink uint32, err error) {
	mtime = s.mtime
	nlink = 1
	return
}
```

`stat(2)` requires `st_size` of a symlink to be the length of the pathname it contains, without a terminating null byte. The intended semantics were already documented in this same file, on `UpdateSize` a few lines above:

```go
// The size of a symlink is its target's length, not the backing object's size.
```

So the contract was written down; `Attributes` just did not implement it. For a legacy symlink the backing object is empty, which is why the reported size came out as 0 rather than as some other wrong number.

The fix is one line: `size = uint64(len(s.target))`.

Scope check: `fs.getAttributes` is the only caller of `Attributes`, and it assigns the value straight to `attr.Size`. The rename path reads `Source()` (the backing object's size) rather than `Attributes`, so it is unaffected. The change is limited to the size reported to the kernel.

### Link to the issue in case of a bug fix.

https://github.com/GoogleCloudPlatform/gcsfuse/issues/2273

I posted the root-cause analysis there first, per the dev guide, including the open question below. Happy to close this PR if you would rather handle it yourselves or scope it differently.

### Testing details

1. Manual - NA. Verified through the composite tests below, which exercise a real mount rather than only the inode layer.
2. Unit tests - updated `TestAttributes`, which previously asserted `uint64(0)`. Added `TestAttributesSizeIsTargetLength`, covering the legacy metadata representation with a zero-size backing object, a non-zero-size backing object (so the assertion cannot pass by coincidence), an empty target, and a multi-byte target. Added `TestAttributesSizeForStandardSymlink` for the content-based representation.
3. Integration tests - not run; I do not have a test bucket. The composite suite was run instead: `./internal/fs/...` passes, including a new `SymlinkTest.LinkSizeIsTargetLength` that creates symlinks through the mount and checks `Lstat` reports the target length.

As a negative control I reverted the one-line fix and confirmed all three new tests fail with `actual: 0x0`, so they do test the change rather than pass incidentally.

Six packages fail in my container (`benchmarks/internal/percentile`, `internal/block`, `internal/bufferedread`, `internal/cache/file`, `internal/cache/util`, `internal/gcsx`). I checked these against a clean checkout and the failing set is identical, so they are environmental - the container runs as root, which defeats the permission-based cases - and unrelated to this change.

### Any backward incompatible change? If so, please explain.

Yes, in observable behaviour, and it is worth an explicit decision rather than being waved through.

`stat` on a symlink now reports the target length instead of 0. Anything that reads `st_size` for a symlink sees a different number - though 0 was never a value a POSIX-conforming caller could use, and tools like `tar`, `rsync` and `ls -l` expect the target length.

Concretely, four existing assertions pinned the old value and are updated here:

- `internal/fs/inode/symlink_test.go` - `TestAttributes`
- `internal/fs/local_modifications_test.go` - `SymlinkTest.CreateLink`, twice, via `Lstat` and via the readdir entry
- `internal/fs/caching_test.go` - `CachingWithImplicitDirsTest.SymlinksWork`
- `internal/fs/foreign_modifications_test.go` - `ForeignModsTest.Symlink`

My reading is that these were written to match the implementation rather than to encode a deliberate decision, but that judgement is yours. The GCS object size assertion in `CreateLink` (`ExpectEq(0, m.Size)`) is left alone - that one is correctly 0, since a legacy symlink's target lives in metadata and the object really is empty.
