### PR TITLE
test(integration): Define dedicated test suites for rapid writes flagsets

### DIFF
--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -17,7 +17,6 @@ package implicit_dir_test
 
 import (
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
@@ -28,7 +27,8 @@ import (
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                               -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
-func TestDeleteNonEmptyImplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitDir() {
+	t := s.T()
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
@@ -43,7 +43,8 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                               -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
-func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitSubDir() {
+	t := s.T()
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
@@ -60,7 +61,8 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                                                 -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                                               -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2                            -- File
-func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirWithExplicitSubDir() {
+	t := s.T()
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
@@ -81,7 +83,8 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2                                                 -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir                                           -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir/fileInExplicitDirInImplicitDir            -- File
-func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir() {
+	t := s.T()
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
@@ -103,7 +106,8 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/fileInImplicitDir1                              -- File
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
-func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirInExplicitDir() {
+	t := s.T()
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
@@ -122,7 +126,8 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/fileInImplicitDir1                              -- File
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
-func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteExplicitDirContainingImplicitSubDir() {
+	t := s.T()
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))

--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -28,14 +28,13 @@ import (
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitDir() {
-	t := s.T()
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -44,14 +43,13 @@ func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitDir() {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
 func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitSubDir() {
-	t := s.T()
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	subDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(subDirPath, implicit_and_explicit_dir_setup.ImplicitSubDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(subDirPath, implicit_and_explicit_dir_setup.ImplicitSubDirectory, s.T())
 }
 
 // Directory Structure
@@ -62,18 +60,17 @@ func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitSubDir() {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                                               -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2                            -- File
 func (s *implicitDirTestSuite) TestDeleteImplicitDirWithExplicitSubDir() {
-	t := s.T()
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, ExplicitDirInImplicitDir)
 
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitDir, explicitDirPath, PrefixFileInExplicitDirInImplicitDir, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitDir, explicitDirPath, PrefixFileInExplicitDirInImplicitDir, s.T())
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -84,17 +81,16 @@ func (s *implicitDirTestSuite) TestDeleteImplicitDirWithExplicitSubDir() {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir                                           -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir/fileInExplicitDirInImplicitDir            -- File
 func (s *implicitDirTestSuite) TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir() {
-	t := s.T()
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory, ExplicitDirInImplicitSubDir)
 
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, s.T())
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -107,14 +103,13 @@ func (s *implicitDirTestSuite) TestDeleteImplicitDirWithImplicitSubDirContaining
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
 func (s *implicitDirTestSuite) TestDeleteImplicitDirInExplicitDir() {
-	t := s.T()
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -127,12 +122,11 @@ func (s *implicitDirTestSuite) TestDeleteImplicitDirInExplicitDir() {
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
 func (s *implicitDirTestSuite) TestDeleteExplicitDirContainingImplicitSubDir() {
-	t := s.T()
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, s.T())
 }

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -59,11 +59,13 @@ type implicitDirTestSuite struct {
 }
 
 func runImplicitDirSuite(t *testing.T, runSuiteFunc func()) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		runSuiteFunc()
 		return
 	}
 
+	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
 		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -24,6 +24,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
@@ -65,9 +66,18 @@ func runImplicitDirSuite(t *testing.T, runSuiteFunc func()) {
 
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
-		log.Printf("Running %s with flags: %s", t.Name(), flags)
+		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
 		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(testEnv.cfg, flags)
-		require.NoError(t, err, "Mount failed")
+		require.NoError(t, err, "Static mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+
+		log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+		err = persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(testEnv.cfg, flags)
+		require.NoError(t, err, "Persistent mount failed")
 
 		runSuiteFunc()
 
@@ -115,12 +125,14 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
+	// 3. Set up test directory for test bucket.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
+	// 4. Run tests.
 	successCode := m.Run()
 
-	// Clean up test directory created.
+	// 5. Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -24,9 +24,11 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 const ExplicitDirInImplicitDir = "explicitDirInImplicitDir"
@@ -45,9 +47,41 @@ type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
 	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
 }
 
 var testEnv env
+
+type implicitDirTestSuite struct {
+	suite.Suite
+}
+
+func runImplicitDirSuite(t *testing.T, runSuiteFunc func()) {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		runSuiteFunc()
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		log.Printf("Running %s with flags: %s", t.Name(), flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(testEnv.cfg, flags)
+		require.NoError(t, err, "Mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+	}
+}
+
+func TestImplicitDirBase(t *testing.T) {
+	runImplicitDirSuite(t, func() {
+		suite.Run(t, new(implicitDirTestSuite))
+		suite.Run(t, &implicitDirLocalFileTest{isRapidWritesEnabled: false})
+	})
+}
 
 func setupTestDir(dirName string) string {
 	dir := setup.SetupTestDirectory(DirForImplicitDirTests)
@@ -71,7 +105,8 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.ImplicitDir[0])
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.ImplicitDir[0])
+	testEnv.cfg = &cfg.ImplicitDir[0]
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -80,14 +115,12 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// 3. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.ImplicitDir[0], bucketType, "")
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
-	// 4. Run tests with the dynamically generated flags.
-	successCode := implicit_and_explicit_dir_setup.RunTestsForExplicitAndImplicitDir(&cfg.ImplicitDir[0], flags, m)
-	setup.SaveLogFileInCaseOfFailure(successCode)
+	successCode := m.Run()
 
-	// 5. Clean up test directory created.
+	// Clean up test directory created.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -21,14 +21,14 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListImplicitObjectsFromBucket(t *testing.T) {
+func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
+	t := s.T()
 	testDirName := "testListImplicitObjectsFromBucket"
 	testDirPath := setupTestDir(testDirName)
 	// Directory Structure
@@ -140,7 +140,8 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	}
 }
 
-func TestStatImplicitDirAfterList(t *testing.T) {
+func (s *implicitDirTestSuite) TestStatImplicitDirAfterList() {
+	t := s.T()
 	testDirPath := setup.SetupTestDirectory(DirForImplicitDirTests)
 	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, DirForImplicitDirTests)
 

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
-	t := s.T()
 	testDirName := "testListImplicitObjectsFromBucket"
 	testDirPath := setupTestDir(testDirName)
 	// Directory Structure
@@ -41,8 +40,8 @@ func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
-	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), s.T())
 
 	err := filepath.WalkDir(testDirPath, func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {
@@ -64,21 +63,21 @@ func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 		if path == testDirPath {
 			// numberOfObjects - 3
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfTotalObjects {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir     -- Dir
 			if objs[0].Name() != implicit_and_explicit_dir_setup.ExplicitDirectory || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			// testBucket/dirForImplicitDirTests/testDir/explicitFile    -- File
 			if objs[1].Name() != implicit_and_explicit_dir_setup.ExplicitFile || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir     -- Dir
 			if objs[2].Name() != implicit_and_explicit_dir_setup.ImplicitDirectory || objs[2].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 		}
 
@@ -86,17 +85,17 @@ func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ExplicitDirectory {
 			// numberOfObjects - 2
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInExplicitDirectory {
-				t.Errorf("Incorrect number of objects in the explicitDirectory.")
+				s.T().Errorf("Incorrect number of objects in the explicitDirectory.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir/fileInExplicitDir1   -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FirstFileInExplicitDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir/fileInExplicitDir2    -- File
 			if objs[1].Name() != implicit_and_explicit_dir_setup.SecondFileInExplicitDirectory || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
@@ -105,16 +104,16 @@ func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ImplicitDirectory {
 			// numberOfObjects - 2
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInImplicitDirectory {
-				t.Errorf("Incorrect number of objects in the implicitDirectory.")
+				s.T().Errorf("Incorrect number of objects in the implicitDirectory.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/fileInImplicitDir1  -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FileInImplicitDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/implicitSubDirectory  -- Dir
 			if objs[1].Name() != implicit_and_explicit_dir_setup.ImplicitSubDirectory || objs[1].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
@@ -123,38 +122,37 @@ func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ImplicitSubDirectory {
 			// numberOfObjects - 1
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInImplicitSubDirectory {
-				t.Errorf("Incorrect number of objects in the implicitSubDirectoryt.")
+				s.T().Errorf("Incorrect number of objects in the implicitSubDirectoryt.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/implicitSubDir/fileInImplicitDir2   -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FileInImplicitSubDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }
 
 func (s *implicitDirTestSuite) TestStatImplicitDirAfterList() {
-	t := s.T()
 	testDirPath := setup.SetupTestDirectory(DirForImplicitDirTests)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, DirForImplicitDirTests)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, DirForImplicitDirTests)
 
 	// List the directory
 	_, err := os.ReadDir(testDirPath)
 	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
+		s.T().Fatalf("ReadDir failed: %v", err)
 	}
 
 	// Stat the implicit directory
 	implicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 	f, err := os.Stat(implicitDirPath)
-	if assert.NoError(t, err) {
-		assert.True(t, f.IsDir())
+	if assert.NoError(s.T(), err) {
+		assert.True(s.T(), f.IsDir())
 	}
 }

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -62,7 +62,7 @@ func (i *implicitDirLocalFileTest) TestNewFileUnderImplicitDirectoryShouldNotGet
 		// An object written without sync would be recognized as having zero-size.
 		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", i.T())
 
-		// An object written with sync can be fully read.
+		// An appendable object written with sync can be fully read.
 		err := fh.Sync()
 		require.NoError(i.T(), err)
 		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, i.T())

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -22,66 +22,82 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 const (
 	testDirName = "ImplicitDirTest"
 )
 
+type implicitDirLocalFileTest struct {
+	isRapidWritesEnabled bool
+	suite.Suite
+}
+
+func TestImplicitDirLocalFileRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	runImplicitDirSuite(t, func() {
+		suite.Run(t, &implicitDirLocalFileTest{isRapidWritesEnabled: true})
+	})
+}
+
 // //////////////////////////////////////////////////////////////////////
 // Tests
 // //////////////////////////////////////////////////////////////////////
 
-func TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose(t *testing.T) {
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+func (i *implicitDirLocalFileTest) TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose() {
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
 	fileName := path.Join(ImplicitDirName, FileName1)
 
-	_, fh := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName, t)
-	operations.WriteWithoutClose(fh, FileContents, t)
-	if !setup.IsZonalBucketRun() {
-		// For non-zonal buckets, the object is not visible until the file is closed.
-		ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, t)
-	} else {
-		// For zonal buckets, the object is unfinalized, but visible.
-		// A zonal bucket object written without sync would be recognized as having zero-size.
-		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", t)
+	_, fh := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName, i.T())
+	operations.WriteWithoutClose(fh, FileContents, i.T())
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && i.isRapidWritesEnabled) {
+		// For zonal buckets and pirlo rapid writes, the object is unfinalized, but visible.
+		// An object written without sync would be recognized as having zero-size.
+		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", i.T())
 
-		// A zonal bucket object written with sync can be fully read.
+		// An object written with sync can be fully read.
 		err := fh.Sync()
-		require.NoError(t, err)
-		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, t)
+		require.NoError(i.T(), err)
+		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, i.T())
+	} else {
+		// For non-zonal/non-rapid buckets, the object is not visible until the file is closed.
+		ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, i.T())
 	}
 
 	// Validate.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh, testBaseDirName, fileName, FileContents, t)
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh, testBaseDirName, fileName, FileContents, i.T())
 }
 
-func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+func (i *implicitDirLocalFileTest) TestReadDirForImplicitDirWithLocalFile() {
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
 	fileName1 := path.Join(ImplicitDirName, FileName1)
 	fileName2 := path.Join(ImplicitDirName, FileName2)
-	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName1, t)
-	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, t)
+	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName1, i.T())
+	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, i.T())
 
 	// Attempt to list implicit directory.
-	entries := operations.ReadDirectory(path.Join(testEnv.testDirPath, ImplicitDirName), t)
+	entries := operations.ReadDirectory(path.Join(testEnv.testDirPath, ImplicitDirName), i.T())
 
 	// Verify entries received successfully.
-	operations.VerifyCountOfDirectoryEntries(3, len(entries), t)
-	operations.VerifyFileEntry(entries[0], FileName1, 0, t)
-	operations.VerifyFileEntry(entries[1], FileName2, 0, t)
-	operations.VerifyFileEntry(entries[2], ImplicitFileName1, GCSFileSize, t)
+	operations.VerifyCountOfDirectoryEntries(3, len(entries), i.T())
+	operations.VerifyFileEntry(entries[0], FileName1, 0, i.T())
+	operations.VerifyFileEntry(entries[1], FileName2, 0, i.T())
+	operations.VerifyFileEntry(entries[2], ImplicitFileName1, GCSFileSize, i.T())
 	// Close the local files.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, fileName1, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", t)
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, fileName1, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", i.T())
 }
 
-func TestRecursiveListingWithLocalFiles(t *testing.T) {
+func (i *implicitDirLocalFileTest) TestRecursiveListingWithLocalFiles() {
 	// Structure
 	// mntDir/
 	// mntDir/foo1 										--- file
@@ -91,18 +107,18 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 	// mntDir/implicit/foo2  					--- file
 	// mntDir/implicit/implicitFile1	--- file
 
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
 	fileName2 := path.Join(ExplicitDirName, ExplicitFileName1)
 	fileName3 := path.Join(ImplicitDirName, FileName2)
 	// Create local file in mnt/ dir.
-	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, FileName1, t)
+	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, FileName1, i.T())
 	// Create explicit dir with 1 local file.
-	operations.CreateDirectory(path.Join(testEnv.testDirPath, ExplicitDirName), t)
-	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, t)
+	operations.CreateDirectory(path.Join(testEnv.testDirPath, ExplicitDirName), i.T())
+	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, i.T())
 	// Create implicit dir with 1 local file1 and 1 synced file.
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
-	_, fh3 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName3, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
+	_, fh3 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName3, i.T())
 
 	// Recursively list mntDir/ directory.
 	err := filepath.WalkDir(testEnv.testDirPath,
@@ -115,39 +131,37 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 				return nil
 			}
 
-			objs := operations.ReadDirectory(walkPath, t)
+			objs := operations.ReadDirectory(walkPath, i.T())
 
 			// Check if mntDir has correct objects.
 			if walkPath == setup.MntDir() {
 				// numberOfObjects = 3
-				operations.VerifyCountOfDirectoryEntries(3, len(objs), t)
-				operations.VerifyDirectoryEntry(objs[0], ExplicitDirName, t)
-				operations.VerifyFileEntry(objs[1], FileName1, 0, t)
-				operations.VerifyDirectoryEntry(objs[2], ImplicitDirName, t)
+				operations.VerifyCountOfDirectoryEntries(3, len(objs), i.T())
+				operations.VerifyDirectoryEntry(objs[0], ExplicitDirName, i.T())
+				operations.VerifyFileEntry(objs[1], FileName1, 0, i.T())
+				operations.VerifyDirectoryEntry(objs[2], ImplicitDirName, i.T())
 			}
 
 			// Check if mntDir/explicitFoo/ has correct objects.
 			if walkPath == path.Join(testEnv.testDirPath, ExplicitDirName) {
 				// numberOfObjects = 1
-				operations.VerifyCountOfDirectoryEntries(1, len(objs), t)
-				operations.VerifyFileEntry(objs[0], ExplicitFileName1, 0, t)
+				operations.VerifyCountOfDirectoryEntries(1, len(objs), i.T())
+				operations.VerifyFileEntry(objs[0], ExplicitFileName1, 0, i.T())
 			}
 
 			// Check if mntDir/implicitFoo/ has correct objects.
 			if walkPath == path.Join(testEnv.testDirPath, ImplicitDirName) {
 				// numberOfObjects = 2
-				operations.VerifyCountOfDirectoryEntries(2, len(objs), t)
-				operations.VerifyFileEntry(objs[0], FileName2, 0, t)
-				operations.VerifyFileEntry(objs[1], ImplicitFileName1, GCSFileSize, t)
+				operations.VerifyCountOfDirectoryEntries(2, len(objs), i.T())
+				operations.VerifyFileEntry(objs[0], FileName2, 0, i.T())
+				operations.VerifyFileEntry(objs[1], ImplicitFileName1, GCSFileSize, i.T())
 			}
 			return nil
 		})
 
 	// Validate and close the files.
-	if err != nil {
-		t.Errorf("filepath.WalkDir() err: %v", err)
-	}
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, FileName1, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh3, testBaseDirName, fileName3, "", t)
+	assert.NoError(i.T(), err, "filepath.WalkDir failed")
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, FileName1, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh3, testBaseDirName, fileName3, "", i.T())
 }

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -58,7 +58,7 @@ func (i *implicitDirLocalFileTest) TestNewFileUnderImplicitDirectoryShouldNotGet
 	_, fh := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName, i.T())
 	operations.WriteWithoutClose(fh, FileContents, i.T())
 	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && i.isRapidWritesEnabled) {
-		// For zonal buckets and pirlo rapid writes, the object is unfinalized, but visible.
+		// For appendable objects, the object is unfinalized, but visible.
 		// An object written without sync would be recognized as having zero-size.
 		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", i.T())
 
@@ -67,7 +67,7 @@ func (i *implicitDirLocalFileTest) TestNewFileUnderImplicitDirectoryShouldNotGet
 		require.NoError(i.T(), err)
 		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, i.T())
 	} else {
-		// For non-zonal/non-rapid buckets, the object is not visible until the file is closed.
+		// For non-appendable objects, the object is not visible until the file is closed.
 		ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, i.T())
 	}
 

