### PR TITLE
refactor: migrate context package imports from golang.org/x/net/context to standard library context

### DIFF
--- a/benchmarks/stat_files/main.go
+++ b/benchmarks/stat_files/main.go
@@ -26,7 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/sync/errgroup"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/benchmarks/internal/format"

--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -34,6 +34,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"golang.org/x/sys/unix"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/common"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/canned"
@@ -50,7 +52,6 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/kardianos/osext"
 	"github.com/spf13/viper"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/cmd/mount.go
+++ b/cmd/mount.go
@@ -19,6 +19,8 @@ import (
 	"os"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/kernelparams"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/mount"
@@ -26,7 +28,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/spf13/viper"
-	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.44.0
 	go.opentelemetry.io/otel/sdk/metric v1.44.0
 	go.opentelemetry.io/otel/trace v1.44.0
-	golang.org/x/net v0.55.0
 	golang.org/x/oauth2 v0.36.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/sys v0.46.0
@@ -102,6 +101,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.52.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	google.golang.org/genproto v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260519071638-aa98bba5eb94 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/internal/cache/file/downloader/job.go
+++ b/internal/cache/file/downloader/job.go
@@ -34,7 +34,8 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/sync/semaphore"
 )
 

--- a/internal/cache/file/downloader/job_testify_test.go
+++ b/internal/cache/file/downloader/job_testify_test.go
@@ -24,10 +24,11 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util/diskutil"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/semaphore"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"

--- a/internal/cache/file/downloader/job_testify_test.go
+++ b/internal/cache/file/downloader/job_testify_test.go
@@ -83,7 +83,9 @@ func (t *JobTestifyTest) initReadCacheTestifyTest(objectName string, objectConte
 }
 
 func (t *JobTestifyTest) SetupTest() {
-	t.ctx, _ = context.WithCancel(context.Background())
+	var cancel context.CancelFunc
+	t.ctx, cancel = context.WithCancel(context.Background())
+	t.T().Cleanup(cancel)
 	t.mockBucket = new(storage.TestifyMockBucket)
 }
 

--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -51,7 +51,9 @@ func (t *ParallelDownloaderJobTestifyTest) SetupTest() {
 		EnableCrc:                true,
 		WriteBufferSize:          4 * 1024 * 1024,
 	}
-	t.ctx, _ = context.WithCancel(context.Background())
+	var cancel context.CancelFunc
+	t.ctx, cancel = context.WithCancel(context.Background())
+	t.T().Cleanup(cancel)
 	t.mockBucket = new(storage.TestifyMockBucket)
 }
 

