### PR TITLE
feat: support HTTP path for unix scheme in token-url using fragments

### DIFF
--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -47,7 +47,26 @@ func newProxyTokenSource(
 				return dialer.DialContext(ctx, u.Scheme, u.Path)
 			},
 		}
-		endpoint = "http://unix?" + u.RawQuery
+		if u.Fragment != "" {
+			relURL, err := url.Parse(u.Fragment)
+			if err != nil {
+				return nil, fmt.Errorf("parsing fragment %q: %w", u.Fragment, err)
+			}
+			targetURL := url.URL{
+				Scheme:   "http",
+				Host:     "unix",
+				Path:     relURL.Path,
+				RawQuery: relURL.RawQuery,
+			}
+			endpoint = targetURL.String()
+		} else {
+			targetURL := url.URL{
+				Scheme:   "http",
+				Host:     "unix",
+				RawQuery: u.RawQuery,
+			}
+			endpoint = targetURL.String()
+		}
 	}
 
 	ts = proxyTokenSource{

--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -47,15 +47,16 @@ func newProxyTokenSource(
 				return dialer.DialContext(ctx, u.Scheme, u.Path)
 			},
 		}
-		if u.Fragment != "" {
-			relURL, err := url.Parse(u.Fragment)
+		if escapedFragment := u.EscapedFragment(); escapedFragment != "" {
+			relURL, err := url.Parse(escapedFragment)
 			if err != nil {
-				return nil, fmt.Errorf("parsing fragment %q: %w", u.Fragment, err)
+				return nil, fmt.Errorf("parsing fragment %q: %w", escapedFragment, err)
 			}
 			targetURL := url.URL{
 				Scheme:   "http",
 				Host:     "unix",
 				Path:     relURL.Path,
+				RawPath:  relURL.RawPath,
 				RawQuery: relURL.RawQuery,
 			}
 			endpoint = targetURL.String()

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -17,8 +17,11 @@ package auth
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -26,15 +29,23 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func Test_NewTokenSourceFromURL_Success(t *testing.T) {
-	// Create fake token server.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+func tokenHandler(accessToken string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
 		token := oauth2.Token{
-			AccessToken: "test-access-token",
+			AccessToken: accessToken,
 			TokenType:   "Bearer",
 		}
-		require.NoError(t, json.NewEncoder(w).Encode(token))
-	}))
+		_ = json.NewEncoder(w).Encode(token)
+	}
+}
+
+func startFakeTCPTokenServer(accessToken string) *httptest.Server {
+	return httptest.NewServer(tokenHandler(accessToken))
+}
+
+func Test_NewTokenSourceFromURL_Success(t *testing.T) {
+	accessToken := "test-access-token"
+	server := startFakeTCPTokenServer(accessToken)
 	defer server.Close()
 
 	ts, err := NewTokenSourceFromURL(context.Background(), server.URL, false)
@@ -44,7 +55,7 @@ func Test_NewTokenSourceFromURL_Success(t *testing.T) {
 	// Fetch token
 	token, err := ts.Token()
 	assert.NoError(t, err)
-	assert.Equal(t, "test-access-token", token.AccessToken)
+	assert.Equal(t, accessToken, token.AccessToken)
 }
 
 func Test_NewTokenSourceFromURL_InvalidURL(t *testing.T) {
@@ -85,4 +96,80 @@ func TestProxyTokenSource_TokenFetch_InvalidJSON(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "decode body")
 	assert.Nil(t, token)
+}
+
+func startFakeUDSTokenServer(t *testing.T, listener net.Listener, expectedPath, expectedQuery, accessToken string) *http.Server {
+	server := &http.Server{
+		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, expectedPath, r.URL.Path)
+			assert.Equal(t, expectedQuery, r.URL.RawQuery)
+			assert.Equal(t, "unix", r.Host)
+			tokenHandler(accessToken)(w, r)
+		}),
+	}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	return server
+}
+
+func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_Success(t *testing.T) {
+	// Create a temp file for the socket.
+	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
+	require.NoError(t, err)
+	socketPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	require.NoError(t, os.Remove(socketPath)) // remove it so net.Listen can create it
+	defer os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	expectedPath := "/computeMetadata/v1/instance/service-accounts/default/token"
+	expectedQuery := "foo=bar&baz=qux"
+	accessToken := "uds-access-token"
+
+	server := startFakeUDSTokenServer(t, listener, expectedPath, expectedQuery, accessToken)
+	defer server.Close()
+
+	// unix:///path/to/socket#/http_path?query
+	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedPath, expectedQuery)
+	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	token, err := ts.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, accessToken, token.AccessToken)
+}
+
+func Test_NewTokenSourceFromURL_UnixSocket_BackwardCompatibility_Success(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
+	require.NoError(t, err)
+	socketPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	require.NoError(t, os.Remove(socketPath))
+	defer os.Remove(socketPath)
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer listener.Close()
+
+	expectedPath := "/"
+	expectedQuery := "foo=bar"
+	accessToken := "uds-access-token-compat"
+
+	server := startFakeUDSTokenServer(t, listener, expectedPath, expectedQuery, accessToken)
+	defer server.Close()
+
+	// unix:///path/to/socket?query (old way, but with query)
+	tokenURL := fmt.Sprintf("unix://%s?%s", socketPath, expectedQuery)
+	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	token, err := ts.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, accessToken, token.AccessToken)
 }

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -98,10 +98,10 @@ func TestProxyTokenSource_TokenFetch_InvalidJSON(t *testing.T) {
 	assert.Nil(t, token)
 }
 