--- a/tools/integration_tests/implicit_dir/rename_sym_link_test.go
+++ b/tools/integration_tests/implicit_dir/rename_sym_link_test.go
@@ -25,32 +25,31 @@ import (
 )
 
 func (s *implicitDirTestSuite) TestRenameSymlinkToImplicitDir() {
-	t := s.T()
 	testDir := setup.SetupTestDirectory(DirForImplicitDirTests)
 	implicitDirName := "implicit_dir"
 	// Create an object that defines an implicit directory. This creates `implicit_dir/`.
 	objectNameInGCS := path.Join(DirForImplicitDirTests, implicitDirName, "placeholder")
 	err := client.CreateObjectOnGCS(testEnv.ctx, testEnv.storageClient, objectNameInGCS, "")
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	implicitDirPath := path.Join(testDir, implicitDirName)
 	oldSymlinkPath := path.Join(testDir, "symlink_old")
 	err = os.Symlink(implicitDirPath, oldSymlinkPath)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	newSymlinkPath := path.Join(testDir, "symlink_new")
 
 	err = os.Rename(oldSymlinkPath, newSymlinkPath)
 
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	_, err = os.Lstat(oldSymlinkPath)
-	require.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.Error(s.T(), err)
+	assert.True(s.T(), os.IsNotExist(err))
 	fi, err := os.Lstat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.ModeSymlink, fi.Mode()&os.ModeType)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), os.ModeSymlink, fi.Mode()&os.ModeType)
 	targetRead, err := os.Readlink(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, implicitDirPath, targetRead)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), implicitDirPath, targetRead)
 	targetFi, err := os.Stat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.True(t, targetFi.IsDir())
+	require.NoError(s.T(), err)
+	assert.True(s.T(), targetFi.IsDir())
 }

--- a/tools/integration_tests/implicit_dir/rename_sym_link_test.go
+++ b/tools/integration_tests/implicit_dir/rename_sym_link_test.go
@@ -17,7 +17,6 @@ package implicit_dir_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -25,7 +24,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenameSymlinkToImplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestRenameSymlinkToImplicitDir() {
+	t := s.T()
 	testDir := setup.SetupTestDirectory(DirForImplicitDirTests)
 	implicitDirName := "implicit_dir"
 	// Create an object that defines an implicit directory. This creates `implicit_dir/`.

--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
 )
 
 // Create below directory structure.
@@ -113,9 +114,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	checkIfCopiedDirectoryHasCorrectData(destDir, s.T())
 }
@@ -142,9 +141,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -181,9 +178,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -248,9 +243,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	objs, err := os.ReadDir(destDir)
 	if err != nil {
@@ -301,9 +294,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInEmptyDirectory() {
 	operations.CreateDirectoryWithNFiles(0, destDir, "", s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -348,9 +339,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonExistingDirectory() {
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	checkIfCopiedEmptyDirectoryHasNoData(destDir, s.T())
 }

--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -107,17 +107,17 @@ func checkIfCopiedDirectoryHasCorrectData(destDir string, t *testing.T) {
 // destCopyDir               -- Dir
 // destCopyDir/copy.txt      -- File
 // destCopyDir/subSrcCopyDir -- Dir
-func TestCopyDirectoryInNonExistingDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
-	checkIfCopiedDirectoryHasCorrectData(destDir, t)
+	checkIfCopiedDirectoryHasCorrectData(destDir, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -129,21 +129,21 @@ func TestCopyDirectoryInNonExistingDirectory(t *testing.T) {
 // destCopyDir/srcCopyDir               -- Dir
 // destCopyDir/srcCopyDir/copy.txt      -- File
 // destCopyDir/srcCopyDir/subSrcCopyDir -- Dir
-func TestCopyDirectoryInEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
 	destDir := path.Join(testDir, DestCopyDirectory)
 	err := os.Mkdir(destDir, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Error in creating directory: %v", err)
+		s.T().Errorf("Error in creating directory: %v", err)
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -155,12 +155,12 @@ func TestCopyDirectoryInEmptyDirectory(t *testing.T) {
 	// destCopyDirectory
 	// destCopyDirectory/srcCopyDirectory
 	if len(obj) != 1 || obj[0].Name() != SrcCopyDirectory || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, t)
+	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
 }
 
 func createDestNonEmptyDirectory(dirPath string, t *testing.T) string {
@@ -172,17 +172,17 @@ func createDestNonEmptyDirectory(dirPath string, t *testing.T) string {
 	return dirPath
 }
 
-func TestCopyDirectoryInNonEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), t)
+	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -195,24 +195,24 @@ func TestCopyDirectoryInNonEmptyDirectory(t *testing.T) {
 	// destCopyDirectory/srcCopyDirectory
 	// destCopyDirectory/subDestCopyDirectory
 	if len(obj) != NumberOfObjectsInNonEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destCopyDirectory/srcCopyDirectory  - Dir
 	if obj[0].Name() != SrcCopyDirectory || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	// destCopyDirectory/subDirInNonEmptyDestCopyDirectory  - Dir
 	if obj[1].Name() != SubDirInNonEmptyDestCopyDirectory || obj[1].IsDir() != true {
-		t.Errorf("Existing object affected.")
+		s.T().Errorf("Existing object affected.")
 		return
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, t)
+	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
 }
 
 func checkIfCopiedEmptyDirectoryHasNoData(destSrc string, t *testing.T) {
@@ -236,20 +236,20 @@ func checkIfCopiedEmptyDirectoryHasNoData(destSrc string, t *testing.T) {
 // destNonEmptyCopyDirectory
 // destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory
 // destNonEmptyCopyDirectory/emptySrcDirectoryCopyTest
-func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// Create below directory
 	// destNonEmptyCopyDirectory                                                -- Dir
 	// destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory              -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), t)
+	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	objs, err := os.ReadDir(destDir)
@@ -262,24 +262,24 @@ func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
 	// destNonEmptyCopyDirectory/emptyDirectoryCopyTest           - Dir
 	// destNonEmptyCopyDirectory/subDestCopyDirectory             - Dir
 	if len(objs) != NumberOfObjectsInNonEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destNonEmptyCopyDirectory/srcCopyDirectory  - Dir
 	if objs[0].Name() != EmptySrcDirectoryCopyTest || objs[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	// destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory  - Dir
 	if objs[1].Name() != SubDirInNonEmptyDestCopyDirectory || objs[1].IsDir() != true {
-		t.Errorf("Existing object affected.")
+		s.T().Errorf("Existing object affected.")
 		return
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, t)
+	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -289,20 +289,20 @@ func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
 
 // Output
 // destEmptyCopyDirectory/emptySrcDirectoryCopyTest
-func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
 	destDir := path.Join(testDir, DestEmptyCopyDirectory)
-	operations.CreateDirectoryWithNFiles(0, destDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, destDir, "", s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -314,18 +314,18 @@ func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
 	// destEmptyCopyDirectory
 	// destEmptyCopyDirectory/emptyDirectoryCopyTest
 	if len(obj) != NumberOfObjectsInEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destEmptyCopyDirectory/srcCopyDirectory  - Dir
 	if obj[0].Name() != EmptySrcDirectoryCopyTest || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, t)
+	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -333,24 +333,24 @@ func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
 
 // Output
 // destCopyDirectoryNotExist
-func TestCopyEmptyDirectoryInNonExistingDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonExistingDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// destCopyDirectoryNotExist             -- Dir
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	_, err := os.Stat(destDir)
 	if err == nil {
-		t.Errorf("destCopyDirectoryNotExist directory exist.")
+		s.T().Errorf("destCopyDirectoryNotExist directory exist.")
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
-	checkIfCopiedEmptyDirectoryHasNoData(destDir, t)
+	checkIfCopiedEmptyDirectoryHasNoData(destDir, s.T())
 }

--- a/tools/integration_tests/operations/copy_file_test.go
+++ b/tools/integration_tests/operations/copy_file_test.go
@@ -18,37 +18,36 @@ package operations_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestCopyFile(t *testing.T) {
+func (s *operationsTestSuite) TestCopyFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName+setup.GenerateRandomString(5))
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 	defer os.Remove(fileName)
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {
-		t.Errorf("Read: %v", err)
+		s.T().Errorf("Read: %v", err)
 	}
 
 	newFileName := fileName + "Copy"
 	if _, err := os.Stat(newFileName); err == nil {
-		t.Errorf("Copied file %s already present", newFileName)
+		s.T().Errorf("Copied file %s already present", newFileName)
 	}
 
 	err = operations.CopyFile(fileName, newFileName)
 	if err != nil {
-		t.Errorf("Error : %v", err)
+		s.T().Errorf("Error : %v", err)
 	}
 	defer os.Remove(newFileName)
 
 	// Check if the data in the copied file matches the original file,
 	// and the data in original file is unchanged.
-	setup.CompareFileContents(t, newFileName, string(content))
-	setup.CompareFileContents(t, fileName, string(content))
+	setup.CompareFileContents(s.T(), newFileName, string(content))
+	setup.CompareFileContents(s.T(), fileName, string(content))
 }

--- a/tools/integration_tests/operations/create_three_level_dir_test.go
+++ b/tools/integration_tests/operations/create_three_level_dir_test.go
@@ -22,13 +22,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestCreateThreeLevelDirectories(t *testing.T) {
+func (s *operationsTestSuite) TestCreateThreeLevelDirectories() {
 	// Directory structure
 	// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest                                                                       -- Dir
 	// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest                                       -- Dir
@@ -39,19 +38,19 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 
 	dirPath := path.Join(testDir, DirOneInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 
 	subDirPath := path.Join(dirPath, DirTwoInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(0, subDirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, subDirPath, "", s.T())
 
 	subDirPath2 := path.Join(subDirPath, DirThreeInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(1, subDirPath2, PrefixFileInDirThreeInCreateThreeLevelDirTest, t)
+	operations.CreateDirectoryWithNFiles(1, subDirPath2, PrefixFileInDirThreeInCreateThreeLevelDirTest, s.T())
 	filePath := path.Join(subDirPath2, FileInDirThreeInCreateThreeLevelDirTest)
 	err := operations.WriteFileInAppendMode(filePath, ContentInFileInDirThreeInCreateThreeLevelDirTest)
 	if err != nil {
-		t.Errorf("Write file error: %v", err)
+		s.T().Errorf("Write file error: %v", err)
 	}
 
 	// Recursively walk into directory and test.
@@ -75,12 +74,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dirPath == testDir {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInBucketDirectoryCreateTest {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest   -- Dir
 			if objs[0].Name() != DirOneInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 		}
 
@@ -88,12 +87,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirOneInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirOneInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirOneInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirOneInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest    -- Dir
 			if objs[0].Name() != DirTwoInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 			return nil
 		}
@@ -102,12 +101,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirTwoInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirTwoInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirTwoInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirTwoInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest/dirThreeInCreateThreeLevelDirTest    -- Dir
 			if objs[0].Name() != DirThreeInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 			return nil
 		}
@@ -116,23 +115,23 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirThreeInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirThreeInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirThreeInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirThreeInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest/dirThreeInCreateThreeLevelDirTest/fileInDirThreeInCreateThreeLevelDirTest     -- File
 			if objs[0].Name() != FileInDirThreeInCreateThreeLevelDirTest || objs[0].IsDir() != false {
-				t.Errorf("Incorrect object exist in the dirThreeInCreateThreeLevelDirTest directory.")
+				s.T().Errorf("Incorrect object exist in the dirThreeInCreateThreeLevelDirTest directory.")
 			}
 
 			// Check if the content of the file is correct.
 			filePath := path.Join(dirPath, objs[0].Name())
 			content, err := operations.ReadFile(filePath)
 			if err != nil {
-				t.Errorf("Error in reading file:%v", err)
+				s.T().Errorf("Error in reading file:%v", err)
 			}
 
 			if got, want := string(content), ContentInFileInDirThreeInCreateThreeLevelDirTest; got != want {
-				t.Errorf("File content %q not match %q", got, want)
+				s.T().Errorf("File content %q not match %q", got, want)
 			}
 
 			return nil
@@ -141,7 +140,7 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }

--- a/tools/integration_tests/operations/delete_dir_test.go
+++ b/tools/integration_tests/operations/delete_dir_test.go
@@ -18,101 +18,100 @@ package operations_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestDeleteEmptyExplicitDir(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteEmptyExplicitDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, EmptyExplicitDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {
-		t.Errorf("Error in deleting empty explicit directory.")
+		s.T().Errorf("Error in deleting empty explicit directory.")
 	}
 
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.Name() == EmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
-		t.Errorf("Directory is not deleted.")
+		s.T().Errorf("Directory is not deleted.")
 	}
 }
 
-func TestDeleteNonEmptyExplicitDir(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteNonEmptyExplicitDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, NonEmptyExplicitDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest, dirPath, PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest, dirPath, PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest, s.T())
 
 	subDirPath := path.Join(dirPath, NonEmptyExplicitSubDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest, subDirPath, PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest, subDirPath, PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest, s.T())
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {
-		t.Errorf("Error in deleting empty explicit directory.")
+		s.T().Errorf("Error in deleting empty explicit directory.")
 	}
 
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.Name() == NonEmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
-		t.Errorf("Directory is not deleted.")
+		s.T().Errorf("Directory is not deleted.")
 	}
 }
 
-func TestRmDirAlreadyDeletedExplicitDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirAlreadyDeletedExplicitDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "explicit_dir_double_delete")
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 	// Delete explicit directory first time.
 	err := os.Remove(dirPath)
 	if err != nil {
-		t.Fatalf("Error in deleting empty explicit directory: %v", err)
+		s.T().Fatalf("Error in deleting empty explicit directory: %v", err)
 	}
 
 	// Delete it again via RmDir, which must return os.ErrNotExist (ENOENT).
 	err = os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when deleting non-existent explicit directory, got nil")
+		s.T().Errorf("Expected ENOENT error when deleting non-existent explicit directory, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error when deleting non-existent explicit directory, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error when deleting non-existent explicit directory, got: %v", err)
 	}
 }
 
-func TestRmDirNonExistentDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirNonExistentDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "non_existent_dir_rmdir_enoent")
 
 	err := os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when calling RmDir on non-existent path, got nil")
+		s.T().Errorf("Expected ENOENT error when calling RmDir on non-existent path, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error when calling RmDir on non-existent path, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error when calling RmDir on non-existent path, got: %v", err)
 	}
 }
 
-func TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirName := "oob_deleted_explicit_dir"
 	dirPath := path.Join(testDir, dirName)
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 	if _, err := os.Stat(dirPath); err != nil {
-		t.Fatalf("Error statting explicit directory: %v", err)
+		s.T().Fatalf("Error statting explicit directory: %v", err)
 	}
 	client.DeleteDirOnGCS(ctx, storageClient, path.Join(DirForOperationTests, dirName))
 
 	err := os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when deleting out-of-band deleted explicit directory, got nil")
+		s.T().Errorf("Expected ENOENT error when deleting out-of-band deleted explicit directory, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error, got: %v", err)
 	}
 }

