### PR TITLE
fix(gke): Fixing GKE tests for rapid_operations package on master.

### DIFF
--- a/tools/integration_tests/rapid_operations/finalize_test.go
+++ b/tools/integration_tests/rapid_operations/finalize_test.go
@@ -16,6 +16,7 @@ package rapid_operations
 
 import (
 	"path"
+	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -26,6 +27,9 @@ import (
 )
 
 func (t *FinalizeRapidWritesEnabledSuite) TestFileClosedInFinalizedState() {
+	if !t.isFinalizeEnabled {
+		t.T().Skip("Skipping test since finalize-file-for-rapid is false")
+	}
 	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
 	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
 	defer t.deleteUnfinalizedObject()
@@ -41,6 +45,9 @@ func (t *FinalizeRapidWritesEnabledSuite) TestFileClosedInFinalizedState() {
 }
 
 func (t *FinalizeRapidWritesDisabledSuite) TestFileClosedInUnfinalizedState() {
+	if t.isFinalizeEnabled {
+		t.T().Skip("Skipping test since finalize-file-for-rapid is true")
+	}
 	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
 	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
 	defer t.deleteUnfinalizedObject()
@@ -62,7 +69,8 @@ func (t *FinalizeRapidWritesDisabledSuite) TestFileClosedInUnfinalizedState() {
 func TestFinalizeRapidWritesEnabledSuite(t *testing.T) {
 	RunTests(t, "TestFinalizeRapidWritesEnabledSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
 		return &FinalizeRapidWritesEnabledSuite{
-			BaseSuite: BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+			BaseSuite:         BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+			isFinalizeEnabled: strings.Contains(strings.Join(primaryFlags, " "), "finalize-file-for-rapid=true"),
 		}
 	})
 }
@@ -70,7 +78,8 @@ func TestFinalizeRapidWritesEnabledSuite(t *testing.T) {
 func TestFinalizeRapidWritesDisabledSuite(t *testing.T) {
 	RunTests(t, "TestFinalizeRapidWritesDisabledSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
 		return &FinalizeRapidWritesDisabledSuite{
-			BaseSuite: BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+			BaseSuite:         BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+			isFinalizeEnabled: strings.Contains(strings.Join(primaryFlags, " "), "finalize-file-for-rapid=true"),
 		}
 	})
 }

--- a/tools/integration_tests/rapid_operations/finalize_test.go
+++ b/tools/integration_tests/rapid_operations/finalize_test.go
@@ -16,7 +16,6 @@ package rapid_operations
 
 import (
 	"path"
-	"strings"
 	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -26,10 +25,7 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func (t *FinalizeRapidWritesTestSuite) TestFileClosedInFinalizedState() {
-	if !t.isFinalizeEnabled {
-		t.T().Skip("Skipping test since finalize-file-for-rapid is false")
-	}
+func (t *FinalizeRapidWritesEnabledSuite) TestFileClosedInFinalizedState() {
 	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
 	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
 	defer t.deleteUnfinalizedObject()
@@ -44,10 +40,7 @@ func (t *FinalizeRapidWritesTestSuite) TestFileClosedInFinalizedState() {
 	assert.False(t.T(), attrs.Finalized.IsZero(), "Finalized field should not be zero for a finalized object")
 }
 
-func (t *FinalizeRapidWritesTestSuite) TestFileClosedInUnfinalizedState() {
-	if t.isFinalizeEnabled {
-		t.T().Skip("Skipping test since finalize-file-for-rapid is true")
-	}
+func (t *FinalizeRapidWritesDisabledSuite) TestFileClosedInUnfinalizedState() {
 	t.fileName = fileNamePrefix + setup.GenerateRandomString(5)
 	filePath := path.Join(t.primaryMount.testDirPath, t.fileName)
 	defer t.deleteUnfinalizedObject()
@@ -66,11 +59,18 @@ func (t *FinalizeRapidWritesTestSuite) TestFileClosedInUnfinalizedState() {
 // Test Runner
 ////////////////////////////////////////////////////////////////////////
 
-func TestFinalizeRapidWritesTestSuite(t *testing.T) {
-	RunTests(t, "TestFinalizeRapidWritesTestSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
-		return &FinalizeRapidWritesTestSuite{
-			BaseSuite:         BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
-			isFinalizeEnabled: strings.Contains(strings.Join(primaryFlags, " "), "finalize-file-for-rapid=true"),
+func TestFinalizeRapidWritesEnabledSuite(t *testing.T) {
+	RunTests(t, "TestFinalizeRapidWritesEnabledSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
+		return &FinalizeRapidWritesEnabledSuite{
+			BaseSuite: BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
+		}
+	})
+}
+
+func TestFinalizeRapidWritesDisabledSuite(t *testing.T) {
+	RunTests(t, "TestFinalizeRapidWritesDisabledSuite", func(primaryFlags, secondaryFlags []string) suite.TestingSuite {
+		return &FinalizeRapidWritesDisabledSuite{
+			BaseSuite: BaseSuite{primaryFlags: primaryFlags, secondaryFlags: secondaryFlags},
 		}
 	})
 }

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -73,10 +73,16 @@ type SingleMountAppendsTestSuite struct{ BaseSuite }
 type DualMountAppendsTestSuite struct{ BaseSuite }
 
 // FinalizeRapidWritesEnabledSuite groups tests for verifying transition to finalized state when enabled.
-type FinalizeRapidWritesEnabledSuite struct{ BaseSuite }
+type FinalizeRapidWritesEnabledSuite struct {
+	BaseSuite
+	isFinalizeEnabled bool
+}
 
 // FinalizeRapidWritesDisabledSuite groups tests for verifying transition to finalized state when disabled.
-type FinalizeRapidWritesDisabledSuite struct{ BaseSuite }
+type FinalizeRapidWritesDisabledSuite struct {
+	BaseSuite
+	isFinalizeEnabled bool
+}
 
 // StatAndListTestSuite groups tests for checking new file discovery.
 type StatAndListTestSuite struct{ BaseSuite }

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -101,17 +101,18 @@ func (t *BaseSuite) SetupTest() {
 
 		if len(t.secondaryFlags) > 0 {
 			t.secondaryMount.mntDir = testEnv.cfg.GKEMountedDirectorySecondary
-			t.secondaryMount.testDirPath = path.Join(t.secondaryMount.mntDir, testDirName)
+			setup.SetMntDir(t.secondaryMount.mntDir)
+			t.secondaryMount.testDirPath = setup.SetupTestDirectory(testDirName)
 		}
 	} else {
 		// GCE Mode: Mount it
 		t.primaryMount.setupTestDir(testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.LogFile)
-		t.mountGcsfuse(t.primaryMount, "primary", t.primaryFlags)
+		t.mountGcsfuse(&t.primaryMount, "primary", t.primaryFlags)
 
 		if len(t.secondaryFlags) > 0 {
 			secondaryLog := path.Join(path.Dir(testEnv.cfg.LogFile), "gcsfuse_secondary.log")
 			t.secondaryMount.setupTestDir(testEnv.cfg.GCSFuseMountedDirectorySecondary, secondaryLog)
-			t.mountGcsfuse(t.secondaryMount, "secondary", t.secondaryFlags)
+			t.mountGcsfuse(&t.secondaryMount, "secondary", t.secondaryFlags)
 		}
 	}
 }
@@ -133,9 +134,9 @@ func (t *BaseSuite) TearDownTest() {
 		setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))
 	} else {
 		// GCE Mode: Unmount and clean up
-		t.unmountAndCleanupMount(t.primaryMount, "primary")
+		t.unmountAndCleanupMount(&t.primaryMount)
 		if len(t.secondaryFlags) > 0 {
-			t.unmountAndCleanupMount(t.secondaryMount, "secondary")
+			t.unmountAndCleanupMount(&t.secondaryMount)
 		}
 	}
 }
@@ -151,7 +152,7 @@ func (mnt *mountPoint) setupTestDir(mountDir, logFile string) {
 	mnt.testDirPath = path.Join(mountDir, testDirName)
 }
 
-func (t *BaseSuite) mountGcsfuse(mnt mountPoint, mountType string, flags []string) {
+func (t *BaseSuite) mountGcsfuse(mnt *mountPoint, mountType string, flags []string) {
 	setup.SetMntDir(mnt.mntDir)
 	setup.SetLogFile(mnt.logFilePath)
 	err := static_mounting.MountGcsfuseWithStaticMounting(flags)
@@ -160,7 +161,7 @@ func (t *BaseSuite) mountGcsfuse(mnt mountPoint, mountType string, flags []strin
 	log.Printf("Running tests with %s mount flags %v", mountType, flags)
 }
 
-func (t *BaseSuite) unmountAndCleanupMount(m mountPoint, name string) {
+func (t *BaseSuite) unmountAndCleanupMount(m *mountPoint) {
 	setup.UnmountGCSFuse(m.mntDir)
 	// Cleaning up the intermediate generated test files.
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(setup.TestBucket(), testDirName))

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -89,8 +89,9 @@ func (t *BaseSuite) SetupTest() {
 	if testEnv.cfg.GKEMountedDirectory != "" {
 		// GKE Mode: Already mounted
 		t.primaryMount.mntDir = testEnv.cfg.GKEMountedDirectory
-		t.primaryMount.testDirPath = path.Join(t.primaryMount.mntDir, testDirName)
 		t.primaryMount.logFilePath = testEnv.cfg.LogFile // Might be empty, but that's fine for GKE
+		setup.SetMntDir(t.primaryMount.mntDir)
+		t.primaryMount.testDirPath = setup.SetupTestDirectory(testDirName)
 
 		if len(t.secondaryFlags) > 0 {
 			t.secondaryMount.mntDir = testEnv.cfg.GKEMountedDirectorySecondary

--- a/tools/integration_tests/rapid_operations/suites_test.go
+++ b/tools/integration_tests/rapid_operations/suites_test.go
@@ -72,11 +72,11 @@ type SingleMountAppendsTestSuite struct{ BaseSuite }
 // DualMountAppendsTestSuite groups general dual-mount tests for append behavior.
 type DualMountAppendsTestSuite struct{ BaseSuite }
 
-// FinalizeRapidWritesTestSuite groups tests for verifying transition to finalized state.
-type FinalizeRapidWritesTestSuite struct {
-	BaseSuite
-	isFinalizeEnabled bool
-}
+// FinalizeRapidWritesEnabledSuite groups tests for verifying transition to finalized state when enabled.
+type FinalizeRapidWritesEnabledSuite struct{ BaseSuite }
+
+// FinalizeRapidWritesDisabledSuite groups tests for verifying transition to finalized state when disabled.
+type FinalizeRapidWritesDisabledSuite struct{ BaseSuite }
 
 // StatAndListTestSuite groups tests for checking new file discovery.
 type StatAndListTestSuite struct{ BaseSuite }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1649,6 +1649,22 @@ rapid_operations:
         run_on_gke: true
       - run: TestFinalizeRapidWritesEnabledSuite
         flags:
+          - "--finalize-file-for-rapid=true"
+        compatible:
+          flat: false
+          hns: false
+          zonal: true
+        run_on_gke: true
+      - run: TestFinalizeRapidWritesDisabledSuite
+        flags:
+          - "--finalize-file-for-rapid=false"
+        compatible:
+          flat: false
+          hns: false
+          zonal: true
+        run_on_gke: true
+      - run: TestFinalizeRapidWritesEnabledSuite
+        flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=true"
         run_on_pirlo:
           flat:

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1647,18 +1647,19 @@ rapid_operations:
             same_zone: true
             different_zone: false
         run_on_gke: true
-      - run: TestFinalizeRapidWritesTestSuite
-        flags:
-          - "--finalize-file-for-rapid=true"
-          - "--finalize-file-for-rapid=false"
-        compatible:
-          flat: false
-          hns: false
-          zonal: true
-        run_on_gke: true
-      - run: TestFinalizeRapidWritesTestSuite
+      - run: TestFinalizeRapidWritesEnabledSuite
         flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=true"
+        run_on_pirlo:
+          flat:
+            same_zone: true
+            different_zone: false
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: true
+      - run: TestFinalizeRapidWritesDisabledSuite
+        flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--finalize-file-for-rapid=false"
         run_on_pirlo:
           hns:


### PR DESCRIPTION
### Description
Cherry pick changes from #4962 to master.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
