### PR TITLE
test(mounting): verify the config is dumped to the log file

### DIFF
--- a/tools/integration_tests/mounting/gcsfuse_test.go
+++ b/tools/integration_tests/mounting/gcsfuse_test.go
@@ -16,6 +16,7 @@ package integration_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -625,6 +626,65 @@ func (t *GcsfuseTest) LogFilePath() {
 		util.Unmount(t.dir)
 		ExpectEq(nil, err)
 	}
+}
+
+// logHasConfigRecordWithKey reports whether the JSON-formatted log in contents
+// holds a "GCSFuse Config" record carrying the given key.
+func logHasConfigRecordWithKey(contents []byte, key string) bool {
+	for _, line := range bytes.Split(contents, []byte("\n")) {
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+
+		var record map[string]any
+		if err := json.Unmarshal(line, &record); err != nil {
+			// Skip anything that isn't a structured log record.
+			continue
+		}
+		if record["message"] != "GCSFuse Config" {
+			continue
+		}
+		if _, ok := record[key]; ok {
+			return true
+		}
+	}
+
+	return false
+}
+
+// gcsfuse dumps the configuration it was started with to the log file, which is
+// useful when debugging a mount after the fact. Assert only that the dump
+// happens, not which flags it contains, to avoid a change-detector test.
+func (t *GcsfuseTest) ConfigIsDumpedToLogFile() {
+	// Keep the log outside t.dir, which is the mount point and must be empty for
+	// TearDown to remove it.
+	logFile, err := os.CreateTemp("", "gcsfuse_config_dump_*.log")
+	AssertEq(nil, err)
+	AssertEq(nil, logFile.Close())
+	defer func() { _ = os.Remove(logFile.Name()) }()
+
+	err = t.runGcsfuse([]string{
+		"--log-file", logFile.Name(),
+		canned.FakeBucketName,
+		t.dir,
+	})
+	AssertEq(nil, err)
+	// Best-effort cleanup; a failure here surfaces via TearDown, which cannot
+	// remove the mount point while it is still mounted.
+	defer func() { _ = util.Unmount(t.dir) }()
+
+	contents, err := os.ReadFile(logFile.Name())
+	AssertEq(nil, err)
+	AssertLt(0, len(contents))
+
+	// The flags supplied on the command line and the fully resolved config are
+	// logged as separate records.
+	ExpectTrue(
+		logHasConfigRecordWithKey(contents, "CLI Flags"),
+		"log did not contain a CLI flags dump:\n%s", contents)
+	ExpectTrue(
+		logHasConfigRecordWithKey(contents, "Full Config"),
+		"log did not contain a resolved config dump:\n%s", contents)
 }
 
 func (t *GcsfuseTest) KeyFilePath() {


### PR DESCRIPTION
Fixes #2134

## What

gcsfuse dumps the configuration it was started with into the log file, which is relied upon when debugging a mount after the fact, but nothing covered that the dump actually happens. This adds an integration test for it.

The test mounts against the canned fake bucket with `--log-file` and asserts that the log holds the two `GCSFuse Config` records emitted by `logGCSFuseMountInformation`: the flags supplied on the command line (`CLI Flags`), and the fully resolved config (`Full Config`).

Per the acceptance criteria on the issue, the assertion only checks that each record is present and carries the expected key — not which flags it contains — so this does not become a change-detector test that has to be updated for every new config param.

It goes in `tools/integration_tests/mounting`, alongside the existing `LogFilePath` test that already exercises `--log-file`. That package is already registered in `improved_run_e2e_tests.sh`, so no test-script change is needed.

## Testing

Run locally on Linux. The `mounting` package uses `canned.FakeBucketName`, so no real bucket is involved:

```
GODEBUG=asyncpreemptoff=1 CGO_ENABLED=0 go test ./tools/integration_tests/mounting/... \
  -p 1 -short --integrationTest --timeout=15m -v
```

```
[ RUN      ] GcsfuseTest.ConfigIsDumpedToLogFile
[       OK ] GcsfuseTest.ConfigIsDumpedToLogFile (999ms)
--- PASS: TestGcsfuse (37.08s)
ok  github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/mounting  66.2s
```

To confirm the test actually fails when the dump is missing rather than passing vacuously, I temporarily commented out the `logGCSFuseMountInformation(mountInfo)` call in `cmd/legacy_main.go` and re-ran:

```
[ RUN      ] GcsfuseTest.ConfigIsDumpedToLogFile
Expected: true
Actual:   false
log did not contain a CLI flags dump:
[  FAILED  ] GcsfuseTest.ConfigIsDumpedToLogFile
```

Every other test in the package still passed in that run, so the assertion is targeted at the dump specifically. The change was reverted before committing.

Also verified: `go build ./...`, `go vet ./tools/integration_tests/mounting/... ./cmd/...`, `gofmt -l` clean, and the unit suite (43 packages, 0 failures).

## Notes

* The issue mentions the config also going to stdout in foreground mode. I scoped this to the log file to match the stated acceptance criteria and keep the diff small — happy to add a foreground/stdout case in a follow-up if you'd like it covered too.
* Unrelated pre-existing nit I noticed while running the suite: `LogFilePath` and `KeyFilePath` pass a relative `test.txt`, which leaves an untracked `tools/integration_tests/mounting/test.txt.stderr` behind after a run. Left alone here to keep this change focused.
