### PR TITLE
refactor: remove requester pays billing project context injection from bucket handle

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -33,7 +33,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"google.golang.org/api/iterator"
-	"google.golang.org/grpc/metadata"
 )
 
 const FullFolderPathHNS = "projects/_/buckets/%s/folders/%s"
@@ -407,10 +406,6 @@ func (bh *bucketHandle) ListObjects(ctx context.Context, req *gcs.ListObjectsReq
 	if err != nil {
 		err = fmt.Errorf("error while setting attribute selection for List Object query :%w", err)
 		return
-	}
-
-	if bh.billingProject != "" {
-		ctx = metadata.AppendToOutgoingContext(ctx, "x-goog-user-project", bh.billingProject)
 	}
 
 	itr := bh.bucket.Objects(ctx, query) // Returning iterator to the list of objects.


### PR DESCRIPTION
### Description
This change was added to fix the requester pays bug for GRPC client protocol for listing. This has been fixed in Go-SDK so there is no need to handle it in GCSFuse.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
