### PR TITLE
fix(custom endpoint): Skipping control client creation for REST custom endpoint

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -425,7 +425,8 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 	var clientOpts []option.ClientOption
 
 	// Control-client is needed for folder APIs and for getting storage-layout of the bucket.
-	if clientConfig.EnableHNS {
+	// Bypassed for HTTP storage testbenches that inject the legacy REST API path.
+	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "/storage/v1/") {
 		// For control client, we don't pass billingProject to avoid setting it globally via option.WithQuotaProject.
 		// The wrapper storageControlClientWithBillingProject will manually add it to the context for supported calls.
 		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false)

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -426,7 +426,7 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 
 	// Control-client is needed for folder APIs and for getting storage-layout of the bucket.
 	// Bypassed for HTTP storage testbenches that inject the legacy REST API path.
-	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "/storage/v1/") {
+	if clientConfig.EnableHNS && !strings.Contains(clientConfig.CustomEndpoint, "/storage/v1") {
 		// For control client, we don't pass billingProject to avoid setting it globally via option.WithQuotaProject.
 		// The wrapper storageControlClientWithBillingProject will manually add it to the context for supported calls.
 		clientOpts, err = createClientOptionForGRPCClient(ctx, &clientConfig, false)
@@ -443,6 +443,8 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		controlClient = NewStorageControlClient(rawStorageControlClient, &clientConfig,
 			WithBillingProject(billingProject),
 		)
+	} else {
+		logger.Infof("Skipping storage control client creation for custom-endpoint %q.", clientConfig.CustomEndpoint)
 	}
 
 	sh = &storageClient{

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -443,7 +443,7 @@ func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClien
 		controlClient = NewStorageControlClient(rawStorageControlClient, &clientConfig,
 			WithBillingProject(billingProject),
 		)
-	} else {
+	} else if clientConfig.EnableHNS {
 		logger.Infof("Skipping storage control client creation for custom-endpoint %q.", clientConfig.CustomEndpoint)
 	}
 


### PR DESCRIPTION
### Description
This PR gracefully skips the creation of the `storageControlClient` when a custom REST endpoint (containing `/storage/v1/`) is provided in the storage client configuration.  

### Link to the issue in case of a bug fix.


### Testing details
1. Manual - NA
2. Unit tests - Done
3. Integration tests - Done

### Any backward incompatible change? If so, please explain.
