### PR TITLE
fix(integration_tests): fallback to MOUNTED_DIR environment variable correctly

### DIFF
--- a/tools/integration_tests/util/setup/setup.go
+++ b/tools/integration_tests/util/setup/setup.go
@@ -43,8 +43,11 @@ import (
 var isPresubmitRun = flag.Bool("presubmit", false, "Boolean flag to indicate if test-run is a presubmit run.")
 var isZonalBucketRun = flag.Bool("zonal", false, "Boolean flag to indicate if test-run should use a zonal bucket.")
 var isPirloBucketRun = flag.Bool("pirlo", false, "Boolean flag to indicate if test-run is for a Pirlo bucket.")
-var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test.")
-var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test.")
+
+// Note: testBucket and mountedDirectory can also be set via BUCKET_NAME and MOUNTED_DIR
+// environment variables respectively. However, command-line flags take precedence.
+var testBucket = flag.String("testbucket", "", "The GCS bucket used for the test. Can also be set via BUCKET_NAME env var.")
+var mountedDirectory = flag.String("mountedDirectory", "", "The GCSFuse mounted directory used for the test. Can also be set via MOUNTED_DIR env var.")
 var integrationTest = flag.Bool("integrationTest", false, "Run tests only when the flag value is true.")
 var testInstalledPackage = flag.Bool("testInstalledPackage", false, "[Optional] Run tests on the package pre-installed on the host machine. By default, integration tests build a new package to run the tests.")
 var testOnTPCEndPoint = flag.Bool("testOnTPCEndPoint", false, "Run tests on TPC endpoint only when the flag value is true.")
@@ -145,6 +148,9 @@ func TestOnTPCEndPoint() bool {
 }
 
 func MountedDirectory() string {
+	if *mountedDirectory == "" {
+		*mountedDirectory = os.Getenv("MOUNTED_DIR")
+	}
 	return *mountedDirectory
 }
 
@@ -692,6 +698,9 @@ func BuildFlagSets(cfg test_suite.TestConfig, bucketType string, testName string
 func SetGlobalVars(cfg *test_suite.TestConfig) {
 	if cfg.TestBucket == "" {
 		cfg.TestBucket = TestBucket()
+	}
+	if cfg.GKEMountedDirectory == "" {
+		cfg.GKEMountedDirectory = MountedDirectory()
 	}
 	// TODO: clean global variables after test migration to config file completes.
 	testBucket = &cfg.TestBucket


### PR DESCRIPTION
### Description
This pull request fixes the environment variable parsing for the mounted directory in the integration test suite. While `test_config.yaml` successfully evaluated the `MOUNTED_DIR` environment variable, the fallback logic inside `setup.go` did not cleanly map it to the underlying configuration structs when invoked locally or when the flag/env var was passed directly. 

Changes included:
* Enabled direct fallback to `os.Getenv("MOUNTED_DIR")` within the `setup.MountedDirectory()` global flag parser, mirroring the existing fallback behavior for `TestBucket()`.
* Updated `setup.SetGlobalVars` to explicitly fallback `cfg.GKEMountedDirectory` to the resolved command-line flag/environment string if it was absent in the YAML config.
* Added clarifying documentation comments to the flag registrations to explicitly denote environment variable support and order of precedence.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Verified that the integration tests can dynamically parse the `MOUNTED_DIR` environment variable through `go test` and fallback correctly in local executions.
2. Unit tests - N/A
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A