--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -21,6 +21,8 @@ import (
 	"sync"
 	"testing"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
@@ -31,7 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 type ParallelDownloaderJobTestifyTest struct {

--- a/internal/canned/canned.go
+++ b/internal/canned/canned.go
@@ -21,9 +21,10 @@ import (
 	"log"
 	"strings"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/timeutil"
 )

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -44,7 +46,6 @@ import (
 	"github.com/jacobsa/fuse/fusetesting"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 const (

--- a/internal/fs/handle/dir_handle.go
+++ b/internal/fs/handle/dir_handle.go
@@ -20,12 +20,13 @@ import (
 	"maps"
 	"slices"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseops"
 	"github.com/jacobsa/fuse/fuseutil"
-	"golang.org/x/net/context"
 )
 
 // DirEntry is a generic interface for directory entries that expose

--- a/internal/fs/inode/core_test.go
+++ b/internal/fs/inode/core_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/inode"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
@@ -26,7 +28,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 func TestCore(t *testing.T) { RunTests(t) }

--- a/internal/fs/server.go
+++ b/internal/fs/server.go
@@ -17,11 +17,12 @@ package fs
 import (
 	"fmt"
 
+	"context"
+
 	newcfg "github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/wrappers"
 	"github.com/jacobsa/fuse"
 	"github.com/jacobsa/fuse/fuseutil"
-	"golang.org/x/net/context"
 )
 
 // NewServer creates a fuse file system server according to the supplied configuration.

--- a/internal/gcsx/compose_object_creator.go
+++ b/internal/gcsx/compose_object_creator.go
@@ -22,8 +22,9 @@ import (
 	"maps"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Create an objectCreator that accepts a source object and the contents that

--- a/internal/gcsx/compose_object_creator_test.go
+++ b/internal/gcsx/compose_object_creator_test.go
@@ -22,12 +22,13 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
-	"golang.org/x/net/context"
 )
 
 func TestComposeObjectCreator(t *testing.T) { RunTests(t) }

--- a/internal/gcsx/content_type_bucket.go
+++ b/internal/gcsx/content_type_bucket.go
@@ -18,8 +18,9 @@ import (
 	"mime"
 	"path"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // NewContentTypeBucket creates a wrapper bucket that guesses MIME types for

--- a/internal/gcsx/content_type_bucket_test.go
+++ b/internal/gcsx/content_type_bucket_test.go
@@ -18,11 +18,12 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 var contentTypeBucketTestCases = []struct {

--- a/internal/gcsx/garbage_collect.go
+++ b/internal/gcsx/garbage_collect.go
@@ -19,9 +19,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"

--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -19,12 +19,13 @@ import (
 	"fmt"
 	"time"
 
+	"context"
+
 	storagev2 "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/clock"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/locker"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // InactiveTimeoutReader is a wrapper over gcs.StorageReader that automatically

--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -24,10 +24,11 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
-	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	. "github.com/jacobsa/oglematchers"

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/fs/gcsfuse_errors"
@@ -30,7 +32,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	"golang.org/x/net/context"
 )
 
 func NewMultiRangeDownloaderWrapper(bucket gcs.Bucket, object *gcs.MinObject, config *cfg.Config, mrdCache *lru.Cache) (*MultiRangeDownloaderWrapper, error) {

--- a/internal/gcsx/prefix_bucket.go
+++ b/internal/gcsx/prefix_bucket.go
@@ -19,8 +19,9 @@ import (
 	"strings"
 	"unicode/utf8"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // NewPrefixBucket creates a view on the wrapped bucket that pretends as if only

--- a/internal/gcsx/prefix_bucket_test.go
+++ b/internal/gcsx/prefix_bucket_test.go
@@ -21,12 +21,13 @@ import (
 	"strings"
 	"testing"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/stretchr/testify/suite"

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -23,6 +23,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	"github.com/google/uuid"
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
@@ -34,7 +36,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
-	"golang.org/x/net/context"
 )
 
 // Min read size in bytes for random reads.

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -537,7 +537,7 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	//  - The file content was modified leading to different generation number.
 	var notFoundError *gcs.NotFoundError
 	if errors.As(err, &notFoundError) {
-		cancel()
+		defer cancel()
 		err = &gcsfuse_errors.FileClobberedError{
 			Err:        fmt.Errorf("NewReader: %w", err),
 			ObjectName: rr.object.Name,
@@ -546,7 +546,7 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	}
 
 	if err != nil {
-		cancel()
+		defer cancel()
 		err = fmt.Errorf("NewReaderWithReadHandle: %w", err)
 		return
 	}

--- a/internal/gcsx/random_reader.go
+++ b/internal/gcsx/random_reader.go
@@ -537,6 +537,7 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	//  - The file content was modified leading to different generation number.
 	var notFoundError *gcs.NotFoundError
 	if errors.As(err, &notFoundError) {
+		cancel()
 		err = &gcsfuse_errors.FileClobberedError{
 			Err:        fmt.Errorf("NewReader: %w", err),
 			ObjectName: rr.object.Name,
@@ -545,6 +546,7 @@ func (rr *randomReader) startRead(ctx context.Context, start int64, end int64, r
 	}
 
 	if err != nil {
+		cancel()
 		err = fmt.Errorf("NewReaderWithReadHandle: %w", err)
 		return
 	}

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util/diskutil"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file/downloader"
@@ -44,7 +46,6 @@ import (
 	. "github.com/jacobsa/oglematchers"
 	. "github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
-	"golang.org/x/net/context"
 )
 
 // NOTE: Please add new tests in random_reader_stretchr_test.go file. This file

--- a/internal/gcsx/syncer.go
+++ b/internal/gcsx/syncer.go
@@ -19,8 +19,9 @@ import (
 	"io"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Syncer is safe for concurrent access.

--- a/internal/gcsx/syncer_test.go
+++ b/internal/gcsx/syncer_test.go
@@ -21,6 +21,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
@@ -28,7 +30,6 @@ import (
 	. "github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 func TestSyncer(t *testing.T) { RunTests(t) }

--- a/internal/ratelimit/throttle.go
+++ b/internal/ratelimit/throttle.go
@@ -15,7 +15,8 @@
 package ratelimit
 
 import (
-	"golang.org/x/net/context"
+	"context"
+
 	"golang.org/x/time/rate"
 )
 

--- a/internal/ratelimit/throttle_reader_test.go
+++ b/internal/ratelimit/throttle_reader_test.go
@@ -19,9 +19,10 @@ import (
 	"io"
 	"testing"
 
+	"context"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/ratelimit/throttle_test.go
+++ b/internal/ratelimit/throttle_test.go
@@ -30,10 +30,11 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/ratelimit"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"golang.org/x/net/context"
 )
 
 ////////////////////////////////////////////////////////////////////////

--- a/internal/ratelimit/throttle_test.go
+++ b/internal/ratelimit/throttle_test.go
@@ -171,9 +171,10 @@ func (t *ThrottleTest) TestIntegration() {
 		var wg sync.WaitGroup
 		var totalProcessed uint64
 
-		ctx, _ := context.WithDeadline(
+		ctx, cancel := context.WithDeadline(
 			context.Background(),
 			time.Now().Add(perCaseDuration))
+		defer cancel()
 
 		for i := 0; i < tc.numActors; i++ {
 			wg.Add(1)

--- a/internal/ratelimit/throttled_bucket.go
+++ b/internal/ratelimit/throttled_bucket.go
@@ -17,9 +17,10 @@ package ratelimit
 import (
 	"io"
 
+	"context"
+
 	storagev2 "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Create a bucket that limits the rate at which it calls the wrapped bucket

--- a/internal/ratelimit/throttled_reader.go
+++ b/internal/ratelimit/throttled_reader.go
@@ -17,7 +17,7 @@ package ratelimit
 import (
 	"io"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // Create a reader that limits the bandwidth of reads made from r according to

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -21,11 +21,12 @@ import (
 	"sync"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
-	"golang.org/x/net/context"
 
 	"github.com/jacobsa/timeutil"
 )

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	gostorage "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/caching"
@@ -32,7 +34,6 @@ import (
 	. "github.com/jacobsa/oglemock"
 	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 func TestFastStatBucket(t *testing.T) { RunTests(t) }

--- a/internal/storage/debug_bucket.go
+++ b/internal/storage/debug_bucket.go
@@ -20,10 +20,11 @@ import (
 	"sync/atomic"
 	"time"
 
+	"context"
+
 	storagev2 "cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Wrap the supplied bucket in a layer that prints debug messages.

--- a/internal/storage/fake/bucket_test.go
+++ b/internal/storage/fake/bucket_test.go
@@ -18,11 +18,12 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	gcstesting "github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake/testing"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
-	"golang.org/x/net/context"
 )
 
 func TestBucket(t *testing.T) { ogletest.RunTests(t) }

--- a/internal/storage/fake/testing/register_bucket_tests.go
+++ b/internal/storage/fake/testing/register_bucket_tests.go
@@ -18,8 +18,9 @@ import (
 	"errors"
 	"reflect"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 

--- a/internal/storage/gcs/bucket.go
+++ b/internal/storage/gcs/bucket.go
@@ -17,8 +17,9 @@ package gcs
 import (
 	"io"
 
+	"context"
+
 	"cloud.google.com/go/storage"
-	"golang.org/x/net/context"
 )
 
 type PirloState int

--- a/internal/storage/mock_bucket.go
+++ b/internal/storage/mock_bucket.go
@@ -11,9 +11,10 @@ import (
 	runtime "runtime"
 	unsafe "unsafe"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	oglemock "github.com/jacobsa/oglemock"
-	context "golang.org/x/net/context"
 )
 
 type MockBucket interface {

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/auth"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
@@ -30,7 +32,6 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/httptrace/otelhttptrace"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/net/context"
 	"golang.org/x/oauth2"
 )
 

--- a/internal/storage/storageutil/create_empty_objects.go
+++ b/internal/storage/storageutil/create_empty_objects.go
@@ -15,8 +15,9 @@
 package storageutil
 
 import (
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Create empty objects with default attributes for all of the supplied names.

--- a/internal/storage/storageutil/create_object.go
+++ b/internal/storage/storageutil/create_object.go
@@ -17,8 +17,9 @@ package storageutil
 import (
 	"bytes"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Create an object with the supplied contents in the given bucket with the

--- a/internal/storage/storageutil/create_objects.go
+++ b/internal/storage/storageutil/create_objects.go
@@ -15,8 +15,9 @@
 package storageutil
 
 import (
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/storage/storageutil/delete_all_objects.go
+++ b/internal/storage/storageutil/delete_all_objects.go
@@ -15,8 +15,9 @@
 package storageutil
 
 import (
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/internal/storage/storageutil/delete_object.go
+++ b/internal/storage/storageutil/delete_object.go
@@ -15,8 +15,9 @@
 package storageutil
 
 import (
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // DeleteObject deletes an object in the given bucket with the given name.

--- a/internal/storage/storageutil/list_all.go
+++ b/internal/storage/storageutil/list_all.go
@@ -15,8 +15,9 @@
 package storageutil
 
 import (
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Repeatedly call bucket.ListObjects until there is nothing further to list,

--- a/internal/storage/storageutil/list_prefix.go
+++ b/internal/storage/storageutil/list_prefix.go
@@ -17,8 +17,9 @@ package storageutil
 import (
 	"fmt"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // List objects in the supplied bucket whose name starts with the given prefix.

--- a/internal/storage/storageutil/read_object.go
+++ b/internal/storage/storageutil/read_object.go
@@ -18,8 +18,9 @@ import (
 	"fmt"
 	"io"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
-	"golang.org/x/net/context"
 )
 
 // Read the contents of the latest generation of the object with the supplied

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -19,11 +19,12 @@ import (
 	"log"
 	"testing"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"golang.org/x/net/context"
 )
 
 func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -32,12 +32,13 @@ import (
 	"testing"
 	"time"
 
+	"context"
+
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/net/context"
 )
 
 const (


### PR DESCRIPTION
### Description
Use standard go context library and remove deprecated context lib.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Part of pre-submits

### Any backward incompatible change? If so, please explain.