--- a/tools/integration_tests/operations/delete_file_test.go
+++ b/tools/integration_tests/operations/delete_file_test.go
@@ -52,28 +52,28 @@ func createFile(filePath string, t *testing.T) {
 }
 
 // Remove testBucket/A.txt
-func TestDeleteFileFromBucket(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteFileFromBucket() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	filePath := path.Join(testDir, FileNameInTestBucket)
 
-	createFile(filePath, t)
+	createFile(filePath, s.T())
 
-	checkIfFileDeletionSucceeded(filePath, t)
+	checkIfFileDeletionSucceeded(filePath, s.T())
 }
 
 // Remove testBucket/A/a.txt
-func TestDeleteFileFromBucketDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteFileFromBucketDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, DirNameInTestBucket)
 	err := os.Mkdir(dirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Error in creating directory: %v", err)
+		s.T().Errorf("Error in creating directory: %v", err)
 	}
 
 	filePath := path.Join(dirPath, FileNameInDirectoryTestBucket)
-	createFile(filePath, t)
+	createFile(filePath, s.T())
 
-	checkIfFileDeletionSucceeded(filePath, t)
+	checkIfFileDeletionSucceeded(filePath, s.T())
 }

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -58,58 +58,58 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	return nil
 }
 
-func TestFileAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestFileAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Logf("Verifying file attributes. Expecting: correct name, size = %d bytes, and mod time within window.", BytesWrittenInFile)
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		fileName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Logf("Verifying file attributes. Expecting: correct name, size = %d bytes, and mod time within window.", BytesWrittenInFile)
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		fileName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+		operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 		postCreateTime := time.Now().Add(+operations.TimeSlop)
 
 		// The file size in createTempFile() is BytesWrittenInFile bytes
 		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
-		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, t)
+		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, s.T())
 		return err == nil, err
 	})
 }
 
-func TestEmptyDirAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestEmptyDirAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Log("Verifying empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		dirName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Log("Verifying empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateDirectoryWithNFiles(0, dirName, "", t)
+		operations.CreateDirectoryWithNFiles(0, dirName, "", s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
 		return err == nil, err
 	})
 }
 
-func TestNonEmptyDirAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestNonEmptyDirAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Log("Verifying non-empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		dirName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Log("Verifying non-empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
+		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
 		return err == nil, err
 	})
 }

--- a/tools/integration_tests/operations/list_dir_test.go
+++ b/tools/integration_tests/operations/list_dir_test.go
@@ -66,11 +66,11 @@ func createDirectoryStructureForTest(t *testing.T) {
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptySubDirInDirectoryForListTest, subDirPath, "", t)
 }
 
-func TestListDirectoryRecursively(t *testing.T) {
+func (s *operationsTestSuite) TestListDirectoryRecursively() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	// Create directory structure for testing.
-	createDirectoryStructureForTest(t)
+	createDirectoryStructureForTest(s.T())
 
 	// Recursively walk into directory and test.
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {
@@ -93,12 +93,12 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if path == testDir {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInBucketDirectoryListTest {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest   -- Dir
 			if objs[0].Name() != DirectoryForListTest || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 		}
 
@@ -106,27 +106,27 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirectoryForListTest {
 			// numberOfObjects - 4
 			if len(objs) != NumberOfObjectsInDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the directoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the directoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/emptySubDirectoryForListTest   -- Dir
 			if objs[0].Name() != EmptySubDirInDirectoryForListTest || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/fileInDirectoryForListTest1     -- File
 			if objs[1].Name() != FileInDirectoryForListTest || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest   -- Dir
 			if objs[2].Name() != FirstSubDirectoryForListTest || objs[2].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest  -- Dir
 			if objs[3].Name() != SecondSubDirectoryForListTest || objs[3].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -136,12 +136,12 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == FirstSubDirectoryForListTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInFirstSubDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the firstSubDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the firstSubDirectoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest/fileInFirstSubDirectoryForListTest1     -- File
 			if objs[0].Name() != FileInFirstSubDirectoryForListTest || objs[0].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -151,17 +151,17 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == SecondSubDirectoryForListTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInSecondSubDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the secondSubDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the secondSubDirectoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest1    -- File
 			if objs[0].Name() != FirstFileInSecondSubDirectoryForListTest || objs[0].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest2   -- File
 			if objs[1].Name() != SecondFileInSecondSubDirectoryForListTest || objs[1].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -171,7 +171,7 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == EmptySubDirInDirectoryForListTest {
 			// numberOfObjects - 0
 			if len(objs) != NumberOfObjectsInEmptySubDirInDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the emptySubDirInDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the emptySubDirInDirectoryForListTest.")
 			}
 
 			return nil
@@ -180,22 +180,22 @@ func TestListDirectoryRecursively(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }
 
-func TestReadFileWorksAfterListDir(t *testing.T) {
+func (s *operationsTestSuite) TestReadFileWorksAfterListDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	obj1 := t.Name() + "-1"
+	obj1 := s.T().Name() + "-1"
 	var objSize int64 = 5
-	client.SetupFileInTestDirectory(ctx, storageClient, DirForOperationTests, obj1, objSize, t)
+	client.SetupFileInTestDirectory(ctx, storageClient, DirForOperationTests, obj1, objSize, s.T())
 
-	_ = operations.ReadDirectory(testDir, t)
+	_ = operations.ReadDirectory(testDir, s.T())
 	fh, err := os.OpenFile(path.Join(testDir, obj1), syscall.O_DIRECT, operations.FilePermission_0600)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	content, err := operations.ReadFileSequentially(fh, util.MiB)
 
-	require.NoError(t, err)
-	require.EqualValues(t, objSize, len(content))
+	require.NoError(s.T(), err)
+	require.EqualValues(s.T(), objSize, len(content))
 }

--- a/tools/integration_tests/operations/move_file_test.go
+++ b/tools/integration_tests/operations/move_file_test.go
@@ -70,58 +70,58 @@ func checkIfFileMoveOperationSucceeded(srcFilePath string, destDirPath string, t
 }
 
 // Move file from Test/move.txt to Test/a/move.txt
-func TestMoveFileWithinSameDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithinSameDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, t)
+	createSrcDirectoryAndFile(dirPath, filePath, s.T())
 
 	destDirPath := path.Join(dirPath, "a")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", destDirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, t)
+	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
 }
 
 // Move file from Test/move.txt to Test1/move.txt
-func TestMoveFileWithinDifferentDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithinDifferentDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, t)
+	createSrcDirectoryAndFile(dirPath, filePath, s.T())
 
 	destDirPath := path.Join(testDir, "Test2")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", destDirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, t)
+	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
 }
 
 // Rename file from Test/move1.txt to Test/move2.txt
-func TestMoveFileWithDestFileExist(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithDestFileExist() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Define source and destination file names.
 	srcFilePath := path.Join(testDir, "move1.txt")
 	destFilePath := path.Join(testDir, "move2.txt")
 	// Create the source and dest file with some content.
-	operations.CreateFileWithContent(srcFilePath, setup.FilePermission_0600, Content, t)
-	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, "Hello from dest file", t)
+	operations.CreateFileWithContent(srcFilePath, setup.FilePermission_0600, Content, s.T())
+	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, "Hello from dest file", s.T())
 
 	// Move the file.
 	err := operations.Move(srcFilePath, destFilePath)
 
