### PR TITLE
refactor(test): move write_large_file test to suites.

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -152,14 +152,15 @@ write_large_files:
     configs:
       - run: TestWriteMaxRequestSize16MiB
         flags:
-          - "--enable-kernel-reader=true,--fuse-max-request-size-kb=16384,--log-severity=trace,--client-protocol=http1"
-          - "--enable-kernel-reader=true,--fuse-max-request-size-kb=16384,--log-severity=trace,--client-protocol=grpc"
+          - "--enable-kernel-reader=true,--fuse-max-request-size-kb=16384,--log-file=/gcsfuse-tmp/TestWriteMaxRequestSize16MiB.log,--log-severity=trace,--client-protocol=http1"
+          - "--enable-kernel-reader=true,--fuse-max-request-size-kb=16384,--log-file=/gcsfuse-tmp/TestWriteMaxRequestSize16MiB.log,--log-severity=trace,--client-protocol=grpc"
         compatible:
           flat: true
           hns: true
           zonal: false
         run_on_gke: true
-      - flags:
+      - run: TestWriteLargeFiles
+        flags:
           - "--enable-streaming-writes=false,--client-protocol=http1"
           - "--enable-streaming-writes=false,--client-protocol=grpc"
           # write-global-max-blocks=5 is for checking multiple file writes in parallel.
@@ -172,7 +173,8 @@ write_large_files:
           hns: true
           zonal: true
         run_on_gke: true
-      - flags:
+      - run: TestWriteLargeFiles
+        flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--write-max-blocks-per-file=2,--write-global-max-blocks=5,--client-protocol=http1"
         run_on_pirlo:
@@ -183,7 +185,8 @@ write_large_files:
             same_zone: true
             different_zone: true
         run_on_gke: true
-      - flags:
+      - run: TestWriteLargeFiles
+        flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--enable-streaming-writes=false,--client-protocol=http1"
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--write-max-blocks-per-file=2,--write-global-max-blocks=5,--client-protocol=http1"
         run_on_pirlo:

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -144,9 +144,6 @@ func TestOnTPCEndPoint() bool {
 }
 
 func MountedDirectory() string {
-	if *mountedDirectory == "" {
-		*mountedDirectory = os.Getenv("MOUNTED_DIR")
-	}
 	return *mountedDirectory
 }
 

--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -144,6 +144,9 @@ func TestOnTPCEndPoint() bool {
 }
 
 func MountedDirectory() string {
+	if *mountedDirectory == "" {
+		*mountedDirectory = os.Getenv("MOUNTED_DIR")
+	}
 	return *mountedDirectory
 }
 

