### PR TITLE
refactor(integration_tests): introduce WriterOptions and streamline GCS writer test utilities

### DIFF
--- a/tools/integration_tests/rapid_operations/helpers_test.go
+++ b/tools/integration_tests/rapid_operations/helpers_test.go
@@ -34,12 +34,10 @@ func (t *BaseSuite) createGCSFile(useAppendableAPI bool, fileSize int64) (filePa
 	content, err := operations.GenerateRandomData(fileSize)
 	require.NoError(t.T(), err)
 
-	// Create file directly in GCS using Go SDK with the chosen API.
-	finalizeOnClose := true
-	err = client.CreateObjectWithOptions(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, t.fileName), content, nil, client.WriterOptions{
-		UseAppendableAPI: useAppendableAPI,
-		FinalizeOnClose:  &finalizeOnClose,
-	})
+	err = client.CreateObjectWithOptions(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, t.fileName), content, nil,
+		client.WithAppendableAPI(useAppendableAPI),
+		client.WithFinalizeOnClose(true),
+	)
 	require.NoError(t.T(), err)
 	return filePath, content
 }

--- a/tools/integration_tests/rapid_operations/helpers_test.go
+++ b/tools/integration_tests/rapid_operations/helpers_test.go
@@ -35,7 +35,11 @@ func (t *BaseSuite) createGCSFile(useAppendableAPI bool, fileSize int64) (filePa
 	require.NoError(t.T(), err)
 
 	// Create file directly in GCS using Go SDK with the chosen API.
-	err = client.CreateObjectWithAPI(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, t.fileName), content, useAppendableAPI)
+	finalizeOnClose := true
+	err = client.CreateObjectWithOptions(testEnv.ctx, testEnv.storageClient, path.Join(testDirName, t.fileName), content, nil, client.WriterOptions{
+		UseAppendableAPI: useAppendableAPI,
+		FinalizeOnClose:  &finalizeOnClose,
+	})
 	require.NoError(t.T(), err)
 	return filePath, content
 }

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -17,6 +17,7 @@ package readonly_test
 
 import (
 	"context"
+	"errors"
 	"log"
 	"os"
 	"path"
@@ -76,8 +77,11 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		writer := client.NewWriterWithOptions(ctx, object, client.WriterOptions{})
 
 		// Write the text to the object
-		if _, err := writer.Write([]byte(file.fileContent + "\n")); err != nil {
+		if _, writeErr := writer.Write([]byte(file.fileContent + "\n")); writeErr != nil {
+			closeErr := writer.Close()
+			err := errors.Join(writeErr, closeErr)
 			log.Printf("Error writing to object %s: %v\n", file.filePath, err)
+			return err
 		}
 		if err := writer.Close(); err != nil {
 			log.Printf("Error in closing writer: %v", err)

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -74,7 +74,7 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
-		writer := client.NewWriterWithOptions(ctx, object, client.WriterOptions{})
+		writer := client.NewWriterWithOptions(ctx, object)
 
 		// Write the text to the object
 		if _, writeErr := writer.Write([]byte(file.fileContent + "\n")); writeErr != nil {

--- a/tools/integration_tests/readonly/readonly_test.go
+++ b/tools/integration_tests/readonly/readonly_test.go
@@ -17,7 +17,6 @@ package readonly_test
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"os"
 	"path"
@@ -74,17 +73,13 @@ func createTestDataForReadOnlyTests(ctx context.Context, storageClient *storage.
 		filePath := path.Join(dirPath, file.filePath)
 		// Create a storage writer for the destination object
 		object := bucketHandle.Object(filePath)
-		writer, err := client.NewWriter(ctx, object, storageClient)
-		if err != nil {
-			return fmt.Errorf("Error opening writer for object %s: %w\n", file.filePath, err)
-		}
+		writer := client.NewWriterWithOptions(ctx, object, client.WriterOptions{})
 
 		// Write the text to the object
-		if _, err = writer.Write([]byte(file.fileContent + "\n")); err != nil {
+		if _, err := writer.Write([]byte(file.fileContent + "\n")); err != nil {
 			log.Printf("Error writing to object %s: %v\n", file.filePath, err)
 		}
-		err = writer.Close()
-		if err != nil {
+		if err := writer.Close(); err != nil {
 			log.Printf("Error in closing writer: %v", err)
 			return err
 		}

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -126,7 +126,7 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 	fullLinkPath := path.Join(TestDirName, linkName)
 	bucketName, objectName := setup.GetBucketAndObjectBasedOnTypeOfMount(fullLinkPath)
 	objHandle := testEnv.storageClient.Bucket(bucketName).Object(objectName)
-	w := client.NewWriterWithOptions(testEnv.ctx, objHandle, client.WriterOptions{})
+	w := client.NewWriterWithOptions(testEnv.ctx, objHandle)
 
 	var content []byte
 	if s.isStandardSymlink {

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -126,8 +126,7 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 	fullLinkPath := path.Join(TestDirName, linkName)
 	bucketName, objectName := setup.GetBucketAndObjectBasedOnTypeOfMount(fullLinkPath)
 	objHandle := testEnv.storageClient.Bucket(bucketName).Object(objectName)
-	w, err := client.NewWriter(testEnv.ctx, objHandle, testEnv.storageClient)
-	s.Require().NoError(err)
+	w := client.NewWriterWithOptions(testEnv.ctx, objHandle, client.WriterOptions{})
 
 	var content []byte
 	if s.isStandardSymlink {
@@ -138,7 +137,7 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 		content = []byte("") // Legacy symlinks have empty content
 	}
 
-	_, err = w.Write(content)
+	_, err := w.Write(content)
 	s.Require().NoError(err)
 	s.Require().NoError(w.Close())
 	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -203,28 +203,55 @@ func ReadChunkFromGCS(ctx context.Context, client *storage.Client, object string
 	return string(content), nil
 }
 
-// WriterOptions contains optional parameters for creating objects on GCS.
-type WriterOptions struct {
-	StorageClass     string
-	UseAppendableAPI bool
-	FinalizeOnClose  *bool
+// WriterOption is a function that configures writer properties.
+type WriterOption func(*writerConfig)
+
+type writerConfig struct {
+	storageClass     string
+	useAppendableAPI bool
+	finalizeOnClose  bool
 }
 
-// NewWriterWithOptions creates a storage.Writer configured with the given WriterOptions.
-func NewWriterWithOptions(ctx context.Context, o *storage.ObjectHandle, opts WriterOptions) *storage.Writer {
-	wc := o.NewWriter(ctx)
+// WithFinalizeOnClose explicitly sets the finalize behavior.
+func WithFinalizeOnClose(finalize bool) WriterOption {
+	return func(c *writerConfig) {
+		c.finalizeOnClose = finalize
+	}
+}
 
-	// Set FinalizeOnClose: true by default for non-zonal runs (including Pirlo uploads),
-	// but false for zonal bucket runs (unless explicitly specified in opts).
-	wc.FinalizeOnClose = !setup.IsZonalBucketRun()
-	if opts.FinalizeOnClose != nil {
-		wc.FinalizeOnClose = *opts.FinalizeOnClose
+// WithStorageClass sets the storage class.
+func WithStorageClass(sc string) WriterOption {
+	return func(c *writerConfig) {
+		c.storageClass = sc
+	}
+}
+
+// WithAppendableAPI sets whether to use the appendable API.
+func WithAppendableAPI(use bool) WriterOption {
+	return func(c *writerConfig) {
+		c.useAppendableAPI = use
+	}
+}
+
+// NewWriterWithOptions creates a storage.Writer configured with the given options.
+func NewWriterWithOptions(ctx context.Context, o *storage.ObjectHandle, opts ...WriterOption) *storage.Writer {
+	// 1. Set the dynamic defaults first
+	cfg := writerConfig{
+		finalizeOnClose: !setup.IsZonalBucketRun(),
 	}
 
-	wc.Append = opts.UseAppendableAPI || setup.IsZonalBucketRun()
+	// 2. Apply any explicit overrides passed by the caller
+	for _, opt := range opts {
+		opt(&cfg)
+	}
 
-	if opts.StorageClass != "" {
-		wc.StorageClass = opts.StorageClass
+	// 3. Construct the writer using the final resolved config
+	wc := o.NewWriter(ctx)
+	wc.FinalizeOnClose = cfg.finalizeOnClose
+	wc.Append = cfg.useAppendableAPI || setup.IsZonalBucketRun()
+
+	if cfg.storageClass != "" {
+		wc.StorageClass = cfg.storageClass
 	} else if wc.Append {
 		wc.StorageClass = "RAPID"
 	}
@@ -238,7 +265,7 @@ func WriteToObject(ctx context.Context, client *storage.Client, object, content 
 		preconditions = &precondition
 	}
 
-	return CreateObjectWithOptions(ctx, client, object, []byte(content), preconditions, WriterOptions{})
+	return CreateObjectWithOptions(ctx, client, object, []byte(content), preconditions)
 }
 
 // CreateObjectOnGCS creates an object with given name and content on GCS.
@@ -247,22 +274,18 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 }
 
 func CreateFinalizedObjectOnGCS(ctx context.Context, client *storage.Client, object, content string) error {
-	finalizeOnClose := true
-	return CreateObjectWithOptions(ctx, client, object, []byte(content), nil, WriterOptions{
-		UseAppendableAPI: true,
-		FinalizeOnClose:  &finalizeOnClose,
-	})
+	return CreateObjectWithOptions(ctx, client, object, []byte(content), nil, WithAppendableAPI(true), WithFinalizeOnClose(true))
 }
 
-// CreateObjectWithOptions creates an object on GCS with custom content, optional preconditions, and WriterOptions.
-func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object string, content []byte, preconditions *storage.Conditions, opts WriterOptions) error {
+// CreateObjectWithOptions creates an object on GCS with custom content, optional preconditions, and WriterOption functional options.
+func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object string, content []byte, preconditions *storage.Conditions, opts ...WriterOption) error {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 	o := getBucketHandle(client, bucket).Object(object)
 	if preconditions != nil && !reflect.DeepEqual(*preconditions, storage.Conditions{}) {
 		o = o.If(*preconditions)
 	}
 
-	wc := NewWriterWithOptions(ctx, o, opts)
+	wc := NewWriterWithOptions(ctx, o, opts...)
 
 	if _, writeErr := wc.Write(content); writeErr != nil {
 		closeErr := wc.Close()
@@ -380,7 +403,7 @@ func UploadGcsObjectWithPreconditions(ctx context.Context, client *storage.Clien
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
-	w := NewWriterWithOptions(ctx, obj, WriterOptions{})
+	w := NewWriterWithOptions(ctx, obj)
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)
@@ -501,7 +524,7 @@ func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, 
 	}
 
 	// Upload an object with storage.Writer.
-	wc := NewWriterWithOptions(ctx, o, WriterOptions{})
+	wc := NewWriterWithOptions(ctx, o)
 	return wc, nil
 }
 
@@ -538,7 +561,7 @@ func uploadGcsObjectWithPreconditionsWithoutIntermediateDelays(ctx context.Conte
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
-	w := NewWriterWithOptions(ctx, obj, WriterOptions{})
+	w := NewWriterWithOptions(ctx, obj)
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -203,54 +203,42 @@ func ReadChunkFromGCS(ctx context.Context, client *storage.Client, object string
 	return string(content), nil
 }
 
-// NewWriter is a wrapper over storage.NewWriter which
-// extends support to zonal buckets.
-func NewWriter(ctx context.Context, o *storage.ObjectHandle, client *storage.Client) (wc *storage.Writer, err error) {
-	wc = o.NewWriter(ctx)
-	wc.FinalizeOnClose = true
+// WriterOptions contains optional parameters for creating objects on GCS.
+type WriterOptions struct {
+	StorageClass     string
+	UseAppendableAPI bool
+	FinalizeOnClose  *bool
+}
 
-	// Changes specific to zonal bucket
-	var attrs *storage.BucketAttrs
-	attrs, err = getBucketHandle(client, o.BucketName()).Attrs(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get attributes for bucket %q: %w", o.BucketName(), err)
-	}
-	if attrs.StorageClass == "RAPID" {
-		if setup.IsZonalBucketRun() {
-			// Zonal bucket writers require append-flag to be set.
-			wc.Append = true
-			// Zonal buckets with rapid appends should not finalize on close.
-			wc.FinalizeOnClose = false
-		} else {
-			return nil, fmt.Errorf("found zonal bucket %q in non-zonal e2e test run (--zonal=false)", o.BucketName())
-		}
+// NewWriterWithOptions creates a storage.Writer configured with the given WriterOptions.
+func NewWriterWithOptions(ctx context.Context, o *storage.ObjectHandle, opts WriterOptions) *storage.Writer {
+	wc := o.NewWriter(ctx)
+
+	// Set FinalizeOnClose: true by default for non-zonal runs (including Pirlo uploads),
+	// but false for zonal bucket runs (unless explicitly specified in opts).
+	wc.FinalizeOnClose = !setup.IsZonalBucketRun()
+	if opts.FinalizeOnClose != nil {
+		wc.FinalizeOnClose = *opts.FinalizeOnClose
 	}
 
-	return
+	wc.Append = opts.UseAppendableAPI || setup.IsZonalBucketRun()
+
+	if opts.StorageClass != "" {
+		wc.ObjectAttrs.StorageClass = opts.StorageClass
+	} else if wc.Append {
+		wc.ObjectAttrs.StorageClass = "RAPID"
+	}
+
+	return wc
 }
 
 func WriteToObject(ctx context.Context, client *storage.Client, object, content string, precondition storage.Conditions) error {
-	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
-
-	o := getBucketHandle(client, bucket).Object(object)
+	var preconditions *storage.Conditions
 	if !reflect.DeepEqual(precondition, storage.Conditions{}) {
-		o = o.If(precondition)
+		preconditions = &precondition
 	}
 
-	// Upload an object with storage.Writer.
-	wc, err := NewWriter(ctx, o, client)
-	if err != nil {
-		return fmt.Errorf("Failed to open writer for object %q: %w", object, err)
-	}
-	if _, err := io.WriteString(wc, content); err != nil {
-		return fmt.Errorf("io.WriteString failed for object %q: %w", object, err)
-	}
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("Writer.Close failed for object %q: %w", object, err)
-	}
-	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
-
-	return nil
+	return CreateObjectWithOptions(ctx, client, object, []byte(content), preconditions, WriterOptions{})
 }
 
 // CreateObjectOnGCS creates an object with given name and content on GCS.
@@ -259,31 +247,22 @@ func CreateObjectOnGCS(ctx context.Context, client *storage.Client, object, cont
 }
 
 func CreateFinalizedObjectOnGCS(ctx context.Context, client *storage.Client, object, content string) error {
-	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
-	o := getBucketHandle(client, bucket).Object(object)
-
-	// Upload an object with storage.Writer with finalizeOnClose=true
-	wc := o.NewWriter(ctx)
-	wc.Append = true
-	wc.FinalizeOnClose = true
-	if _, err := io.WriteString(wc, content); err != nil {
-		return fmt.Errorf("io.WriteString failed for object %q: %w", object, err)
-	}
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("Writer.Close failed for object %q: %w", object, err)
-	}
-	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
-	return nil
+	finalizeOnClose := true
+	return CreateObjectWithOptions(ctx, client, object, []byte(content), nil, WriterOptions{
+		UseAppendableAPI: true,
+		FinalizeOnClose:  &finalizeOnClose,
+	})
 }
 
-// CreateObjectWithAPI creates an object on GCS with the given content, allowing the choice of whether to use the appendable API.
-func CreateObjectWithAPI(ctx context.Context, client *storage.Client, object string, content []byte, useAppendableAPI bool) error {
+// CreateObjectWithOptions creates an object on GCS with custom content, optional preconditions, and WriterOptions.
+func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object string, content []byte, preconditions *storage.Conditions, opts WriterOptions) error {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 	o := getBucketHandle(client, bucket).Object(object)
+	if preconditions != nil && !reflect.DeepEqual(*preconditions, storage.Conditions{}) {
+		o = o.If(*preconditions)
+	}
 
-	wc := o.NewWriter(ctx)
-	wc.Append = useAppendableAPI
-	wc.FinalizeOnClose = true
+	wc := NewWriterWithOptions(ctx, o, opts)
 
 	if _, err := wc.Write(content); err != nil {
 		return fmt.Errorf("wc.Write failed for object %q: %w", object, err)
@@ -291,6 +270,7 @@ func CreateObjectWithAPI(ctx context.Context, client *storage.Client, object str
 	if err := wc.Close(); err != nil {
 		return fmt.Errorf("wc.Close failed for object %q: %w", object, err)
 	}
+	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
 	return nil
 }
 
@@ -399,10 +379,7 @@ func UploadGcsObjectWithPreconditions(ctx context.Context, client *storage.Clien
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
-	w, err := NewWriter(ctx, obj, client)
-	if err != nil {
-		return fmt.Errorf("failed to open writer for GCS object gs://%s/%s: %w", bucketName, objectName, err)
-	}
+	w := NewWriterWithOptions(ctx, obj, WriterOptions{})
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)
@@ -523,10 +500,7 @@ func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, 
 	}
 
 	// Upload an object with storage.Writer.
-	wc, err := NewWriter(ctx, o, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open writer for object %q: %w", o.ObjectName(), err)
-	}
+	wc := NewWriterWithOptions(ctx, o, WriterOptions{})
 	return wc, nil
 }
 
@@ -563,10 +537,7 @@ func uploadGcsObjectWithPreconditionsWithoutIntermediateDelays(ctx context.Conte
 	if preconditions != nil {
 		obj = obj.If(*preconditions)
 	}
-	w, err := NewWriter(ctx, obj, client)
-	if err != nil {
-		return fmt.Errorf("failed to open writer for GCS object gs://%s/%s: %w", bucketName, objectName, err)
-	}
+	w := NewWriterWithOptions(ctx, obj, WriterOptions{})
 	defer func() {
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -224,9 +224,9 @@ func NewWriterWithOptions(ctx context.Context, o *storage.ObjectHandle, opts Wri
 	wc.Append = opts.UseAppendableAPI || setup.IsZonalBucketRun()
 
 	if opts.StorageClass != "" {
-		wc.ObjectAttrs.StorageClass = opts.StorageClass
+		wc.StorageClass = opts.StorageClass
 	} else if wc.Append {
-		wc.ObjectAttrs.StorageClass = "RAPID"
+		wc.StorageClass = "RAPID"
 	}
 
 	return wc
@@ -264,8 +264,9 @@ func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object
 
 	wc := NewWriterWithOptions(ctx, o, opts)
 
-	if _, err := wc.Write(content); err != nil {
-		return fmt.Errorf("wc.Write failed for object %q: %w", object, err)
+	if _, writeErr := wc.Write(content); writeErr != nil {
+		closeErr := wc.Close()
+		return fmt.Errorf("wc.Write failed for object %q: %w", object, errors.Join(writeErr, closeErr))
 	}
 	if err := wc.Close(); err != nil {
 		return fmt.Errorf("wc.Close failed for object %q: %w", object, err)


### PR DESCRIPTION
### Description

This PR refactors the GCS writer initialization in integration tests by introducing a `WriterOptions` struct and streamlined helper methods (`NewWriterWithOptions` / `CreateObjectWithOptions`). This reduces boilerplate, removes redundant network calls, and improves write error handling.

Crucially, this PR also ensures that the `RAPID` storage class is explicitly set whenever the appendable API is used. While Zonal buckets are exclusively `RAPID`, Pirlo buckets support both `RAPID` and `STANDARD` classes, but the appendable API is only supported on `RAPID`. This explicit assignment prevents test failures when a bucket's default storage class differs.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No