### PR TITLE
fix(lru): track internal entry size to prevent TOCTOU race and size underflow

### DIFF
--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -73,6 +73,7 @@ type ValueType interface {
 type entry struct {
 	Key   string
 	Value ValueType
+	size  uint64
 }
 
 // NewCache returns the reference of cache object by initialising the cache with
@@ -100,13 +101,18 @@ func (c *Cache) checkInvariants() {
 		panic(fmt.Sprintf("CurrentSize %v over maxSize %v", c.currentSize, c.maxSize))
 	}
 
-	// INVARIANT: Each element is of type entry
+	// INVARIANT: Each element is of type entry and sum of entry sizes matches currentSize
+	var sumSize uint64
 	for e := c.entries.Front(); e != nil; e = e.Next() {
-		switch e.Value.(type) {
-		case entry:
-		default:
+		ent, ok := e.Value.(entry)
+		if !ok {
 			panic(fmt.Sprintf("Unexpected element type: %v", reflect.TypeOf(e.Value)))
 		}
+		sumSize += ent.size
+	}
+
+	if sumSize != c.currentSize {
+		panic(fmt.Sprintf("Size mismatch: sum of entry sizes %v vs currentSize %v", sumSize, c.currentSize))
 	}
 
 	// INVARIANT: For each k, v: v.Value.(entry).Key == k
@@ -129,13 +135,13 @@ func (c *Cache) evictOne() ValueType {
 	e := c.entries.Back()
 	key := e.Value.(entry).Key
 
-	evictedEntry := e.Value.(entry).Value
-	c.currentSize -= evictedEntry.Size()
+	evictedEntry := e.Value.(entry)
+	c.currentSize -= evictedEntry.size
 
 	c.entries.Remove(e)
 	delete(c.index, key)
 
-	return evictedEntry
+	return evictedEntry.Value
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -163,13 +169,13 @@ func (c *Cache) Insert(
 	e, ok := c.index[key]
 	if ok {
 		// Update an entry if already exist.
-		c.currentSize -= e.Value.(entry).Value.Size()
+		c.currentSize -= e.Value.(entry).size
 		c.currentSize += valueSize
-		e.Value = entry{key, value}
+		e.Value = entry{key, value, valueSize}
 		c.entries.MoveToFront(e)
 	} else {
 		// Add the entry if already doesn't exist.
-		e := c.entries.PushFront(entry{key, value})
+		e := c.entries.PushFront(entry{key, value, valueSize})
 		c.index[key] = e
 		c.currentSize += valueSize
 	}
@@ -192,13 +198,13 @@ func (c *Cache) eraseInternal(key string) (value ValueType) {
 		return
 	}
 
-	deletedEntry := e.Value.(entry).Value
-	c.currentSize -= deletedEntry.Size()
+	deletedEntry := e.Value.(entry)
+	c.currentSize -= deletedEntry.size
 
 	delete(c.index, key)
 	c.entries.Remove(e)
 
-	return deletedEntry
+	return deletedEntry.Value
 }
 
 // eraseKeys removes a list of keys from the cache.
@@ -276,11 +282,12 @@ func (c *Cache) UpdateWithoutChangingOrder(
 		return ErrEntryNotExist
 	}
 
-	if value.Size() != e.Value.(entry).Value.Size() {
+	ent := e.Value.(entry)
+	if value.Size() != ent.size {
 		return ErrInvalidUpdateEntrySize
 	}
 
-	e.Value = entry{key, value}
+	e.Value = entry{key, value, ent.size}
 	c.index[key] = e
 
 	return nil
@@ -294,10 +301,14 @@ func (c *Cache) UpdateSize(key string, sizeDelta uint64) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	_, ok := c.index[key]
+	e, ok := c.index[key]
 	if !ok {
 		return ErrEntryNotExist
 	}
+
+	ent := e.Value.(entry)
+	ent.size += sizeDelta
+	e.Value = ent
 
 	// Update currentSize accounting
 	// Note: This may temporarily violate currentSize <= maxSize invariant

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -391,3 +391,49 @@ func Test_EraseEntriesWithGivenPrefix_Concurrent(t *testing.T) {
 
 	wg.Wait()
 }
+
+type testSparseData struct {
+	Value    int64
+	DataSize uint64
+}
+
+func (td *testSparseData) Size() uint64 {
+	return td.DataSize
+}
+
+func TestUpdateSizeTOCTOU_EraseBeforeUpdateSizeDoesNotUnderflow(t *testing.T) {
+	cache := setupCacheTest(t)
+	data := &testSparseData{Value: 1, DataSize: 0}
+	insertAndAssert(t, cache, "key", data, []int64{}, nil)
+	data.DataSize = 1000
+
+	deletedEntry := cache.Erase("key")
+	err := cache.UpdateSize("key", 1000)
+
+	require.NotNil(t, deletedEntry)
+	assert.ErrorIs(t, err, lru.ErrEntryNotExist)
+}
+
+func TestUpdateSizeTOCTOU_ConcurrentUpdateAndErase(t *testing.T) {
+	cache := setupCacheTest(t)
+	data := &testSparseData{Value: 1, DataSize: 0}
+	insertAndAssert(t, cache, "key", data, []int64{}, nil)
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		for range 10 {
+			data.DataSize += 2
+			_ = cache.UpdateSize("key", 2)
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		_ = cache.Erase("key")
+	}()
+
+	wg.Wait()
+	// Assert: Invariant checks (sum(size) == currentSize and currentSize <= maxSize)
+	// run automatically on lock release via setupCacheTest.
+}


### PR DESCRIPTION
### Description
Track entry size internally within `lru.entry` to decouple LRU `currentSize` accounting from dynamic caller-side object mutations (e.g. sparse file downloads). When evicting or erasing an entry, subtract the internally tracked entry size instead of dynamically invoking `Value.Size()`.

### Link to the issue in case of a bug fix.
b/533320736

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No