-	assert.NoError(t, err, "error in file moving")
+	assert.NoError(s.T(), err, "error in file moving")
 	// Verify the file was renamed and content is preserved.
-	setup.CompareFileContents(t, destFilePath, Content)
+	setup.CompareFileContents(s.T(), destFilePath, Content)
 	// Verify the old file is removed.
 	_, err = os.Stat(srcFilePath)
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no such file or directory"))
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "no such file or directory"))
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -23,14 +23,42 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/dynamic_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type operationsTestSuite struct {
+	suite.Suite
+}
+
+func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
+	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
+		runSuiteFunc()
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
+	for _, flags := range flagsSet {
+		log.Printf("Running %s with flags: %s", t.Name(), flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+	}
+}
+
+func TestOperationsBase(t *testing.T) {
+	runOperationsSuite(t, func() {
+		suite.Run(t, new(operationsTestSuite))
+		suite.Run(t, &writeOperationsTest{isRapidWritesEnabled: false})
+	})
+}
 
 const DirForOperationTests = "dirForOperationsTest"
 const MoveFile = "move.txt"
@@ -89,8 +117,10 @@ const Content = "line 1\nline 2\n"
 const onlyDirMounted = "OnlyDirMountOperations"
 
 var (
-	storageClient *storage.Client
-	ctx           context.Context
+	storageClient    *storage.Client
+	ctx              context.Context
+	operationsConfig *test_suite.TestConfig
+	bucketType       string
 )
 
 func TestMain(m *testing.M) {
@@ -103,7 +133,8 @@ func TestMain(m *testing.M) {
 	}
 
 	ctx = context.Background()
-	bucketType := setup.TestEnvironment(ctx, &cfg.Operations[0])
+	operationsConfig = &cfg.Operations[0]
+	bucketType = setup.TestEnvironment(ctx, operationsConfig)
 
 	// 2. Create storage client before running tests.
 	var err error
@@ -115,41 +146,13 @@ func TestMain(m *testing.M) {
 	defer storageClient.Close()
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	if cfg.Operations[0].GKEMountedDirectory != "" && cfg.Operations[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.Operations[0].GKEMountedDirectory, m))
+	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(operationsConfig.GKEMountedDirectory, m))
 	}
 
 	// 4. Override GKE specific paths with GCSFuse paths if running in GCE environment.
-	setup.OverrideFilePathsInFlagSet(&cfg.Operations[0], setup.TestDir())
+	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
+	setup.SetUpTestDirForTestBucket(operationsConfig)
 
-	// Run tests for testBucket
-	// 5. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.Operations[0], bucketType, "")
-	setup.SetUpTestDirForTestBucket(&cfg.Operations[0])
-
-	if setup.TestOnTPCEndPoint() {
-		os.Exit(static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m))
-	}
-
-	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-
-	if successCode == 0 {
-		successCode = only_dir_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, onlyDirMounted, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-	}
-
-	if successCode == 0 {
-		successCode = dynamic_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-	}
-
-	if successCode == 0 {
-		// Test for admin permission on test bucket.
-		log.Printf("Running cred tests...")
-		successCode = creds_tests.RunTestsForDifferentAuthMethods(ctx, &cfg.Operations[0], storageClient, flags, "objectAdmin", m)
-	}
-
-	os.Exit(successCode)
+	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -56,12 +56,17 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
 				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
 				require.NoError(t, err, "Static mount failed")
+				defer func() {
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+				}()
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
+
+			if setup.TestOnTPCEndPoint() {
+				return
+			}
 
 			// 2. Only-dir mounting
 			t.Run("OnlyDir", func(t *testing.T) {
@@ -72,6 +77,8 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 						log.Printf("Error deleting object on GCS: %v", err)
 					}
 					setup.SetOnlyDirMounted("")
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
 				}()
 
 				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
@@ -79,9 +86,6 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				require.NoError(t, err, "Only dir mount failed")
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
 
 			// 3. Persistent mounting
@@ -89,11 +93,12 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
 				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
 				require.NoError(t, err, "Persistent mount failed")
+				defer func() {
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+				}()
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
 
 			// 4. Dynamic mounting
@@ -104,18 +109,19 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
 				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
 				require.NoError(t, err, "Dynamic mount failed")
+				defer func() {
+					setup.SetMntDir(rootMntDir)
+					operationsConfig.GCSFuseMountedDirectory = rootMntDir
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+					setup.SetDynamicBucketMounted("")
+				}()
 
 				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
 				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
 				setup.SetMntDir(mntDirOfTestBucket)
 
 				runSuiteFunc()
-
-				setup.SetMntDir(rootMntDir)
-				operationsConfig.GCSFuseMountedDirectory = rootMntDir
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
-				setup.SetDynamicBucketMounted("")
 			})
 
 			// 5. Creds tests (runs for different auth methods)
