### PR TITLE
feat: Adding new directpath fallback stragegy

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1206,7 +1206,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("gid", "", -1, "GID owner of all inodes.")
 
-	flagSet.StringP("grpc-path-strategy", "", "direct-path-with-fallback", "Strategy for DirectPath connectivity when client-protocol=grpc. Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available).")
+	flagSet.StringP("grpc-path-strategy", "", "direct-path-with-fallback", "Strategy for DirectPath connectivity when client-protocol=grpc. Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available), 'direct-path-with-grpc-fallback' (fallback to standard gRPC cloud path when direct path is not available).")
 
 	if err := flagSet.MarkHidden("grpc-path-strategy"); err != nil {
 		return err

--- a/cfg/decode_hook_test.go
+++ b/cfg/decode_hook_test.go
@@ -35,17 +35,18 @@ func bindFlag(t *testing.T, v *viper.Viper, key string, f *flag.Flag) {
 
 func TestParsingSuccess(t *testing.T) {
 	type TestConfig struct {
-		OctalParam       Octal
-		BoolParam        bool
-		StringParam      string
-		IntParam         int
-		FloatParam       float64
-		DurationParam    time.Duration
-		StringSliceParam []string
-		IntSliceParam    []int
-		LogSeverityParam LogSeverity
-		ProtocolParam    Protocol
-		PathParam        ResolvedPath
+		OctalParam              Octal
+		BoolParam               bool
+		StringParam             string
+		IntParam                int
+		FloatParam              float64
+		DurationParam           time.Duration
+		StringSliceParam        []string
+		IntSliceParam           []int
+		LogSeverityParam        LogSeverity
+		ProtocolParam           Protocol
+		PathParam               ResolvedPath
+		DirectPathStrategyParam DirectPathStrategy
 	}
 	declareFlags := func() *flag.FlagSet {
 		fs := flag.NewFlagSet("test", flag.ExitOnError)
@@ -60,6 +61,7 @@ func TestParsingSuccess(t *testing.T) {
 		fs.String("logSeverityParam", "INFO", "")
 		fs.String("protocolParam", "http1", "")
 		fs.String("pathParam", "", "")
+		fs.String("directPathStrategyParam", "direct-path-with-fallback", "")
 		return fs
 	}
 
@@ -77,6 +79,7 @@ func TestParsingSuccess(t *testing.T) {
 		bindFlag(t, v, "LogSeverityParam", fs.Lookup("logSeverityParam"))
 		bindFlag(t, v, "ProtocolParam", fs.Lookup("protocolParam"))
 		bindFlag(t, v, "PathParam", fs.Lookup("pathParam"))
+		bindFlag(t, v, "DirectPathStrategyParam", fs.Lookup("directPathStrategyParam"))
 		return v
 	}
 	tests := []struct {
@@ -212,6 +215,13 @@ func TestParsingSuccess(t *testing.T) {
 				assert.Equal(t, "/a/test.txt", string(c.PathParam))
 			},
 		},
+		{
+			name: "DirectPathStrategy - direct-path-with-grpc-fallback",
+			args: []string{"--directPathStrategyParam=direct-path-with-grpc-fallback"},
+			testFn: func(t *testing.T, c TestConfig) {
+				assert.Equal(t, DirectPathWithGrpcFallback, c.DirectPathStrategyParam)
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -286,7 +296,7 @@ func TestParsingError(t *testing.T) {
 		{
 			name:   "DirectPathStrategy",
 			args:   []string{"--directPathStrategyParam=invalid-strategy"},
-			errMsg: "invalid direct-path strategy value: invalid-strategy. It can only accept values in the list: [direct-path-only direct-path-with-fallback]",
+			errMsg: "invalid direct-path strategy value: invalid-strategy. It can only accept values in the list: [direct-path-only direct-path-with-fallback direct-path-with-grpc-fallback]",
 		},
 	}
 	for _, tc := range tests {

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -690,7 +690,7 @@ params:
     type: "directPathStrategy"
     usage: >-
       Strategy for DirectPath connectivity when client-protocol=grpc.
-      Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available).
+      Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available), 'direct-path-with-grpc-fallback' (fallback to standard gRPC when direct path is not available).
     default: "direct-path-with-fallback"
     hide-flag: true
 

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -690,7 +690,7 @@ params:
     type: "directPathStrategy"
     usage: >-
       Strategy for DirectPath connectivity when client-protocol=grpc.
-      Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available), 'direct-path-with-grpc-fallback' (fallback to standard gRPC when direct path is not available).
+      Options: 'direct-path-only' (fail if unavailable), 'direct-path-with-fallback' (always fallback to HTTP/1 when direct path is not available), 'direct-path-with-grpc-fallback' (fallback to standard gRPC cloud path when direct path is not available).
     default: "direct-path-with-fallback"
     hide-flag: true
 

--- a/cfg/types.go
+++ b/cfg/types.go
@@ -68,16 +68,18 @@ const (
 	DirectPathOnly DirectPathStrategy = "direct-path-only"
 	// DirectPathWithFallback falls back to HTTP/1 if DirectPath is unavailable.
 	DirectPathWithFallback DirectPathStrategy = "direct-path-with-fallback"
+	// DirectPathWithGrpcFallback falls back to standard gRPC cloud path if DirectPath is unavailable.
+	DirectPathWithGrpcFallback DirectPathStrategy = "direct-path-with-grpc-fallback"
 )
 
 func (d *DirectPathStrategy) UnmarshalText(text []byte) error {
 	strategy := DirectPathStrategy(strings.ToLower(string(text)))
 	switch strategy {
-	case DirectPathOnly, DirectPathWithFallback:
+	case DirectPathOnly, DirectPathWithFallback, DirectPathWithGrpcFallback:
 		*d = strategy
 		return nil
 	default:
-		validValues := []string{string(DirectPathOnly), string(DirectPathWithFallback)}
+		validValues := []string{string(DirectPathOnly), string(DirectPathWithFallback), string(DirectPathWithGrpcFallback)}
 		return fmt.Errorf("invalid direct-path strategy value: %s. It can only accept values in the list: %v", string(text), validValues)
 	}
 }

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -221,6 +221,16 @@ func TestValidateCliFlag(t *testing.T) {
 			args:    []string{"--fuse-max-write-size-kb=2048"},
 			wantErr: true,
 		},
+		{
+			name:    "valid grpc-path-strategy direct-path-with-grpc-fallback",
+			args:    []string{"--grpc-path-strategy=direct-path-with-grpc-fallback"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid grpc-path-strategy",
+			args:    []string{"--grpc-path-strategy=invalid-strategy"},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -898,6 +898,27 @@ func TestArgsParsing_GCSConnectionFlags(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test grpc-path-strategy direct-path-with-grpc-fallback",
+			args: []string{"gcsfuse", "--grpc-path-strategy=direct-path-with-grpc-fallback", "abc", "pqr"},
+			expectedConfig: &cfg.Config{
+				GcsConnection: cfg.GcsConnectionConfig{
+					BillingProject:             "",
+					ClientProtocol:             "http1",
+					CustomEndpoint:             "",
+					ExperimentalEnableJsonRead: false,
+					GrpcPathStrategy:           "direct-path-with-grpc-fallback",
+					GrpcConnPoolSize:           1,
+					HttpClientTimeout:          0,
+					LimitBytesPerSec:           -1,
+					LimitOpsPerSec:             -1,
+					MaxConnsPerHost:            0,
+					MaxIdleConnsPerHost:        100,
+					SequentialReadSizeMb:       200,
+					EnableHttpDnsCache:         true,
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -63,6 +63,9 @@ const (
 
 	// nonExistentObjectName is the object name used for bucket existence/access check when HNS feature is disabled by providing "--enable-hns:false". E.g. Using Regional Endpoints which do not support GRPC protocol.
 	nonExistentObjectName = "gcsfuse-nonexistent-object-check"
+
+	// directPathVerificationErrorPrefix is the prefix used for errors returned when DirectPath verification fails.
+	directPathVerificationErrorPrefix = "DirectPath verification failed for bucket"
 )
 
 type StorageHandle interface {
@@ -187,7 +190,7 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string, verifyDirectPath bool) (*storage.Client, error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -199,8 +202,10 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	if verifyDirectPath {
+		// Add DirectPath enforcement - client creation will fail if DirectPath is not available
+		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	}
 
 	sc, err := storage.NewGRPCClient(ctx, clientOpts...)
 	if err != nil {
@@ -212,6 +217,10 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		logger.Infof("Applying production retry config after DirectPath verification.")
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
+
+	if !verifyDirectPath {
+		return sc, nil
+	}
 
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
 	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
@@ -256,7 +265,7 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
-		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
+		return fmt.Errorf("%s %q: %w", directPathVerificationErrorPrefix, bucketName, statErr)
 	}
 
 	return nil
@@ -471,7 +480,7 @@ func (sh *storageClient) getClient(ctx context.Context, isBucketRapid bool, buck
 	var err error
 	if isBucketRapid {
 		if sh.grpcClientWithBidiConfig == nil {
-			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isBucketRapid, true, bucketName, billingProject)
+			sh.grpcClientWithBidiConfig, err = createGRPCClientHandle(ctx, &sh.clientConfig, isBucketRapid, true, bucketName, billingProject, true)
 		}
 		return sh.grpcClientWithBidiConfig, err
 	}
@@ -496,14 +505,28 @@ func (sh *storageClient) createNonBidiGRPCClientWithHttpFallback(ctx context.Con
 	}
 
 	var err error
-	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, false, bucketName, billingProject)
+	verifyDirectPath := sh.clientConfig.GrpcPathStrategy != cfg.DirectPathWithGrpcFallback
+	sh.grpcClient, err = createGRPCClientHandle(ctx, &sh.clientConfig, false, false, bucketName, billingProject, verifyDirectPath)
 	// No error means we are able to successfully create a grpc client with direct path. Return it.
 	if err == nil {
 		return sh.grpcClient, nil
 	}
 
+	// Check if the error is due to DP failure. If not, return it.
+	if !isDirectPathFailure(err) {
+		logger.Errorf("Grpc client creation failed with non-DirectPath error: %v", err)
+		return nil, err
+	}
+
 	// We will reach here when we failed to create a grpc client with direct path.
-	// Decide whether to create a http client based on grpPathStrategy param.
+	// Decide what to do based on grpPathStrategy param.
+	// Ideally this condition will never be true, since we are checking for non-DP error above.
+	if sh.clientConfig.GrpcPathStrategy == cfg.DirectPathWithGrpcFallback {
+		// We already tried standard gRPC (since verifyDirectPath was false).
+		// No need to retry. Just return the error.
+		return nil, err
+	}
+
 	if sh.clientConfig.GrpcPathStrategy == cfg.DirectPathOnly {
 		logger.Infof("Grpc dp is not available and not falling back to Http as gRPC path strategy is set to DirectPathOnly")
 		return nil, err
@@ -559,4 +582,11 @@ func (sh *storageClient) BucketHandle(ctx context.Context, bucketName string, bi
 	}
 
 	return
+}
+
+func isDirectPathFailure(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), directPathVerificationErrorPrefix)
 }

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -217,7 +217,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// Set the production level retry config.
 	defer func() {
-		logger.Infof("Applying production retry config after DirectPath verification.")
+		logger.Infof("Applying production retry config.")
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -56,16 +56,19 @@ const (
 
 	zonalLocationType = "zone"
 
-	// DirectPath detection parameters - used for fast-fail detection during client creation
-	directPathDetectionMaxAttempts = 5
-	directPathDetectionTimeout     = 15 * time.Second
-	directPathDetectionMaxBackoff  = 5 * time.Second
-
 	// nonExistentObjectName is the object name used for bucket existence/access check when HNS feature is disabled by providing "--enable-hns:false". E.g. Using Regional Endpoints which do not support GRPC protocol.
 	nonExistentObjectName = "gcsfuse-nonexistent-object-check"
 
 	// directPathVerificationErrorPrefix is the prefix used for errors returned when DirectPath verification fails.
 	directPathVerificationErrorPrefix = "DirectPath verification failed for bucket"
+)
+
+// Keeping these as variables instead of constants to overwrite the values in unit tests.
+var (
+	// DirectPath detection parameters - used for fast-fail detection during client creation
+	directPathDetectionMaxAttempts = 5
+	directPathDetectionTimeout     = 15 * time.Second
+	directPathDetectionMaxBackoff  = 5 * time.Second
 )
 
 type StorageHandle interface {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1048,3 +1048,126 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_Exhausts
 	assert.ErrorContains(testSuite.T(), err, "bucket access check failed")
 	assert.Equal(testSuite.T(), testMaxRetryAttempts, *attempts, "expected max retry attempts to be exhausted")
 }
+
+func (testSuite *StorageHandleTest) TestIsDirectPathFailure() {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "generic error (not DP)",
+			err:      fmt.Errorf("some error"),
+			expected: false,
+		},
+		{
+			name:     "NewGRPCClient error (not DP)",
+			err:      fmt.Errorf("NewGRPCClient: some config error"),
+			expected: false,
+		},
+		{
+			name:     "DirectPath verification failed error (is DP)",
+			err:      fmt.Errorf("%s %q: some network error", directPathVerificationErrorPrefix, "my-bucket"),
+			expected: true,
+		},
+		{
+			name:     "wrapped DirectPath verification failed error (is DP)",
+			err:      fmt.Errorf("wrapped: %w", fmt.Errorf("%s %q: timeout", directPathVerificationErrorPrefix, "my-bucket")),
+			expected: true,
+		},
+	}
+
+	for _, tc := range tests {
+		testSuite.Run(tc.name, func() {
+			actual := isDirectPathFailure(tc.err)
+
+			assert.Equal(testSuite.T(), tc.expected, actual)
+		})
+	}
+}
+
+func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategies() {
+	tests := []struct {
+		name             string
+		strategy         cfg.DirectPathStrategy
+		expectHttpClient bool
+		expectGrpcClient bool
+		expectErr        bool
+	}{
+		{
+			name:             "DirectPathOnly - fails on DP verification",
+			strategy:         cfg.DirectPathOnly,
+			expectHttpClient: false,
+			expectGrpcClient: false,
+			expectErr:        true,
+		},
+		{
+			name:             "DirectPathWithFallback - falls back to HTTP on DP verification failure",
+			strategy:         cfg.DirectPathWithFallback,
+			expectHttpClient: true,
+			expectGrpcClient: false,
+			expectErr:        false,
+		},
+		{
+			name:             "DirectPathWithGrpcFallback - uses standard gRPC directly (no verification)",
+			strategy:         cfg.DirectPathWithGrpcFallback,
+			expectHttpClient: false,
+			expectGrpcClient: true,
+			expectErr:        false,
+		},
+	}
+
+	for _, tc := range tests {
+		testSuite.Run(tc.name, func() {
+			// Create a storageClient without pre-populated clients.
+			// Point custom endpoint to a non-listening address to force DP verification failure.
+			sh := &storageClient{
+				clientConfig: storageutil.StorageClientConfig{
+					ClientProtocol:     cfg.GRPC,
+					GrpcPathStrategy:   tc.strategy,
+					CustomEndpoint:     "http://localhost:54321", // Non-listening port
+					AnonymousAccess:    true,                     // Avoid auth issues
+					EnableMountRetries: false,
+				},
+			}
+
+			client, err := sh.getClient(testSuite.ctx, false, "some-bucket", "")
+
+			if tc.expectErr {
+				assert.Error(testSuite.T(), err)
+				assert.Nil(testSuite.T(), client)
+			} else {
+				assert.NoError(testSuite.T(), err)
+				assert.NotNil(testSuite.T(), client)
+			}
+
+			if tc.expectHttpClient {
+				assert.NotNil(testSuite.T(), sh.httpClient)
+				assert.Equal(testSuite.T(), sh.httpClient, client)
+				assert.Nil(testSuite.T(), sh.grpcClient)
+			} else {
+				assert.Nil(testSuite.T(), sh.httpClient)
+			}
+
+			if tc.expectGrpcClient {
+				assert.NotNil(testSuite.T(), sh.grpcClient)
+				assert.Equal(testSuite.T(), sh.grpcClient, client)
+			} else if !tc.expectErr {
+				assert.Nil(testSuite.T(), sh.grpcClient)
+			}
+
+			// Clean up if clients were created
+			if sh.httpClient != nil {
+				_ = sh.httpClient.Close()
+			}
+			if sh.grpcClient != nil {
+				_ = sh.grpcClient.Close()
+			}
+		})
+	}
+}

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1091,83 +1091,72 @@ func (testSuite *StorageHandleTest) TestIsDirectPathFailure() {
 	}
 }
 
-func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategies() {
-	tests := []struct {
-		name             string
-		strategy         cfg.DirectPathStrategy
-		expectHttpClient bool
-		expectGrpcClient bool
-		expectErr        bool
-	}{
-		{
-			name:             "DirectPathOnly - fails on DP verification",
-			strategy:         cfg.DirectPathOnly,
-			expectHttpClient: false,
-			expectGrpcClient: false,
-			expectErr:        true,
-		},
-		{
-			name:             "DirectPathWithFallback - falls back to HTTP on DP verification failure",
-			strategy:         cfg.DirectPathWithFallback,
-			expectHttpClient: true,
-			expectGrpcClient: false,
-			expectErr:        false,
-		},
-		{
-			name:             "DirectPathWithGrpcFallback - uses standard gRPC directly (no verification)",
-			strategy:         cfg.DirectPathWithGrpcFallback,
-			expectHttpClient: false,
-			expectGrpcClient: true,
-			expectErr:        false,
+func (testSuite *StorageHandleTest) setupStorageClientForGrpcPathStrategyTest(strategy cfg.DirectPathStrategy) *storageClient {
+	// Override DirectPath detection parameters to make tests fast.
+	oldMaxAttempts := directPathDetectionMaxAttempts
+	oldTimeout := directPathDetectionTimeout
+	oldMaxBackoff := directPathDetectionMaxBackoff
+
+	directPathDetectionMaxAttempts = 1
+	directPathDetectionTimeout = 10 * time.Millisecond
+	directPathDetectionMaxBackoff = 1 * time.Millisecond
+
+	testSuite.T().Cleanup(func() {
+		directPathDetectionMaxAttempts = oldMaxAttempts
+		directPathDetectionTimeout = oldTimeout
+		directPathDetectionMaxBackoff = oldMaxBackoff
+	})
+
+	return &storageClient{
+		clientConfig: storageutil.StorageClientConfig{
+			ClientProtocol:     cfg.GRPC,
+			GrpcPathStrategy:   strategy,
+			CustomEndpoint:     "http://localhost:54321", // Non-listening port
+			AnonymousAccess:    true,                     // Avoid auth issues
+			EnableMountRetries: false,
 		},
 	}
+}
 
-	for _, tc := range tests {
-		testSuite.Run(tc.name, func() {
-			// Create a storageClient without pre-populated clients.
-			// Point custom endpoint to a non-listening address to force DP verification failure.
-			sh := &storageClient{
-				clientConfig: storageutil.StorageClientConfig{
-					ClientProtocol:     cfg.GRPC,
-					GrpcPathStrategy:   tc.strategy,
-					CustomEndpoint:     "http://localhost:54321", // Non-listening port
-					AnonymousAccess:    true,                     // Avoid auth issues
-					EnableMountRetries: false,
-				},
-			}
+func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategy_DirectPathOnly() {
+	sh := testSuite.setupStorageClientForGrpcPathStrategyTest(cfg.DirectPathOnly)
 
-			client, err := sh.getClient(testSuite.ctx, false, "some-bucket", "")
+	client, err := sh.getClient(testSuite.ctx, false, "some-bucket", "")
 
-			if tc.expectErr {
-				assert.Error(testSuite.T(), err)
-				assert.Nil(testSuite.T(), client)
-			} else {
-				assert.NoError(testSuite.T(), err)
-				assert.NotNil(testSuite.T(), client)
-			}
+	assert.Error(testSuite.T(), err)
+	assert.Nil(testSuite.T(), client)
+	assert.Nil(testSuite.T(), sh.httpClient)
+	assert.Nil(testSuite.T(), sh.grpcClient)
+}
 
-			if tc.expectHttpClient {
-				assert.NotNil(testSuite.T(), sh.httpClient)
-				assert.Equal(testSuite.T(), sh.httpClient, client)
-				assert.Nil(testSuite.T(), sh.grpcClient)
-			} else {
-				assert.Nil(testSuite.T(), sh.httpClient)
-			}
+func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategy_DirectPathWithFallback() {
+	sh := testSuite.setupStorageClientForGrpcPathStrategyTest(cfg.DirectPathWithFallback)
 
-			if tc.expectGrpcClient {
-				assert.NotNil(testSuite.T(), sh.grpcClient)
-				assert.Equal(testSuite.T(), sh.grpcClient, client)
-			} else if !tc.expectErr {
-				assert.Nil(testSuite.T(), sh.grpcClient)
-			}
+	client, err := sh.getClient(testSuite.ctx, false, "some-bucket", "")
 
-			// Clean up if clients were created
-			if sh.httpClient != nil {
-				_ = sh.httpClient.Close()
-			}
-			if sh.grpcClient != nil {
-				_ = sh.grpcClient.Close()
-			}
-		})
+	assert.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), client)
+	assert.NotNil(testSuite.T(), sh.httpClient)
+	assert.Equal(testSuite.T(), sh.httpClient, client)
+	assert.Nil(testSuite.T(), sh.grpcClient)
+
+	if sh.httpClient != nil {
+		_ = sh.httpClient.Close()
+	}
+}
+
+func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategy_DirectPathWithGrpcFallback() {
+	sh := testSuite.setupStorageClientForGrpcPathStrategyTest(cfg.DirectPathWithGrpcFallback)
+
+	client, err := sh.getClient(testSuite.ctx, false, "some-bucket", "")
+
+	assert.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), client)
+	assert.NotNil(testSuite.T(), sh.grpcClient)
+	assert.Equal(testSuite.T(), sh.grpcClient, client)
+	assert.Nil(testSuite.T(), sh.httpClient)
+
+	if sh.grpcClient != nil {
+		_ = sh.grpcClient.Close()
 	}
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1139,7 +1139,6 @@ func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategy_DirectPathWit
 	assert.NotNil(testSuite.T(), sh.httpClient)
 	assert.Equal(testSuite.T(), sh.httpClient, client)
 	assert.Nil(testSuite.T(), sh.grpcClient)
-
 	if sh.httpClient != nil {
 		_ = sh.httpClient.Close()
 	}
@@ -1155,7 +1154,6 @@ func (testSuite *StorageHandleTest) TestGetClient_GrpcPathStrategy_DirectPathWit
 	assert.NotNil(testSuite.T(), sh.grpcClient)
 	assert.Equal(testSuite.T(), sh.grpcClient, client)
 	assert.Nil(testSuite.T(), sh.httpClient)
-
 	if sh.grpcClient != nil {
 		_ = sh.grpcClient.Close()
 	}


### PR DESCRIPTION
Today we only support using gRPC with directPath and fallback to http when directPath is not available.

Added a new option to use gRPC Cloud path when direct path is not available.

### Testing details
1. Manual - Done
2. Unit tests - Done
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