-func startFakeUDSTokenServer(t *testing.T, listener net.Listener, expectedPath, expectedQuery, accessToken string) *http.Server {
+func startFakeUDSTokenServer(t *testing.T, listener net.Listener, expectedEscapedPath, expectedQuery, accessToken string) *http.Server {
 	server := &http.Server{
 		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, expectedPath, r.URL.Path)
+			assert.Equal(t, expectedEscapedPath, r.URL.EscapedPath())
 			assert.Equal(t, expectedQuery, r.URL.RawQuery)
 			assert.Equal(t, "unix", r.Host)
 			tokenHandler(accessToken)(w, r)
@@ -120,21 +120,51 @@ func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_Success(t *testing.T) {
 	socketPath := tmpFile.Name()
 	require.NoError(t, tmpFile.Close())
 	require.NoError(t, os.Remove(socketPath)) // remove it so net.Listen can create it
-	defer os.Remove(socketPath)
+	defer func() { _ = os.Remove(socketPath) }()
 
 	listener, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
-	expectedPath := "/computeMetadata/v1/instance/service-accounts/default/token"
+	expectedEscapedPath := "/computeMetadata/v1/instance/service-accounts/default/token"
 	expectedQuery := "foo=bar&baz=qux"
 	accessToken := "uds-access-token"
 
-	server := startFakeUDSTokenServer(t, listener, expectedPath, expectedQuery, accessToken)
-	defer server.Close()
+	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
+	defer func() { _ = server.Close() }()
 
 	// unix:///path/to/socket#/http_path?query
-	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedPath, expectedQuery)
+	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedEscapedPath, expectedQuery)
+	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	token, err := ts.Token()
+	assert.NoError(t, err)
+	assert.Equal(t, accessToken, token.AccessToken)
+}
+
+func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_EscapedChars_Success(t *testing.T) {
+	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
+	require.NoError(t, err)
+	socketPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	require.NoError(t, os.Remove(socketPath))
+	defer func() { _ = os.Remove(socketPath) }()
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+	defer func() { _ = listener.Close() }()
+
+	// Path contains escaped slash (%2F) and query contains escaped space (%20)
+	expectedEscapedPath := "/computeMetadata%2Fv1%2Finstance%2Fservice-accounts%2Fdefault%2Ftoken"
+	expectedQuery := "foo=bar%20baz"
+	accessToken := "uds-access-token-escaped"
+
+	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
+	defer func() { _ = server.Close() }()
+
+	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedEscapedPath, expectedQuery)
 	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
 	require.NoError(t, err)
 	require.NotNil(t, ts)
@@ -150,18 +180,18 @@ func Test_NewTokenSourceFromURL_UnixSocket_BackwardCompatibility_Success(t *test
 	socketPath := tmpFile.Name()
 	require.NoError(t, tmpFile.Close())
 	require.NoError(t, os.Remove(socketPath))
-	defer os.Remove(socketPath)
+	defer func() { _ = os.Remove(socketPath) }()
 
 	listener, err := net.Listen("unix", socketPath)
 	require.NoError(t, err)
-	defer listener.Close()
+	defer func() { _ = listener.Close() }()
 
-	expectedPath := "/"
+	expectedEscapedPath := "/"
 	expectedQuery := "foo=bar"
 	accessToken := "uds-access-token-compat"
 
-	server := startFakeUDSTokenServer(t, listener, expectedPath, expectedQuery, accessToken)
-	defer server.Close()
+	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
+	defer func() { _ = server.Close() }()
 
 	// unix:///path/to/socket?query (old way, but with query)
 	tokenURL := fmt.Sprintf("unix://%s?%s", socketPath, expectedQuery)


### PR DESCRIPTION

This PR adds support for specifying an HTTP request path (and query parameters) when using a Unix Domain Socket (UDS) with the token-url config.

Why is this change needed?
Previously, when configuring token-url with the unix:// scheme, GCSFuse would drop the HTTP path entirely and default to requesting the root path (/). This made it impossible to use a single UDS server to host multiple endpoints (e.g., mimicking the GCP metadata server structure like /computeMetadata/v1/instance/service-accounts/default/token).

Solution: The Fragment Approach (#)
We introduce the URL fragment (#) as a separator to define the HTTP destination path and query parameters:

Format: unix://<path_to_socket>#<http_path>?<http_query>
Example: unix:///tmp/metadata.sock#/computeMetadata/v1/instance/service-accounts/default/token?foo=bar
Using the fragment identifier (#) prevents collisions with any query parameters required by the destination request itself (e.g., if the server expects a query parameter named path).

Backward Compatibility
If no fragment is present (e.g. unix:///tmp/metadata.sock?foo=bar), GCSFuse falls back to the previous behavior by defaulting the path to / and appending the query parameters, ensuring GKE Workload Identity sidecars are not affected.

### Description

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