--- a/tools/integration_tests/write_large_files/concurrent_write_files_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_files_test.go
@@ -16,7 +16,6 @@ package write_large_files
 
 import (
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -29,7 +28,7 @@ const (
 	DirForConcurrentWrite = "dirForConcurrentWrite"
 )
 
-func TestWriteMultipleFilesConcurrently(t *testing.T) {
+func (s *WriteLargeFilesTestSuite) TestWriteMultipleFilesConcurrently() {
 	concurrentWriteDir := setup.SetupTestDirectory(DirForConcurrentWrite)
 	var FileOne = "fileOne" + setup.GenerateRandomString(5) + ".txt"
 	var FileTwo = "fileTwo" + setup.GenerateRandomString(5) + ".txt"
@@ -41,18 +40,18 @@ func TestWriteMultipleFilesConcurrently(t *testing.T) {
 	for i := range files {
 		// Copy the current value of i into a local variable to avoid data races.
 		fileIndex := i
+		localFilePath := path.Join(TmpDir, setup.GenerateRandomString(5))
+		s.T().Cleanup(func() { operations.RemoveFile(localFilePath) })
 
 		// Thread to write the current file.
 		eG.Go(func() error {
 			mountedDirFilePath := path.Join(concurrentWriteDir, files[fileIndex])
-			localFilePath := path.Join(TmpDir, setup.GenerateRandomString(5))
-			t.Cleanup(func() { operations.RemoveFile(localFilePath) })
 
-			operations.WriteFilesSequentially(t, []string{localFilePath, mountedDirFilePath}, FiveHundredMB, ChunkSize)
+			operations.WriteFilesSequentially(s.T(), []string{localFilePath, mountedDirFilePath}, FiveHundredMB, ChunkSize)
 
 			identical, err := operations.AreFilesIdentical(mountedDirFilePath, localFilePath)
-			require.NoError(t, err)
-			assert.True(t, identical)
+			require.NoError(s.T(), err)
+			assert.True(s.T(), identical)
 			return nil
 		})
 	}

--- a/tools/integration_tests/write_large_files/concurrent_write_to_same_file_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_to_same_file_test.go
@@ -27,12 +27,12 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func TestWriteToSameFileConcurrently(t *testing.T) {
+func (s *WriteLargeFilesTestSuite) TestWriteToSameFileConcurrently() {
 	// Setup Test directory and files to write to.
 	seqWriteDir := setup.SetupTestDirectory(DirForSeqWrite)
 	mountedDirFilePath := path.Join(seqWriteDir, setup.GenerateRandomString(5))
 	localFilePath := path.Join(TmpDir, setup.GenerateRandomString(5))
-	t.Cleanup(func() { operations.RemoveFile(localFilePath) })
+	s.T().Cleanup(func() { operations.RemoveFile(localFilePath) })
 	// We will have x numbers of concurrent writers trying to write to the same file.
 	// Every thread will start at offset = writer_index * (fileSize/thread_count).
 	var eG errgroup.Group
@@ -42,17 +42,17 @@ func TestWriteToSameFileConcurrently(t *testing.T) {
 	for i := range concurrentWriterCount {
 		offset := i * chunkSize
 		eG.Go(func() error {
-			writeToFileSequentially(t, []string{localFilePath, mountedDirFilePath}, offset, offset+chunkSize)
+			writeToFileSequentially(s.T(), []string{localFilePath, mountedDirFilePath}, offset, offset+chunkSize)
 			return nil
 		})
 	}
 
 	// Wait on threads to end.
 	err := eG.Wait()
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	identical, err := operations.AreFilesIdentical(mountedDirFilePath, localFilePath)
-	require.NoError(t, err)
-	assert.True(t, identical)
+	require.NoError(s.T(), err)
+	assert.True(s.T(), identical)
 }
 
 func writeToFileSequentially(t *testing.T, filePaths []string, startOffset int, endOffset int) {

--- a/tools/integration_tests/write_large_files/max_request_size_test.go
+++ b/tools/integration_tests/write_large_files/max_request_size_test.go
@@ -85,7 +85,7 @@ func runWriteMaxRequestSize16MiBTest(t *testing.T) {
 }
 
 func TestWriteMaxRequestSize16MiB(t *testing.T) {
-	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
 		runWriteMaxRequestSize16MiBTest(t)
 		return
 	}

--- a/tools/integration_tests/write_large_files/max_request_size_test.go
+++ b/tools/integration_tests/write_large_files/max_request_size_test.go
@@ -17,6 +17,7 @@ package write_large_files
 import (
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -33,19 +34,23 @@ const (
 	oneMiBInBytes     = "1048576"
 )
 
-func TestWriteMaxRequestSize16MiB(t *testing.T) {
-	logContent, err := os.ReadFile(setup.LogFile())
-	require.NoError(t, err, "Failed to read log file")
-	if !strings.Contains(string(logContent), "--fuse-max-request-size-kb=16384") {
-		t.Skip("Skipping TestWriteMaxRequestSize16MiB: --fuse-max-request-size-kb=16384 is not set in the mount config")
+func isKernelMaxPagesSupported(requiredBytes int) bool {
+	requiredPages := requiredBytes / os.Getpagesize()
+	maxPagesData, err := os.ReadFile("/proc/sys/fs/fuse/max_pages_limit")
+	if err != nil {
+		return false
 	}
+	limit, err := strconv.Atoi(strings.TrimSpace(string(maxPagesData)))
+	return err == nil && limit >= requiredPages
+}
 
+func runWriteMaxRequestSize16MiBTest(t *testing.T) {
 	// Setup test directory and target file.
 	writeDir := setup.SetupTestDirectory("dirForMaxRequestSizeWrite")
 	filePath := path.Join(writeDir, "16MiB_write_test_"+setup.GenerateRandomString(5)+".txt")
 
 	// Truncate the log file right before writing so only our write operations are logged.
-	err = os.Truncate(setup.LogFile(), 0)
+	err := os.Truncate(setup.LogFile(), 0)
 	require.NoError(t, err, "Failed to truncate log file")
 
 	// Generate 16 MiB of random data (memory-aligned to os.Getpagesize() for O_DIRECT write).
@@ -65,7 +70,7 @@ func TestWriteMaxRequestSize16MiB(t *testing.T) {
 	require.NoError(t, err, "Failed to close file")
 
 	// Read log content after write.
-	logContent, err = os.ReadFile(setup.LogFile())
+	logContent, err := os.ReadFile(setup.LogFile())
 	require.NoError(t, err, "Failed to read log file after write")
 
 	lines := strings.Split(string(logContent), "\n")
@@ -77,4 +82,28 @@ func TestWriteMaxRequestSize16MiB(t *testing.T) {
 		}
 	}
 	assert.Equal(t, 16, writeRequestCount, "Expected exactly 16 write requests of 1 MiB each for 16 MiB write, got %d", writeRequestCount)
+}
+
+func TestWriteMaxRequestSize16MiB(t *testing.T) {
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		runWriteMaxRequestSize16MiBTest(t)
+		return
+	}
+
+	if !isKernelMaxPagesSupported(sixteenMiB) {
+		t.Skip("Skipping TestWriteMaxRequestSize16MiB: kernel /proc/sys/fs/fuse/max_pages_limit does not support 16 MiB request size")
+	}
+
+	flagsSet := setup.BuildFlagSets(testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			mustMountGCSFuseAndSetupTestDir(flags, testEnv.ctx, testEnv.storageClient)
+			t.Cleanup(func() {
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuse(testEnv.rootDir)
+			})
+
+			runWriteMaxRequestSize16MiBTest(t)
+		})
+	}
 }

--- a/tools/integration_tests/write_large_files/random_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/random_write_large_file_test.go
@@ -17,7 +17,6 @@ package write_large_files
 import (
 	rand2 "math/rand"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -32,14 +31,14 @@ const (
 	MaxFileOffset            = 500 * OneMiB
 )
 
-func TestWriteLargeFileRandomly(t *testing.T) {
+func (s *WriteLargeFilesTestSuite) TestWriteLargeFileRandomly() {
 	// Setup Test directory and files to write to.
 	randomWriteDir := setup.SetupTestDirectory(DirForRandomWrite)
 	mountedDirFilePath := path.Join(randomWriteDir, FiveHundredMBFile)
 	localFilePath := path.Join(TmpDir, setup.GenerateRandomString(5))
-	t.Cleanup(func() { operations.RemoveFile(localFilePath) })
+	s.T().Cleanup(func() { operations.RemoveFile(localFilePath) })
 	// Open local file and mounted directory file for writing.
-	filesToWrite := operations.OpenFiles(t, []string{localFilePath, mountedDirFilePath})
+	filesToWrite := operations.OpenFiles(s.T(), []string{localFilePath, mountedDirFilePath})
 
 	for range NumberOfRandomWriteCalls {
 		offset := rand2.Int63n(MaxFileOffset - ChunkSize)
@@ -47,11 +46,11 @@ func TestWriteLargeFileRandomly(t *testing.T) {
 		offset = offset - offset%(4*util.KiB)
 		// Write chunk of random data to both local and mounted directory file.
 		err := operations.WriteChunkOfRandomBytesToFiles(filesToWrite, ChunkSize, offset)
-		require.NoError(t, err)
+		require.NoError(s.T(), err)
 	}
 
-	operations.CloseFiles(t, filesToWrite)
+	operations.CloseFiles(s.T(), filesToWrite)
 	identical, err := operations.AreFilesIdentical(mountedDirFilePath, localFilePath)
-	require.NoError(t, err)
-	assert.True(t, identical)
+	require.NoError(s.T(), err)
+	assert.True(s.T(), identical)
 }

--- a/tools/integration_tests/write_large_files/seq_write_large_file_test.go
+++ b/tools/integration_tests/write_large_files/seq_write_large_file_test.go
@@ -16,7 +16,6 @@ package write_large_files
 
 import (
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -32,16 +31,16 @@ const (
 
 var FiveHundredMBFile = "fiveHundredMBFile" + setup.GenerateRandomString(5) + ".txt"
 
-func TestWriteLargeFileSequentially(t *testing.T) {
+func (s *WriteLargeFilesTestSuite) TestWriteLargeFileSequentially() {
 	seqWriteDir := setup.SetupTestDirectory(DirForSeqWrite)
 	mountedDirFilePath := path.Join(seqWriteDir, FiveHundredMBFile)
 	localFilePath := path.Join(TmpDir, setup.GenerateRandomString(5))
-	t.Cleanup(func() { operations.RemoveFile(localFilePath) })
+	s.T().Cleanup(func() { operations.RemoveFile(localFilePath) })
 
 	// Write sequentially to local and mounted directory file.
-	operations.WriteFilesSequentially(t, []string{localFilePath, mountedDirFilePath}, FiveHundredMB, ChunkSize)
+	operations.WriteFilesSequentially(s.T(), []string{localFilePath, mountedDirFilePath}, FiveHundredMB, ChunkSize)
 
 	identical, err := operations.AreFilesIdentical(mountedDirFilePath, localFilePath)
-	require.NoError(t, err)
-	assert.True(t, identical)
+	require.NoError(s.T(), err)
+	assert.True(s.T(), identical)
 }

--- a/tools/integration_tests/write_large_files/slow_file_write_test.go
+++ b/tools/integration_tests/write_large_files/slow_file_write_test.go
@@ -16,7 +16,6 @@ package write_large_files
 
 import (
 	"path"
-	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -28,21 +27,21 @@ const (
 	DirForSlowWrite = "dirForSlowWrite"
 )
 
-func TestSlowWriteToFile(t *testing.T) {
+func (s *WriteLargeFilesTestSuite) TestSlowWriteToFile() {
 	slowWriteDir := setup.SetupTestDirectory(DirForSlowWrite)
 	slowWriteFileName := "slowWriteFile" + setup.GenerateRandomString(5) + ".txt"
 	mountedDirFilePath := path.Join(slowWriteDir, slowWriteFileName)
-	fh := operations.OpenFileWithODirect(t, mountedDirFilePath)
-	defer operations.CloseFileShouldNotThrowError(t, fh)
+	fh := operations.OpenFileWithODirect(s.T(), mountedDirFilePath)
+	defer operations.CloseFileShouldNotThrowError(s.T(), fh)
 	data := setup.GenerateRandomString(33 * operations.MiB)
 
 	// Write 2 blocks of 33MiB to file
 	for range 2 {
 		n, err := fh.Write([]byte(data))
 
-		assert.NoError(t, err)
-		assert.Equal(t, len(data), n)
-		operations.SyncFile(fh, t)
+		assert.NoError(s.T(), err)
+		assert.Equal(s.T(), len(data), n)
+		operations.SyncFile(fh, s.T())
 		// Add a delay of 40 sec between each block to ensure 32 sec
 		// ChunkRetryDeadline is completely used while reading the second Chunk.
 		time.Sleep(40 * time.Second)

--- a/tools/integration_tests/write_large_files/write_large_files_test.go
+++ b/tools/integration_tests/write_large_files/write_large_files_test.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -19,24 +19,93 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/dynamic_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/only_dir_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/suite"
 )
 
 const (
-	TmpDir = "/tmp"
-	OneMiB = 1024 * 1024
+	testDirName    = "WriteLargeFilesTests"
+	onlyDirMounted = "OnlyDirMountWriteLargeFiles"
+	TmpDir         = "/tmp"
+	OneMiB         = 1024 * 1024
 )
 
-var (
+type env struct {
+	testDirPath   string
+	mountFunc     func(*test_suite.TestConfig, []string) error
+	mountDir      string
+	rootDir       string
 	storageClient *storage.Client
 	ctx           context.Context
+	bucketType    string
+	cfg           test_suite.TestConfig
+}
+
+var (
+	testEnv env
 )
+
+func mountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) error {
+	err := setup.MayMountGCSFuseWithGivenMountWithConfigFunc(&testEnv.cfg, flags, testEnv.mountFunc)
+	if err != nil {
+		return err
+	}
+	if testEnv.cfg.GKEMountedDirectory == "" {
+		setup.SetMntDir(testEnv.mountDir)
+	}
+	testEnv.testDirPath = client.SetupTestDirectory(ctx, storageClient, testDirName)
+	return nil
+}
+
+func mustMountGCSFuseAndSetupTestDir(flags []string, ctx context.Context, storageClient *storage.Client) {
+	if err := mountGCSFuseAndSetupTestDir(flags, ctx, storageClient); err != nil {
+		panic(err)
+	}
+}
+
+type WriteLargeFilesTestSuite struct {
+	suite.Suite
+	flags []string
+}
+
+func (s *WriteLargeFilesTestSuite) SetupSuite() {
+	mustMountGCSFuseAndSetupTestDir(s.flags, testEnv.ctx, testEnv.storageClient)
+}
+
+func (s *WriteLargeFilesTestSuite) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+func (s *WriteLargeFilesTestSuite) TearDownSuite() {
+	if testEnv.cfg.GKEMountedDirectory == "" {
+		setup.UnmountGCSFuse(testEnv.rootDir)
+	}
+}
+
+func TestWriteLargeFiles(t *testing.T) {
+	if setup.AreBothMountedDirectoryAndTestBucketFlagsSet() {
+		suite.Run(t, new(WriteLargeFilesTestSuite))
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		s := &WriteLargeFilesTestSuite{flags: flags}
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			suite.Run(t, s)
+		})
+	}
+}
 
 func TestMain(m *testing.M) {
 	setup.ParseSetUpFlags()
@@ -47,10 +116,10 @@ func TestMain(m *testing.M) {
 		log.Fatal("No configuration found for WriteLargeFiles in config file.")
 	}
 
-	// 2. Create storage client before running tests.
-	ctx = context.Background()
-	bucketType := setup.TestEnvironment(ctx, &cfg.WriteLargeFiles[0])
-	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
+	testEnv.ctx = context.Background()
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.WriteLargeFiles[0])
+	testEnv.cfg = cfg.WriteLargeFiles[0]
+	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
 		if err != nil {
@@ -58,19 +127,42 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
+	setup.ExitWithFailureIfBothTestBucketAndMountedDirectoryFlagsAreNotSet()
+
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	// flags to be set, as WriteLargeFiles tests validates content from the bucket.
-	if cfg.WriteLargeFiles[0].GKEMountedDirectory != "" && cfg.WriteLargeFiles[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.WriteLargeFiles[0].GKEMountedDirectory, m))
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
 	}
 
 	// Run tests for testBucket
-	// 4. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.WriteLargeFiles[0], bucketType, "")
+	setup.SetUpTestDirForTestBucket(&testEnv.cfg)
+	setup.OverrideFilePathsInFlagSet(&testEnv.cfg, setup.TestDir())
 
-	setup.SetUpTestDirForTestBucket(&cfg.WriteLargeFiles[0])
+	testEnv.mountDir, testEnv.rootDir = setup.MntDir(), setup.MntDir()
 
-	successCode := static_mounting.RunTestsWithConfigFile(&cfg.WriteLargeFiles[0], flags, m)
+	log.Println("Running static mounting tests...")
+	testEnv.mountFunc = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile
+	successCode := m.Run()
 
+	if successCode == 0 {
+		log.Println("Running dynamic mounting tests...")
+		testEnv.mountDir = path.Join(setup.MntDir(), setup.TestBucket())
+		testEnv.mountFunc = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig
+		successCode = m.Run()
+	}
+
+	if successCode == 0 {
+		log.Println("Running only dir mounting tests...")
+		setup.SetOnlyDirMounted(onlyDirMounted + "/")
+		testEnv.mountDir = testEnv.rootDir
+		testEnv.mountFunc = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile
+		successCode = m.Run()
+		if err := client.DeleteAllObjectsWithPrefix(testEnv.ctx, testEnv.storageClient, path.Join(setup.OnlyDirMounted(), testDirName)); err != nil {
+			log.Printf("Error deleting object on GCS: %v", err)
+		}
+	}
+
+	setup.SaveLogFileInCaseOfFailure(successCode)
+	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	os.Exit(successCode)
 }


### PR DESCRIPTION
### Description
Move write_large_files test package to testify.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
