### PR TITLE
fix(integration_tests on gke): disable mounting test suite on GKE for httpmtls protocol

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1191,7 +1191,7 @@ mounting:
           flat: true
           hns: true
           zonal: false
-        run_on_gke: true
+        run_on_gke: false
       - flags:
           - "--experimental-enable-pirlo,--client-protocol=http1"
         run_on_pirlo:


### PR DESCRIPTION
### Description
Mounting integration test package is not suppose to run on GKE as it literally tries to mount GCSFuse which is not possible on GKE environment. This was accidentally enabled in #4948 for httpmtls protocol.

<img width="3398" height="364" alt="image" src="https://github.com/user-attachments/assets/fe60ec8a-212e-477b-9a26-7ea9a5b03780" />

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