@@ -226,11 +232,6 @@ func TestMain(m *testing.M) {
 	// 4. Override GKE specific paths with GCSFuse paths if running in GCE environment.
 	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
 	setup.SetUpTestDirForTestBucket(operationsConfig)
-
-	if setup.TestOnTPCEndPoint() {
-		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "TestOperationsBase")
-		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
-	}
 
 	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -225,5 +225,10 @@ func TestMain(m *testing.M) {
 	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
 	setup.SetUpTestDirForTestBucket(operationsConfig)
 
+	if setup.TestOnTPCEndPoint() {
+		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "")
+		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
+	}
+
 	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -53,15 +51,7 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
 			// 1. Static mounting
 			t.Run("Static", func(t *testing.T) {
-				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
-				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Static mount failed")
-				defer func() {
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				runSuiteFunc()
+				static_mounting.RunSuiteForStaticMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			if setup.TestOnTPCEndPoint() {
@@ -70,58 +60,17 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 			// 2. Only-dir mounting
 			t.Run("OnlyDir", func(t *testing.T) {
-				setup.SetOnlyDirMounted(onlyDirMounted)
-				client.SetupTestDirectory(ctx, storageClient, onlyDirMounted)
-				defer func() {
-					if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, onlyDirMounted); err != nil {
-						log.Printf("Error deleting object on GCS: %v", err)
-					}
-					setup.SetOnlyDirMounted("")
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
-				err := only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Only dir mount failed")
-
-				runSuiteFunc()
+				only_dir_mounting.RunSuiteForOnlyDirMounting(ctx, storageClient, operationsConfig, flags, onlyDirMounted, t, runSuiteFunc)
 			})
 
 			// 3. Persistent mounting
 			t.Run("Persistent", func(t *testing.T) {
-				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Persistent mount failed")
-				defer func() {
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				runSuiteFunc()
+				persistent_mounting.RunSuiteForPersistentMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			// 4. Dynamic mounting
 			t.Run("Dynamic", func(t *testing.T) {
-				rootMntDir := operationsConfig.GCSFuseMountedDirectory
-				setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
-
-				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
-				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
-				require.NoError(t, err, "Dynamic mount failed")
-				defer func() {
-					setup.SetMntDir(rootMntDir)
-					operationsConfig.GCSFuseMountedDirectory = rootMntDir
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-					setup.SetDynamicBucketMounted("")
-				}()
-
-				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
-				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-				setup.SetMntDir(mntDirOfTestBucket)
-
-				runSuiteFunc()
+				dynamic_mounting.RunSuiteForDynamicMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			// 5. Creds tests (runs for different auth methods)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -41,11 +41,13 @@ type operationsTestSuite struct {
 }
 
 func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
 		runSuiteFunc()
 		return
 	}
 
+	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
 	for _, flags := range flagsSet {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -47,60 +48,79 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
 	for _, flags := range flagsSet {
-		// 1. Static mounting
-		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
-		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Static mount failed")
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			// 1. Static mounting
+			t.Run("Static", func(t *testing.T) {
+				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
+				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Static mount failed")
 
-		runSuiteFunc()
+				runSuiteFunc()
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		// 2. Only-dir mounting
-		setup.SetOnlyDirMounted(onlyDirMounted)
-		log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
-		err = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Only dir mount failed")
+			// 2. Only-dir mounting
+			t.Run("OnlyDir", func(t *testing.T) {
+				setup.SetOnlyDirMounted(onlyDirMounted)
+				client.SetupTestDirectory(ctx, storageClient, onlyDirMounted)
+				defer func() {
+					if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, onlyDirMounted); err != nil {
+						log.Printf("Error deleting object on GCS: %v", err)
+					}
+					setup.SetOnlyDirMounted("")
+				}()
 
-		runSuiteFunc()
+				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+				err := only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Only dir mount failed")
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
-		setup.SetOnlyDirMounted("")
+				runSuiteFunc()
 
-		// 3. Persistent mounting
-		log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-		err = persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Persistent mount failed")
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		runSuiteFunc()
+			// 3. Persistent mounting
+			t.Run("Persistent", func(t *testing.T) {
+				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Persistent mount failed")
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
+				runSuiteFunc()
 
-		// 4. Dynamic mounting
-		rootMntDir := operationsConfig.GCSFuseMountedDirectory
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
-		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
-		require.NoError(t, err, "Dynamic mount failed")
+			// 4. Dynamic mounting
+			t.Run("Dynamic", func(t *testing.T) {
+				rootMntDir := operationsConfig.GCSFuseMountedDirectory
+				setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
-		mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
-		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-		setup.SetMntDir(mntDirOfTestBucket)
-		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
+				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
+				require.NoError(t, err, "Dynamic mount failed")
 
-		runSuiteFunc()
+				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
+				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+				setup.SetMntDir(mntDirOfTestBucket)
 
-		setup.SetMntDir(rootMntDir)
-		operationsConfig.GCSFuseMountedDirectory = rootMntDir
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
-		setup.SetDynamicBucketMounted("")
+				runSuiteFunc()
 
-		// 5. Creds tests (runs for different auth methods)
-		creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
+				setup.SetMntDir(rootMntDir)
+				operationsConfig.GCSFuseMountedDirectory = rootMntDir
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+				setup.SetDynamicBucketMounted("")
+			})
+
+			// 5. Creds tests (runs for different auth methods)
+			t.Run("Creds", func(t *testing.T) {
+				creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
+			})
+		})
 	}
 }
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -228,7 +228,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(operationsConfig)
 
 	if setup.TestOnTPCEndPoint() {
-		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "")
+		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "TestOperationsBase")
 		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
 	}
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -81,14 +81,15 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 		// 4. Dynamic mounting
 		rootMntDir := operationsConfig.GCSFuseMountedDirectory
-		mntDirOfTestBucket := path.Join(operationsConfig.GCSFuseMountedDirectory, operationsConfig.TestBucket)
-		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-		setup.SetMntDir(mntDirOfTestBucket)
-		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
 		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
 		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
 		require.NoError(t, err, "Dynamic mount failed")
+
+		mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
+		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+		setup.SetMntDir(mntDirOfTestBucket)
+		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
 		runSuiteFunc()
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -19,10 +19,15 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
@@ -42,14 +47,59 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
 	for _, flags := range flagsSet {
-		log.Printf("Running %s with flags: %s", t.Name(), flags)
+		// 1. Static mounting
+		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
 		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Mount failed")
+		require.NoError(t, err, "Static mount failed")
 
 		runSuiteFunc()
 
 		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
 		setup.UnmountGCSFuseWithConfig(operationsConfig)
+
+		// 2. Only-dir mounting
+		setup.SetOnlyDirMounted(onlyDirMounted)
+		log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+		err = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Only dir mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+		setup.SetOnlyDirMounted("")
+
+		// 3. Persistent mounting
+		log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+		err = persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Persistent mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+
+		// 4. Dynamic mounting
+		rootMntDir := operationsConfig.GCSFuseMountedDirectory
+		mntDirOfTestBucket := path.Join(operationsConfig.GCSFuseMountedDirectory, operationsConfig.TestBucket)
+		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+		setup.SetMntDir(mntDirOfTestBucket)
+		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
+
+		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
+		require.NoError(t, err, "Dynamic mount failed")
+
+		runSuiteFunc()
+
+		setup.SetMntDir(rootMntDir)
+		operationsConfig.GCSFuseMountedDirectory = rootMntDir
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+		setup.SetDynamicBucketMounted("")
+
+		// 5. Creds tests (runs for different auth methods)
+		creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
 	}
 }
 

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -51,7 +51,7 @@ type testDirStrucure struct {
 //	explicitDir2Name/file1InExplicitDir2Name
 //
 // Also returns the path to test directory.
-func createDirStructure(s *operationsTestSuite) testDirStrucure {
+func (s *operationsTestSuite) createDirStructure() testDirStrucure {
 	var tds testDirStrucure
 	tds.testDir = setup.SetupTestDirectory(DirForOperationTests + "-" + setup.GenerateRandomString(5))
 
@@ -109,7 +109,7 @@ func lookUpFileStat(wg *sync.WaitGroup, filePath string, result *os.FileInfo, er
 
 func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -148,7 +148,7 @@ func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 
 func (s *operationsTestSuite) TestParallelReadDirs() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -200,7 +200,7 @@ func (s *operationsTestSuite) TestParallelReadDirs() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	deleteFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -232,7 +232,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 
 func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -275,7 +275,7 @@ func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 
 func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -315,7 +315,7 @@ func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	deleteFileFunc := func(wg *sync.WaitGroup, filePath string, err *error) {
 		defer wg.Done()
@@ -350,7 +350,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	renameFunc := func(wg *sync.WaitGroup, oldFilePath string, newFilePath string, err *error) {
 		defer wg.Done()
@@ -388,7 +388,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndMkdirSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	mkdirFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -52,35 +51,35 @@ type testDirStrucure struct {
 //	explicitDir2Name/file1InExplicitDir2Name
 //
 // Also returns the path to test directory.
-func createDirStructure(t *testing.T) testDirStrucure {
+func createDirStructure(s *operationsTestSuite) testDirStrucure {
 	var tds testDirStrucure
 	tds.testDir = setup.SetupTestDirectory(DirForOperationTests + "-" + setup.GenerateRandomString(5))
 
 	// Create explicitDir1 structure
 	tds.explicitDir1Name = "explicitDir1-" + setup.GenerateRandomString(5)
 	explicitDir1 := path.Join(tds.testDir, tds.explicitDir1Name)
-	operations.CreateDirectory(explicitDir1, t)
+	operations.CreateDirectory(explicitDir1, s.T())
 	tds.file1InExplicitDir1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 := path.Join(explicitDir1, tds.file1InExplicitDir1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(5, filePath1, s.T())
 	tds.file2InExplicitDir1Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 := path.Join(explicitDir1, tds.file2InExplicitDir1Name)
-	operations.CreateFileOfSize(10, filePath2, t)
+	operations.CreateFileOfSize(10, filePath2, s.T())
 
 	// Create explicitDir2 structure
 	tds.explicitDir2Name = "explicitDir2-" + setup.GenerateRandomString(5)
 	explicitDir2 := path.Join(tds.testDir, tds.explicitDir2Name)
-	operations.CreateDirectory(explicitDir2, t)
+	operations.CreateDirectory(explicitDir2, s.T())
 	tds.file1InExplicitDir2Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(explicitDir2, tds.file1InExplicitDir2Name)
-	operations.CreateFileOfSize(11, filePath1, t)
+	operations.CreateFileOfSize(11, filePath1, s.T())
 
 	tds.file1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(tds.testDir, tds.file1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(5, filePath1, s.T())
 	tds.file2Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 = path.Join(tds.testDir, tds.file2Name)
-	operations.CreateFileOfSize(3, filePath2, t)
+	operations.CreateFileOfSize(3, filePath2, s.T())
 
 	return tds
 }
@@ -108,9 +107,9 @@ func lookUpFileStat(wg *sync.WaitGroup, filePath string, result *os.FileInfo, er
 	*err = lookupErr
 }
 
-func TestParallelLookUpsForSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -124,12 +123,12 @@ func TestParallelLookUpsForSameFile(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(5), stat2.Size())
-	assert.Contains(t, filePath, stat1.Name())
-	assert.Contains(t, filePath, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(5), stat2.Size())
+	assert.Contains(s.T(), filePath, stat1.Name())
+	assert.Contains(s.T(), filePath, stat2.Name())
 
 	// Parallel lookups of file under a directory in mount.
 	filePath = path.Join(tds.testDir, tds.explicitDir1Name, tds.file2InExplicitDir1Name)
@@ -139,17 +138,17 @@ func TestParallelLookUpsForSameFile(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(10), stat1.Size())
-	assert.Equal(t, int64(10), stat2.Size())
-	assert.Contains(t, filePath, stat1.Name())
-	assert.Contains(t, filePath, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(10), stat1.Size())
+	assert.Equal(s.T(), int64(10), stat2.Size())
+	assert.Contains(s.T(), filePath, stat1.Name())
+	assert.Contains(s.T(), filePath, stat2.Name())
 }
 
-func TestParallelReadDirs(t *testing.T) {
+func (s *operationsTestSuite) TestParallelReadDirs() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -168,14 +167,14 @@ func TestParallelReadDirs(t *testing.T) {
 	wg.Wait()
 
 	// Assert both readDirs passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, 2, len(dirEntries1))
-	assert.Equal(t, 2, len(dirEntries2))
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries1[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries1[1].Name())
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries2[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries2[1].Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), 2, len(dirEntries1))
+	assert.Equal(s.T(), 2, len(dirEntries2))
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries1[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries1[1].Name())
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries2[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries2[1].Name())
 
 	// Parallel readDirs of a directory and its parent directory.
 	dirPath = path.Join(tds.testDir, tds.explicitDir1Name)
@@ -187,21 +186,21 @@ func TestParallelReadDirs(t *testing.T) {
 	wg.Wait()
 
 	// Assert both readDirs passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, 2, len(dirEntries1))
-	assert.Equal(t, 4, len(dirEntries2))
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries1[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries1[1].Name())
-	assert.Contains(t, tds.explicitDir1Name, dirEntries2[0].Name())
-	assert.Contains(t, tds.explicitDir2Name, dirEntries2[1].Name())
-	assert.Contains(t, tds.file1Name, dirEntries2[2].Name())
-	assert.Contains(t, tds.file2Name, dirEntries2[3].Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), 2, len(dirEntries1))
+	assert.Equal(s.T(), 4, len(dirEntries2))
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries1[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries1[1].Name())
+	assert.Contains(s.T(), tds.explicitDir1Name, dirEntries2[0].Name())
+	assert.Contains(s.T(), tds.explicitDir2Name, dirEntries2[1].Name())
+	assert.Contains(s.T(), tds.file1Name, dirEntries2[2].Name())
+	assert.Contains(s.T(), tds.file2Name, dirEntries2[3].Name())
 }
 
-func TestParallelLookUpAndDeleteSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	deleteFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -218,22 +217,22 @@ func TestParallelLookUpAndDeleteSameDir(t *testing.T) {
 	go deleteFunc(&wg, dirPath, &deleteErr)
 	wg.Wait()
 
-	assert.NoError(t, deleteErr)
+	assert.NoError(s.T(), deleteErr)
 	_, err := os.Stat(dirPath)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(s.T(), os.IsNotExist(err))
 	// Assert either dir is looked up first or deleted first
 	if lookUpErr == nil {
-		assert.NotNil(t, statInfo, "statInfo should not be nil when lookUpErr is nil")
-		assert.Contains(t, statInfo.Name(), tds.explicitDir1Name)
-		assert.True(t, statInfo.IsDir(), "The created path should be a directory")
+		assert.NotNil(s.T(), statInfo, "statInfo should not be nil when lookUpErr is nil")
+		assert.Contains(s.T(), statInfo.Name(), tds.explicitDir1Name)
+		assert.True(s.T(), statInfo.IsDir(), "The created path should be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpsForDifferentFiles(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -249,12 +248,12 @@ func TestParallelLookUpsForDifferentFiles(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(3), stat2.Size())
-	assert.Contains(t, filePath1, stat1.Name())
-	assert.Contains(t, filePath2, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(3), stat2.Size())
+	assert.Contains(s.T(), filePath1, stat1.Name())
+	assert.Contains(s.T(), filePath2, stat2.Name())
 
 	// Parallel lookups of two files under a directory in mount.
 	filePath1 = path.Join(tds.testDir, tds.explicitDir1Name, tds.file1InExplicitDir1Name)
@@ -266,17 +265,17 @@ func TestParallelLookUpsForDifferentFiles(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(10), stat2.Size())
-	assert.Contains(t, filePath1, stat1.Name())
-	assert.Contains(t, filePath2, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(10), stat2.Size())
+	assert.Contains(s.T(), filePath1, stat1.Name())
+	assert.Contains(s.T(), filePath2, stat2.Name())
 }
 
-func TestParallelReadDirAndMkdirInsideSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -301,22 +300,22 @@ func TestParallelReadDirAndMkdirInsideSameDir(t *testing.T) {
 	wg.Wait()
 
 	// Assert both listing and mkdir succeeded
-	assert.NoError(t, readDirErr)
-	assert.NoError(t, mkdirErr)
+	assert.NoError(s.T(), readDirErr)
+	assert.NoError(s.T(), mkdirErr)
 	dirStatInfo, err := os.Stat(newDirPath)
-	assert.NoError(t, err)
-	assert.True(t, dirStatInfo.IsDir(), "The created path should be a directory")
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), dirStatInfo.IsDir(), "The created path should be a directory")
 	// List should happen either before or after creation of newDir.
-	assert.GreaterOrEqual(t, len(dirEntries), 8)
-	assert.LessOrEqual(t, len(dirEntries), 9)
+	assert.GreaterOrEqual(s.T(), len(dirEntries), 8)
+	assert.LessOrEqual(s.T(), len(dirEntries), 9)
 	if len(dirEntries) == 9 {
-		assert.Contains(t, dirEntries[8].Name(), "newDir")
+		assert.Contains(s.T(), dirEntries[8].Name(), "newDir")
 	}
 }
 
-func TestParallelLookUpAndDeleteSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	deleteFileFunc := func(wg *sync.WaitGroup, filePath string, err *error) {
 		defer wg.Done()
@@ -335,23 +334,23 @@ func TestParallelLookUpAndDeleteSameFile(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, deleteErr)
+	assert.NoError(s.T(), deleteErr)
 	_, err := os.Stat(filePath)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(s.T(), os.IsNotExist(err))
 	// Assert either file is looked up first or deleted first
 	if lookUpErr == nil {
-		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
-		assert.Equal(t, int64(5), fileInfo.Size())
-		assert.Contains(t, fileInfo.Name(), tds.file1InExplicitDir1Name)
-		assert.False(t, fileInfo.IsDir(), "The created path should not be a directory")
+		assert.NotNil(s.T(), fileInfo, "fileInfo should not be nil when lookUpErr is nil")
+		assert.Equal(s.T(), int64(5), fileInfo.Size())
+		assert.Contains(s.T(), fileInfo.Name(), tds.file1InExplicitDir1Name)
+		assert.False(s.T(), fileInfo.IsDir(), "The created path should not be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpAndRenameSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	renameFunc := func(wg *sync.WaitGroup, oldFilePath string, newFilePath string, err *error) {
 		defer wg.Done()
@@ -370,26 +369,26 @@ func TestParallelLookUpAndRenameSameFile(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, renameErr)
+	assert.NoError(s.T(), renameErr)
 	newFileInfo, err := os.Stat(newFilePath)
-	assert.NoError(t, err)
-	assert.Contains(t, newFileInfo.Name(), "newFile.txt")
-	assert.False(t, newFileInfo.IsDir())
-	assert.Equal(t, int64(5), newFileInfo.Size())
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), newFileInfo.Name(), "newFile.txt")
+	assert.False(s.T(), newFileInfo.IsDir())
+	assert.Equal(s.T(), int64(5), newFileInfo.Size())
 	// Assert either file is renamed first or looked up first
 	if lookUpErr == nil {
-		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
-		assert.Equal(t, int64(5), fileInfo.Size())
-		assert.Contains(t, fileInfo.Name(), tds.file1InExplicitDir1Name)
-		assert.False(t, fileInfo.IsDir(), "The created path should not be a directory")
+		assert.NotNil(s.T(), fileInfo, "fileInfo should not be nil when lookUpErr is nil")
+		assert.Equal(s.T(), int64(5), fileInfo.Size())
+		assert.Contains(s.T(), fileInfo.Name(), tds.file1InExplicitDir1Name)
+		assert.False(s.T(), fileInfo.IsDir(), "The created path should be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpAndMkdirSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndMkdirSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	mkdirFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -408,16 +407,16 @@ func TestParallelLookUpAndMkdirSameDir(t *testing.T) {
 	wg.Wait()
 
 	// Assert either directory is created first or looked up first
-	assert.NoError(t, mkdirErr, "mkdirFunc should not fail")
+	assert.NoError(s.T(), mkdirErr, "mkdirFunc should not fail")
 
 	if lookUpErr == nil {
-		assert.NotNil(t, statInfo, "statInfo should not be nil when lookUpErr is nil")
-		assert.Contains(t, statInfo.Name(), "newDir")
-		assert.True(t, statInfo.IsDir())
+		assert.NotNil(s.T(), statInfo, "statInfo should not be nil when lookUpErr is nil")
+		assert.Contains(s.T(), statInfo.Name(), "newDir")
+		assert.True(s.T(), statInfo.IsDir())
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr), "lookUpErr should indicate directory does not exist")
+		assert.True(s.T(), os.IsNotExist(lookUpErr), "lookUpErr should indicate directory does not exist")
 		dirStatInfo, err := os.Stat(dirPath)
-		assert.NoError(t, err, "os.Stat should succeed after directory creation")
-		assert.True(t, dirStatInfo.IsDir(), "The created path should be a directory")
+		assert.NoError(s.T(), err, "os.Stat should succeed after directory creation")
+		assert.True(s.T(), dirStatInfo.IsDir(), "The created path should be a directory")
 	}
 }

--- a/tools/integration_tests/operations/read_test.go
+++ b/tools/integration_tests/operations/read_test.go
@@ -17,43 +17,42 @@ package operations_test
 
 import (
 	"os"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestReadAfterWrite(t *testing.T) {
+func (s *operationsTestSuite) TestReadAfterWrite() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	tmpDir, err := os.MkdirTemp(testDir, "tmpDir")
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", testDir, err)
+		s.T().Errorf("Mkdir at %q: %v", testDir, err)
 		return
 	}
 	for range 10 {
 		tmpFile, err := os.CreateTemp(tmpDir, tempFileName)
 		if err != nil {
-			t.Errorf("Create file at %q: %v", tmpDir, err)
+			s.T().Errorf("Create file at %q: %v", tmpDir, err)
 			return
 		}
 
 		// Closing file at the end
-		operations.CloseFileShouldNotThrowError(t, tmpFile)
+		operations.CloseFileShouldNotThrowError(s.T(), tmpFile)
 
 		fileName := tmpFile.Name()
 
 		err = operations.WriteFileInAppendMode(fileName, "line 1\n")
 		if err != nil {
-			t.Errorf("AppendString: %v", err)
+			s.T().Errorf("AppendString: %v", err)
 		}
 
 		content, err := operations.ReadFile(fileName)
 		if err != nil {
-			t.Errorf("ReadAll: %v", err)
+			s.T().Errorf("ReadAll: %v", err)
 		}
 		if got, want := string(content), "line 1\n"; got != want {
-			t.Errorf("File content %q not match %q", got, want)
+			s.T().Errorf("File content %q not match %q", got, want)
 		}
 	}
 }

--- a/tools/integration_tests/operations/rename_dir_test.go
+++ b/tools/integration_tests/operations/rename_dir_test.go
@@ -19,44 +19,43 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRenameDirToNonEmptyDestDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestRenameDirToNonEmptyDestDirectory() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create source directory.
 	srcDirPath := path.Join(testDir, "srcDir")
 	err := os.Mkdir(srcDirPath, 0700)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	// Create destination directory and put a file in it.
 	destDirPath := path.Join(testDir, "destDir")
 	err = os.Mkdir(destDirPath, 0700)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	destFilePath := path.Join(destDirPath, "file.txt")
-	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, Content, s.T())
 	// Attempt to rename the source directory to the destination directory.
 	err = os.Rename(srcDirPath, destDirPath)
 	// Assert that an error occurred (because destination is not empty).
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "file exists") || strings.Contains(err.Error(), "directory not empty") || strings.Contains(err.Error(), "not empty"), "Error message should mention file exists or not empty, but got: %v", err)
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "file exists") || strings.Contains(err.Error(), "directory not empty") || strings.Contains(err.Error(), "not empty"), "Error message should mention file exists or not empty, but got: %v", err)
 
 	// Perform operations on source and destination to ensure they are healthy.
 	// Context: https://b.corp.google.com/issues/504921217
 	_, err = os.Stat(srcDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	_, err = os.Stat(destDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
 	// Delete both directories successfully
 	err = os.Remove(destFilePath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	err = os.Remove(destDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	err = os.Remove(srcDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 }

--- a/tools/integration_tests/operations/rename_file_test.go
+++ b/tools/integration_tests/operations/rename_file_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -27,28 +26,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenameFile(t *testing.T) {
+func (s *operationsTestSuite) TestRenameFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {
-		t.Errorf("Read: %v", err)
+		s.T().Errorf("Read: %v", err)
 	}
 
 	newFileName := fileName + "Rename"
 
 	err = operations.RenameFile(fileName, newFileName)
 	if err != nil {
-		t.Errorf("Error in file renaming: %v", err)
+		s.T().Errorf("Error in file renaming: %v", err)
 	}
 	// Check if the data in the file is the same after renaming.
-	setup.CompareFileContents(t, newFileName, string(content))
+	setup.CompareFileContents(s.T(), newFileName, string(content))
 }
 
-func TestRenameFileWithSrcFileDoesNoExist(t *testing.T) {
+func (s *operationsTestSuite) TestRenameFileWithSrcFileDoesNoExist() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Define source and destination file names.
@@ -59,34 +58,34 @@ func TestRenameFileWithSrcFileDoesNoExist(t *testing.T) {
 	err := operations.RenameFile(srcFilePath, destFilePath)
 
 	// Assert that an error occurred.
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no such file or directory"))
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "no such file or directory"))
 }
 
-func TestRenameSymlinkToFile(t *testing.T) {
+func (s *operationsTestSuite) TestRenameSymlinkToFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	targetName := "target.txt"
 	targetPath := path.Join(testDir, targetName)
 	err := os.WriteFile(targetPath, []byte("taco"), setup.FilePermission_0600)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	oldSymlinkPath := path.Join(testDir, "symlink_old")
 	err = os.Symlink(targetPath, oldSymlinkPath)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	newSymlinkPath := path.Join(testDir, "symlink_new")
 
 	err = os.Rename(oldSymlinkPath, newSymlinkPath)
 
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	_, err = os.Lstat(oldSymlinkPath)
-	require.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.Error(s.T(), err)
+	assert.True(s.T(), os.IsNotExist(err))
 	fi, err := os.Lstat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.ModeSymlink, fi.Mode()&os.ModeType)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), os.ModeSymlink, fi.Mode()&os.ModeType)
 	targetRead, err := os.Readlink(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, targetPath, targetRead)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), targetPath, targetRead)
 	content, err := operations.ReadFile(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, "taco", string(content))
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "taco", string(content))
 }

--- a/tools/integration_tests/operations/stat_file_test.go
+++ b/tools/integration_tests/operations/stat_file_test.go
@@ -17,18 +17,17 @@ package operations_test
 import (
 	"os"
 	"syscall"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatWithTrailingNewline(t *testing.T) {
+func (s *operationsTestSuite) TestStatWithTrailingNewline() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	_, err := os.Stat(testDir + "/\n")
 
-	require.Error(t, err)
-	assert.Equal(t, err.(*os.PathError).Err, syscall.ENOENT)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), err.(*os.PathError).Err, syscall.ENOENT)
 }

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -30,7 +30,24 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type writeOperationsTest struct {
+	isRapidWritesEnabled bool
+	suite.Suite
+}
+
+func TestWriteOperationsRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	runOperationsSuite(t, func() {
+		suite.Run(t, &writeOperationsTest{isRapidWritesEnabled: true})
+	})
+}
 
 const tempFileName = "tmpFile"
 const appendContent = "Content"
@@ -45,191 +62,173 @@ func validateExtendedObjectAttributesNonEmpty(objectName string, t *testing.T) *
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
-		if err != nil {
-			t.Errorf("closeStorageClient failed: %v", err)
-		}
+		assert.NoError(t, err, "closeStorageClient failed")
 	}()
 
 	attrs, err := client.StatObject(ctx, storageClient, objectName)
-	if err != nil {
-		t.Errorf("Could not fetch object attributes: %v", err)
-	}
+	require.NoError(t, err, "Could not fetch object attributes")
 	o := storageutil.ObjectAttrsToBucketObject(attrs)
 	e := storageutil.ConvertObjToExtendedObjectAttributes(o)
 
-	if e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}) {
-		t.Errorf("Received nil/empty extended object attributes.")
-	}
+	require.False(t, e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}), "Received nil/empty extended object attributes.")
 	return attrs
 }
 
-func validateObjectAttributes(attr1, attr2 *storage.ObjectAttrs, t *testing.T) {
+func (w *writeOperationsTest) validateObjectAttributes(attr1, attr2 *storage.ObjectAttrs) {
 	const contentType = "text/plain; charset=utf-8"
 	const componentCount = 0
 	const sizeBeforeOperation = int64(len(tempFileContent))
 	const sizeAfterOperation = sizeBeforeOperation + int64(len(appendContent))
 	storageClass := "STANDARD"
 	if attr1 == nil || attr2 == nil {
-		t.Fatalf("attr1 or attr2 is nil. attr1: %v, attr2: %v", attr1, attr2)
+		w.T().Fatalf("attr1 or attr2 is nil. attr1: %v, attr2: %v", attr1, attr2)
 	}
 
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && w.isRapidWritesEnabled) {
 		storageClass = "RAPID"
 	}
 
 	if attr1.ContentType != contentType || attr2.ContentType != contentType {
-		t.Errorf("Expected content type: %s, Got: %s, %s", contentType, attr1.ContentType, attr2.ContentType)
+		w.T().Errorf("Expected content type: %s, Got: %s, %s", contentType, attr1.ContentType, attr2.ContentType)
 	}
 	if attr1.ComponentCount != componentCount || attr2.ComponentCount != componentCount {
-		t.Errorf("Expected component count: %d, Got: %d, %d", componentCount, attr1.ComponentCount, attr2.ComponentCount)
+		w.T().Errorf("Expected component count: %d, Got: %d, %d", componentCount, attr1.ComponentCount, attr2.ComponentCount)
 	}
 	if attr1.Name != attr2.Name {
-		t.Errorf("Object name mismatch: %s, %s", attr1.Name, attr2.Name)
+		w.T().Errorf("Object name mismatch: %s, %s", attr1.Name, attr2.Name)
 	}
 	if attr1.Bucket != attr2.Bucket {
-		t.Errorf("Bucket name mismatch: %s, %s", attr1.Bucket, attr2.Bucket)
+		w.T().Errorf("Bucket name mismatch: %s, %s", attr1.Bucket, attr2.Bucket)
 	}
 	if attr1.EventBasedHold != false || attr2.EventBasedHold != false {
-		t.Errorf("Expected EventBasedHold: false, Got: %v %v", attr1.EventBasedHold, attr2.EventBasedHold)
+		w.T().Errorf("Expected EventBasedHold: false, Got: %v %v", attr1.EventBasedHold, attr2.EventBasedHold)
 	}
 	if attr1.Size != sizeBeforeOperation {
-		t.Errorf("Expected size before file operation: %d, Got: %d", sizeBeforeOperation, attr1.Size)
+		w.T().Errorf("Expected size before file operation: %d, Got: %d", sizeBeforeOperation, attr1.Size)
 	}
 	if attr2.Size != sizeAfterOperation {
-		t.Errorf("Expected size after file operation: %d, Got: %d", sizeAfterOperation, attr2.Size)
+		w.T().Errorf("Expected size after file operation: %d, Got: %d", sizeAfterOperation, attr2.Size)
 	}
 	if reflect.DeepEqual(attr1.MD5, []byte{}) || reflect.DeepEqual(attr2.MD5, []byte{}) {
-		t.Error("Expected MD5 attributes to be non empty")
+		w.T().Error("Expected MD5 attributes to be non empty")
 	}
 	if attr1.CRC32C == 0 || attr2.CRC32C == 0 {
-		t.Error("Expected CRC32 attributes to be non 0")
+		w.T().Error("Expected CRC32 attributes to be non 0")
 	}
 	if attr1.MediaLink == "" || attr2.MediaLink == "" {
-		if setup.IsZonalBucketRun() {
-			t.Logf("media link is empty, but it is a known limitation in RAPID/zonal buckets.")
+		if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && w.isRapidWritesEnabled) {
+			w.T().Logf("media link is empty, but it is a known limitation in RAPID/zonal buckets.")
 		} else {
-			t.Errorf("Expected media link to be non empty")
+			w.T().Errorf("Expected media link to be non empty")
 		}
 	}
 	if attr1.StorageClass != storageClass || attr2.StorageClass != storageClass {
-		t.Errorf("Expected storage class to be %q, but found attr1.StorageClass = %q (bucketName = %q), attr2.StorageClass = %q (bucketName = %q)", storageClass, attr1.StorageClass, attr1.Bucket, attr2.StorageClass, attr2.Bucket)
+		w.T().Errorf("Expected storage class to be %q, but found attr1.StorageClass = %q (bucketName = %q), attr2.StorageClass = %q (bucketName = %q)", storageClass, attr1.StorageClass, attr1.Bucket, attr2.StorageClass, attr2.Bucket)
 	}
 	attr1MTime, _ := time.Parse(time.RFC3339Nano, attr1.Metadata[gcs.MtimeMetadataKey])
 	attr2MTime, _ := time.Parse(time.RFC3339Nano, attr2.Metadata[gcs.MtimeMetadataKey])
 	if attr2MTime.Before(attr1MTime) {
-		t.Errorf("Unexpected MTime received. After operation1: %v, After operation2: %v", attr1MTime, attr2MTime)
+		w.T().Errorf("Unexpected MTime received. After operation1: %v, After operation2: %v", attr1MTime, attr2MTime)
 	}
 }
 
 // //////////////////////////////////////////////////////////////////////
 // Tests
 // //////////////////////////////////////////////////////////////////////
-func TestWriteAtEndOfFile(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtEndOfFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	err := operations.WriteFileInAppendMode(fileName, "line 3\n")
-	if err != nil {
-		t.Errorf("AppendString: %v", err)
-	}
+	require.NoError(w.T(), err, "AppendString failed")
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 2\nline 3\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\nline 3\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestWriteAtStartOfFile(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtStartOfFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	err := operations.WriteFile(fileName, "line 4\n")
-	if err != nil {
-		t.Errorf("WriteString-Start: %v", err)
-	}
+	require.NoError(w.T(), err, "WriteString-Start failed")
 
-	setup.CompareFileContents(t, fileName, "line 4\nline 2\n")
+	setup.CompareFileContents(w.T(), fileName, "line 4\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestWriteAtRandom(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtRandom() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	f, err := os.OpenFile(fileName, os.O_WRONLY|syscall.O_DIRECT, setup.FilePermission_0600)
-	if err != nil {
-		t.Errorf("Open file for write at random: %v", err)
-	}
+	require.NoError(w.T(), err, "Open file for write at random failed")
 
 	// Write at 7th byte which corresponds to the start of 2nd line
 	// thus changing line2\n with line5\n.
-	if _, err = f.WriteAt([]byte("line 5\n"), 7); err != nil {
-		t.Errorf("WriteString-Random: %v", err)
-	}
+	_, err = f.WriteAt([]byte("line 5\n"), 7)
+	require.NoError(w.T(), err, "WriteString-Random failed")
 	// Closing file at the end
-	operations.CloseFileShouldNotThrowError(t, f)
+	operations.CloseFileShouldNotThrowError(w.T(), f)
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 5\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 5\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestCreateFile(t *testing.T) {
+func (w *writeOperationsTest) TestCreateFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	// Stat the file to check if it exists.
-	if _, err := os.Stat(fileName); err != nil {
-		t.Errorf("File not found, %v", err)
-	}
+	_, err := os.Stat(fileName)
+	require.NoError(w.T(), err, "File not found")
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 2\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestAppendFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
+func (w *writeOperationsTest) TestAppendFileOperationsDoesNotChangeObjectAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 	// Append to the file.
 	err := operations.WriteFileInAppendMode(fileName, appendContent)
-	if err != nil {
-		t.Errorf("Could not append to file: %v", err)
-	}
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	require.NoError(w.T(), err, "Could not append to file")
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 
 	// Validate object attributes are as expected.
-	validateObjectAttributes(attr1, attr2, t)
+	w.validateObjectAttributes(attr1, attr2)
 }
 
-func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtFileOperationsDoesNotChangeObjectAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 	// Over-write the file.
 	fh, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
-	if err != nil {
-		t.Fatalf("Could not open file %s after creation.", fileName)
-	}
-	operations.WriteAt(tempFileContent+appendContent, 0, fh, t)
-	operations.CloseFileShouldNotThrowError(t, fh)
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	require.NoError(w.T(), err, "Could not open file after creation")
+	operations.WriteAt(tempFileContent+appendContent, 0, fh, w.T())
+	operations.CloseFileShouldNotThrowError(w.T(), fh)
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 
 	// Validate object attributes are as expected.
-	validateObjectAttributes(attr1, attr2, t)
+	w.validateObjectAttributes(attr1, attr2)
 }

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -62,6 +62,7 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, readFullFile bo
 	if readFullFile {
 		file, err := os.OpenFile(path.Join(testDirPath, fileName), os.O_RDONLY|syscall.O_DIRECT, setup.FilePermission_0600)
 		require.NoError(t, err)
+		defer file.Close()
 		content, err = operations.ReadFileSequentially(file, chunkSizeToRead)
 		if err != nil {
 			t.Errorf("Failed to read file sequentially: %v", err)

--- a/tools/integration_tests/read_cache/helpers_test.go
+++ b/tools/integration_tests/read_cache/helpers_test.go
@@ -62,7 +62,6 @@ func readFileAndGetExpectedOutcome(testDirPath, fileName string, readFullFile bo
 	if readFullFile {
 		file, err := os.OpenFile(path.Join(testDirPath, fileName), os.O_RDONLY|syscall.O_DIRECT, setup.FilePermission_0600)
 		require.NoError(t, err)
-		defer file.Close()
 		content, err = operations.ReadFileSequentially(file, chunkSizeToRead)
 		if err != nil {
 			t.Errorf("Failed to read file sequentially: %v", err)

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -114,11 +114,13 @@ func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss() {
 ////////////////////////////////////////////////////////////////////////
 
 func runLocalModificationTest(t *testing.T, ts *localModificationTest) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
+	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, ts.flags = range flagsSet {
 		log.Printf("Running %s with flags: %s", t.Name(), ts.flags)

--- a/tools/integration_tests/read_cache/local_modification_test.go
+++ b/tools/integration_tests/read_cache/local_modification_test.go
@@ -34,10 +34,11 @@ import (
 // Boilerplate
 // //////////////////////////////////////////////////////////////////////
 type localModificationTest struct {
-	flags         []string
-	storageClient *storage.Client
-	ctx           context.Context
-	baseTestName  string
+	flags                []string
+	storageClient        *storage.Client
+	ctx                  context.Context
+	baseTestName         string
+	isRapidWritesEnabled bool
 	suite.Suite
 }
 
@@ -75,14 +76,13 @@ func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss() {
 	expectedOutcome1 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize, true, s.T())
 	// Append data in the same file to change object generation.
 	smallContent, err := operations.GenerateRandomData(smallContentSize)
-	if err != nil {
-		s.T().Errorf("TestReadAfterLocalGCSFuseWriteIsCacheMiss: could not generate randomm data: %v", err)
-	}
+	require.NoError(s.T(), err, "TestReadAfterLocalGCSFuseWriteIsCacheMiss: could not generate random data")
+
 	err = operations.WriteFileInAppendMode(path.Join(testEnv.testDirPath, testFileName), string(smallContent))
-	if err != nil {
-		s.T().Errorf("Error in appending data in file: %v", err)
-	}
-	if !setup.IsZonalBucketRun() {
+	require.NoError(s.T(), err, "Error in appending data in file")
+
+	isPirloRapidWrites := setup.IsPirloBucketRun() && s.isRapidWritesEnabled
+	if !setup.IsZonalBucketRun() && !isPirloRapidWrites {
 		// Read file 2nd time.
 		expectedOutcome2 := readFileAndValidateCacheWithGCS(s.ctx, s.storageClient, testFileName, fileSize+smallContentSize, true, s.T())
 
@@ -113,19 +113,38 @@ func (s *localModificationTest) TestReadAfterLocalGCSFuseWriteIsCacheMiss() {
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestLocalModificationTest(t *testing.T) {
-	ts := &localModificationTest{ctx: context.Background(), storageClient: testEnv.storageClient, baseTestName: t.Name()}
-
-	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
+func runLocalModificationTest(t *testing.T, ts *localModificationTest) {
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
-	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, ts.flags = range flagsSet {
-		log.Printf("Running tests with flags: %s", ts.flags)
+		log.Printf("Running %s with flags: %s", t.Name(), ts.flags)
 		suite.Run(t, ts)
 	}
+}
+
+func TestLocalModificationBase(t *testing.T) {
+	ts := &localModificationTest{
+		ctx:                  context.Background(),
+		storageClient:        testEnv.storageClient,
+		baseTestName:         t.Name(),
+		isRapidWritesEnabled: false,
+	}
+	runLocalModificationTest(t, ts)
+}
+
+func TestLocalModificationRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	ts := &localModificationTest{
+		ctx:                  context.Background(),
+		storageClient:        testEnv.storageClient,
+		baseTestName:         t.Name(),
+		isRapidWritesEnabled: true,
+	}
+	runLocalModificationTest(t, ts)
 }

--- a/tools/integration_tests/read_cache/setup_test.go
+++ b/tools/integration_tests/read_cache/setup_test.go
@@ -172,13 +172,13 @@ func TestMain(m *testing.M) {
 		cfg.ReadCache[0].Configs[3].Run = "TestRangeReadWithParallelDownloadsTest"
 
 		cfg.ReadCache[0].Configs[4].Flags = []string{
-			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestLocalModificationTest --log-file=/gcsfuse-tmp/TestLocalModificationTest.log --log-severity=TRACE --implicit-dirs --enable-kernel-reader=false",
-			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=true --cache-dir=/gcsfuse-tmp/TestLocalModificationTest --log-file=/gcsfuse-tmp/TestLocalModificationTest.log --log-severity=TRACE --enable-kernel-reader=false",
-			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestLocalModificationTest --log-file=/gcsfuse-tmp/TestLocalModificationTest.log --log-severity=TRACE --implicit-dirs --client-protocol=grpc --enable-kernel-reader=false",
-			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=true --cache-dir=/gcsfuse-tmp/TestLocalModificationTest --log-file=/gcsfuse-tmp/TestLocalModificationTest.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
+			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestLocalModificationBase --log-file=/gcsfuse-tmp/TestLocalModificationBase.log --log-severity=TRACE --implicit-dirs --enable-kernel-reader=false",
+			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=true --cache-dir=/gcsfuse-tmp/TestLocalModificationBase --log-file=/gcsfuse-tmp/TestLocalModificationBase.log --log-severity=TRACE --enable-kernel-reader=false",
+			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestLocalModificationBase --log-file=/gcsfuse-tmp/TestLocalModificationBase.log --log-severity=TRACE --implicit-dirs --client-protocol=grpc --enable-kernel-reader=false",
+			"--file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=true --cache-dir=/gcsfuse-tmp/TestLocalModificationBase --log-file=/gcsfuse-tmp/TestLocalModificationBase.log --log-severity=TRACE --client-protocol=grpc --enable-kernel-reader=false",
 		}
 		cfg.ReadCache[0].Configs[4].Compatible = map[string]bool{"flat": true, "hns": true, "zonal": true}
-		cfg.ReadCache[0].Configs[4].Run = "TestLocalModificationTest"
+		cfg.ReadCache[0].Configs[4].Run = "TestLocalModificationBase"
 
 		cfg.ReadCache[0].Configs[5].Flags = []string{
 			"--stat-cache-ttl=0s --file-cache-max-size-mb=9 --file-cache-enable-parallel-downloads=false --cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest --log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log --log-severity=TRACE --implicit-dirs --enable-kernel-reader=false",

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -109,11 +109,13 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 ////////////////////////////////////////////////////////////////////////
 
 func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		suite.Run(t, ts)
 		return
 	}
 
+	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -80,6 +80,7 @@ func (r *readOnlyCredsTest) TestEmptyCreateFileFails_FailedFileNotInListing() {
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
+		require.NoError(r.T(), err)
 		r.assertFileSyncFailsWithPermissionError(fh, r.T())
 	}
 
@@ -94,6 +95,7 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
+		require.NoError(r.T(), err)
 		operations.WriteWithoutClose(fh, content, r.T())
 		operations.WriteWithoutClose(fh, content, r.T())
 		r.assertFileSyncFailsWithPermissionError(fh, r.T())

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -15,11 +15,13 @@
 package readonly_creds
 
 import (
+	"log"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +34,8 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 type readOnlyCredsTest struct {
-	testDirPath string
+	testDirPath          string
+	isRapidWritesEnabled bool
 	suite.Suite
 }
 
@@ -41,6 +44,7 @@ func (r *readOnlyCredsTest) SetupTest() {
 }
 
 func (r *readOnlyCredsTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(r.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -72,7 +76,7 @@ func (r *readOnlyCredsTest) TestEmptyCreateFileFails_FailedFileNotInListing() {
 	filePath := path.Join(r.testDirPath, testFileName)
 
 	fh, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, operations.FilePermission_0777)
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && r.isRapidWritesEnabled) {
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
@@ -86,7 +90,7 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 	filePath := path.Join(r.testDirPath, testFileName)
 
 	fh, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, operations.FilePermission_0777)
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && r.isRapidWritesEnabled) {
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
@@ -102,9 +106,33 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestReadOnlyTest(t *testing.T) {
-	ts := &readOnlyCredsTest{}
+func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		suite.Run(t, ts)
+		return
+	}
 
-	// Run tests.
-	suite.Run(t, ts)
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		log.Printf("Running %s with flags: %s", t.Name(), flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(testEnv.cfg, flags)
+		require.NoError(t, err, "Mount failed")
+
+		suite.Run(t, ts)
+
+		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+	}
+}
+
+func TestReadOnlyCredsBase(t *testing.T) {
+	ts := &readOnlyCredsTest{isRapidWritesEnabled: false}
+	runReadOnlyCredsTest(t, ts)
+}
+
+func TestReadOnlyCredsRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	ts := &readOnlyCredsTest{isRapidWritesEnabled: true}
+	runReadOnlyCredsTest(t, ts)
 }

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -116,9 +116,11 @@ func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
 
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
-		log.Printf("Running %s with flags: %s", t.Name(), flags)
-		creds_tests.RunSuiteForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", t, func() {
-			suite.Run(t, ts)
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			log.Printf("Running %s with flags: %s", t.Name(), flags)
+			creds_tests.RunSuiteForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", t, func() {
+				suite.Run(t, ts)
+			})
 		})
 	}
 }

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -109,13 +109,6 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 ////////////////////////////////////////////////////////////////////////
 
 func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
-	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
-	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
-		suite.Run(t, ts)
-		return
-	}
-
-	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {

--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
@@ -115,12 +115,9 @@ func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	for _, flags := range flagsSet {
 		log.Printf("Running %s with flags: %s", t.Name(), flags)
-		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(testEnv.cfg, flags)
-		require.NoError(t, err, "Mount failed")
-
-		suite.Run(t, ts)
-
-		setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+		creds_tests.RunSuiteForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", t, func() {
+			suite.Run(t, ts)
+		})
 	}
 }
 

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -95,9 +95,21 @@ func TestMain(m *testing.M) {
 	// Save mount and root directory variables.
 	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
-	flags := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, "")
-	// Test for viewer permission on test bucket.
-	successCode := creds_tests.RunTestsForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", m)
+	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(testEnv.ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
+	creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, serviceAccount, "objectViewer", testEnv.cfg.TestBucket)
+	defer creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, serviceAccount, "objectViewer", testEnv.cfg.TestBucket)
+
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+	if err != nil {
+		log.Fatalf("Error in setting environment variable: %v", err)
+	}
+
+	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -23,7 +23,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
@@ -94,20 +93,6 @@ func TestMain(m *testing.M) {
 
 	// Save mount and root directory variables.
 	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
-
-	serviceAccount, localKeyFilePath := creds_tests.CreateCredentials(testEnv.ctx)
-	defer func() {
-		if err := os.Remove(localKeyFilePath); err != nil {
-			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
-		}
-	}()
-	creds_tests.ApplyPermissionToServiceAccount(testEnv.ctx, testEnv.storageClient, serviceAccount, "objectViewer", testEnv.cfg.TestBucket)
-	defer creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, serviceAccount, "objectViewer", testEnv.cfg.TestBucket)
-
-	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-	if err != nil {
-		log.Fatalf("Error in setting environment variable: %v", err)
-	}
 
 	successCode := m.Run()
 

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -38,7 +38,7 @@ implicit_dir:
         run_on_gke: true
         run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -46,7 +46,7 @@ implicit_dir:
         run_on_gke: false
         run: TestImplicitDirLocalFileRapidWritesEnabled
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -125,7 +125,7 @@ operations:
         run: TestOperationsBase
       - flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -134,7 +134,7 @@ operations:
         run: TestWriteOperationsRapidWritesEnabled
       - flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -404,7 +404,7 @@ read_cache:
         run: TestSmallCacheTTLTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=10,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestSmallCacheTTLTest,--log-file=/gcsfuse-tmp/TestSmallCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
@@ -428,9 +428,9 @@ read_cache:
         run: TestReadOnlyTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--implicit-dirs,--o=ro,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-cache-file-for-range-read,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--file-cache-enable-parallel-downloads=false,--o=ro,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestReadOnlyTest,--log-file=/gcsfuse-tmp/TestReadOnlyTest.log,--log-severity=TRACE,--o=ro,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
@@ -448,7 +448,7 @@ read_cache:
         run: TestRangeReadTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRangeReadTest,--log-file=/gcsfuse-tmp/TestRangeReadTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -465,7 +465,7 @@ read_cache:
         run: TestRangeReadWithParallelDownloadsTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest,--log-file=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=15,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest,--log-file=/gcsfuse-tmp/TestRangeReadWithParallelDownloadsTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -484,7 +484,7 @@ read_cache:
         run: TestLocalModificationBase
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--enable-kernel-reader=false"
         run_on_pirlo:
           hns:
@@ -493,7 +493,7 @@ read_cache:
         run_on_gke: false
         run: TestLocalModificationRapidWritesEnabled
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false"
         run_on_pirlo:
           hns:
@@ -513,7 +513,7 @@ read_cache:
         run: TestDisabledCacheTTLTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
@@ -535,7 +535,7 @@ read_cache:
         run: TestCacheFileForRangeReadTrueTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-cache-file-for-range-read,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadTrueTest.log,--log-severity=TRACE,--file-cache-enable-o-direct,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
@@ -568,7 +568,7 @@ read_cache:
         run: TestCacheFileForRangeReadFalseTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=50,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest,--log-file=/gcsfuse-tmp/TestCacheFileForRangeReadFalseTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -698,8 +698,8 @@ read_cache:
         run: TestRemountTest
         run_on_gke: false
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--implicit-dirs,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestRemountTest,--log-file=/gcsfuse-tmp/TestRemountTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -1168,8 +1168,7 @@ readonly_creds:
         run_on_gke: false
         run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -1177,8 +1176,7 @@ readonly_creds:
         run_on_gke: false
         run: TestReadOnlyCredsRapidWritesEnabled
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false"
         run_on_pirlo:
           hns:
             same_zone: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -36,13 +36,23 @@ implicit_dir:
           hns: true
           zonal: true
         run_on_gke: true
+        run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
+        run_on_gke: false
+        run: TestImplicitDirLocalFileRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestImplicitDirBase
       - flags:
           - "--implicit-dirs,--client-protocol=grpc"
         compatible:
@@ -50,6 +60,7 @@ implicit_dir:
           hns: true
           zonal: false
         run_on_gke: true
+        run: TestImplicitDirBase
 
 list_large_dir:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -111,14 +122,25 @@ operations:
           hns: true
           zonal: true
         run_on_gke: true
+        run: TestOperationsBase
       - flags:
-          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
+        run_on_gke: false
+        run: TestWriteOperationsRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestOperationsBase
       - flags:
           - "--enable-atomic-rename-object=true,--client-protocol=http1"
           - "--experimental-enable-json-read=true,--client-protocol=http1"
@@ -130,6 +152,7 @@ operations:
           zonal: true
         tpc: true
         run_on_gke: false
+        run: TestOperationsBase
 
 write_large_files:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -450,25 +473,34 @@ read_cache:
         run_on_gke: true
         run: TestRangeReadWithParallelDownloadsTest
       - flags:
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
-        run: TestLocalModificationTest
+        run: TestLocalModificationBase
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--enable-kernel-reader=false"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
-        run: TestLocalModificationTest
+        run_on_gke: false
+        run: TestLocalModificationRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestLocalModificationBase
       - flags:
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
@@ -1134,14 +1166,25 @@ readonly_creds:
           hns: true
           zonal: true
         run_on_gke: false
+        run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs=true,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
         run_on_gke: false
+        run: TestReadOnlyCredsRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestReadOnlyCredsBase
 
 mount_timeout:
   - mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -225,6 +225,10 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
+	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
+	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
+	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
+
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
 	t.Run("EnvVar", func(t *testing.T) {
 		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -231,7 +231,9 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 
 	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
 	require.NoError(t, err, "Error setting environment variable")
-	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	defer func() {
+		_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	}()
 
 	keyFileFlag := "--key-file=" + localKeyFilePath
 	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -226,45 +226,53 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
-	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
-	}
+	t.Run("EnvVar", func(t *testing.T) {
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		require.NoError(t, err, "Error setting environment variable")
 
-	log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
-	require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
 
-	runSuiteFunc()
+		runSuiteFunc()
 
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(cfg)
+	})
 
 	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
-	keyFileFlag := "--key-file=" + localKeyFilePath
-	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+	t.Run("KeyFileAndEnvVar", func(t *testing.T) {
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		require.NoError(t, err, "Error setting environment variable")
 
-	log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-	require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+		keyFileFlag := "--key-file=" + localKeyFilePath
+		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
-	runSuiteFunc()
+		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
 
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(cfg)
+	})
 
 	// 3. Testing with --key-file flag only.
-	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
-	}
+	t.Run("KeyFileOnly", func(t *testing.T) {
+		err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		require.NoError(t, err, "Error unsetting environment variable")
 
-	log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-	require.NoError(t, err, "Creds mount with --key-file failed")
+		keyFileFlag := "--key-file=" + localKeyFilePath
+		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
-	runSuiteFunc()
+		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		require.NoError(t, err, "Creds mount with --key-file failed")
 
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(cfg)
+	})
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -34,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 const NameOfServiceAccount = "creds-integration-tests"
@@ -212,4 +213,58 @@ func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	}
 
 	return successCode
+}
+
+func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, flags []string, permission string, t *testing.T, runSuiteFunc func()) {
+	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
+	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
+	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
+
+	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
+	}
+
+	log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+	require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
+
+	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
+	keyFileFlag := "--key-file=" + localKeyFilePath
+	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+
+	log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+	require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
+
+	// 3. Testing with --key-file flag only.
+	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
+	}
+
+	log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+	require.NoError(t, err, "Creds mount with --key-file failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -233,11 +233,12 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
 		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
 		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
 		runSuiteFunc()
-
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(cfg)
 	})
 
 	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
@@ -251,11 +252,12 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
 		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
 		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
 		runSuiteFunc()
-
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(cfg)
 	})
 
 	// 3. Testing with --key-file flag only.
@@ -269,10 +271,11 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
 		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
 		require.NoError(t, err, "Creds mount with --key-file failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
 		runSuiteFunc()
-
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(cfg)
 	})
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -229,13 +229,17 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
 	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
 
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+	require.NoError(t, err, "Error setting environment variable")
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	keyFileFlag := "--key-file=" + localKeyFilePath
+	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
 	t.Run("EnvVar", func(t *testing.T) {
-		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-		require.NoError(t, err, "Error setting environment variable")
-
 		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
-		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
 		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
 		defer func() {
 			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
@@ -247,14 +251,8 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 
 	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
 	t.Run("KeyFileAndEnvVar", func(t *testing.T) {
-		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-		require.NoError(t, err, "Error setting environment variable")
-
-		keyFileFlag := "--key-file=" + localKeyFilePath
-		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
-
 		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
-		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
 		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
 		defer func() {
 			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
@@ -268,9 +266,6 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	t.Run("KeyFileOnly", func(t *testing.T) {
 		err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 		require.NoError(t, err, "Error unsetting environment variable")
-
-		keyFileFlag := "--key-file=" + localKeyFilePath
-		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
 		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
 		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 func MountGcsfuseWithDynamicMountingWithConfig(cfg *test_suite.TestConfig, flags []string) (err error) {
@@ -86,4 +87,26 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForDynamicMounting(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForDynamicMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	rootMntDir := config.GCSFuseMountedDirectory
+	setup.SetDynamicBucketMounted(config.TestBucket)
+
+	log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithDynamicMountingWithConfig(config, flags)
+	require.NoError(t, err, "Dynamic mount failed")
+	defer func() {
+		setup.SetMntDir(rootMntDir)
+		config.GCSFuseMountedDirectory = rootMntDir
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+		setup.SetDynamicBucketMounted("")
+	}()
+
+	mntDirOfTestBucket := path.Join(rootMntDir, config.TestBucket)
+	config.GCSFuseMountedDirectory = mntDirOfTestBucket
+	setup.SetMntDir(mntDirOfTestBucket)
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -15,16 +15,17 @@
 package only_dir_mounting
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
 
-	"context"
-
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
@@ -98,4 +99,23 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForOnlyDirMounting(config, flagsSet, dirName, m)
 	return successCode
+}
+
+func RunSuiteForOnlyDirMounting(ctx context.Context, storageClient *storage.Client, config *test_suite.TestConfig, flags []string, dirName string, t *testing.T, runSuiteFunc func()) {
+	setup.SetOnlyDirMounted(dirName)
+	client.SetupTestDirectory(ctx, storageClient, dirName)
+	defer func() {
+		if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, dirName); err != nil {
+			log.Printf("Error deleting object on GCS: %v", err)
+		}
+		setup.SetOnlyDirMounted("")
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithOnlyDirWithConfigFile(config, flags)
+	require.NoError(t, err, "Only dir mount failed")
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -43,7 +43,7 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 	return
 }
 
-func MountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
+func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{config.TestBucket,
 		config.GCSFuseMountedDirectory,
 		"-o",
@@ -68,7 +68,7 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 	var err error
 
 	for i := range flagsSet {
-		if err = MountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
+		if err = mountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])
@@ -89,7 +89,7 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 
 func RunSuiteForPersistentMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
 	log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-	err := MountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
+	err := mountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
 	require.NoError(t, err, "Persistent mount failed")
 	defer func() {
 		setup.SaveGCSFuseLogFileInCaseOfFailure(t)

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 // Change e.g --log_severity=trace to log_severity=trace
@@ -84,4 +85,16 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForPersistentMountingWithConfigFile(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForPersistentMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
+	require.NoError(t, err, "Persistent mount failed")
+	defer func() {
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -42,7 +42,7 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 	return
 }
 
-func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
+func MountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{config.TestBucket,
 		config.GCSFuseMountedDirectory,
 		"-o",
@@ -67,7 +67,7 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 	var err error
 
 	for i := range flagsSet {
-		if err = mountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
+		if err = MountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
@@ -76,4 +77,16 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForStaticMounting(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForStaticMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
+	require.NoError(t, err, "Static mount failed")
+	defer func() {
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	runSuiteFunc()
 }


### PR DESCRIPTION
### Description
Bifurcate integration test suites in `operations`, `implicit_dir`, `read_cache`, and `readonly_creds` to support separate test runners for standard runs (`TestXxxBase`) and rapid-writes enabled runs (`TestXxxRapidWritesEnabled`).

On Pirlo buckets, enabling rapid writes (`--enable-rapid-writes=true`) introduces different runtime behavior—such as using appendable writers and leaving objects unfinalized prior to file close—compared to standard runs (`--enable-rapid-writes=false`). Splitting the test suites and calling `setup.BuildFlagSets` dynamically per runner allows `test_config.yaml` to configure distinct flag combinations and ensures test assertions evaluate `isRapidWritesEnabled` correctly.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No
