### PR TITLE
fix: Fixing only-dir mounting for managed folders

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -163,6 +163,7 @@ func createStorageHandle(newConfig *cfg.Config, userAgent string, metricHandle m
 		GrpcConnPoolSize:           int(newConfig.GcsConnection.GrpcConnPoolSize),
 		GrpcPathStrategy:           newConfig.GcsConnection.GrpcPathStrategy,
 		EnableHNS:                  newConfig.EnableHns,
+		OnlyDir:                    newConfig.OnlyDir,
 		EnableGoogleLibAuth:        newConfig.EnableGoogleLibAuth,
 		ReadStallRetryConfig:       newConfig.GcsRetries.ReadStall,
 		MetricHandle:               metricHandle,

--- a/internal/storage/control_client_wrapper.go
+++ b/internal/storage/control_client_wrapper.go
@@ -101,10 +101,15 @@ func (sccwros *storageControlClientWithRetry) GetStorageLayout(ctx context.Conte
 		return sccwros.raw.GetStorageLayout(attemptCtx, req, opts...)
 	}
 
-	if sccwros.enableRetriesOnMount {
-		return storageutil.ExecuteWithCustomShouldRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, storageutil.ShouldRetryOnMount, logger.LevelInfo)
+	desc := req.Name
+	if req.Prefix != "" {
+		desc = fmt.Sprintf("%s (prefix: %q)", req.Name, req.Prefix)
 	}
-	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", req.Name, req.RequestId, apiCall, logger.LevelInfo)
+
+	if sccwros.enableRetriesOnMount {
+		return storageutil.ExecuteWithCustomShouldRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", desc, req.RequestId, apiCall, storageutil.ShouldRetryOnMount, logger.LevelInfo)
+	}
+	return storageutil.ExecuteWithRetryAtLogLevel(ctx, sccwros.retryConfig, "GetStorageLayout", desc, req.RequestId, apiCall, logger.LevelInfo)
 }
 
 func (sccwros *storageControlClientWithRetry) DeleteFolder(ctx context.Context,

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -397,7 +397,8 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 	}
 
 	startTime := time.Now()
-	logger.Infof("GetStorageLayout <- (%s)", bucketName)
+	prefix := sh.clientConfig.OnlyDir
+	logger.Infof("GetStorageLayout <- (%s, prefix: %q)", bucketName, prefix)
 	storageLayout, err := sh.getStorageLayout(bucketName)
 	duration := time.Since(startTime)
 
@@ -405,7 +406,7 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 		return nil, err
 	}
 
-	logger.Infof("GetStorageLayout -> (%s) %v msec", bucketName, duration.Milliseconds())
+	logger.Infof("GetStorageLayout -> (%s, prefix: %q) %v msec", bucketName, prefix, duration.Milliseconds())
 
 	// TODO (b/483608308): Once GetStorageLayout starts returning Pirlo bucket type,
 	// update this logic to use the response instead of inferring from clientConfig.
@@ -428,13 +429,13 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 func (sh *storageClient) getStorageLayout(bucketName string) (*controlpb.StorageLayout, error) {
 	var callOptions []gax.CallOption
 
-	stoargeLayout, err := sh.storageControlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
+	storageLayout, err := sh.storageControlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
 		Name:      fmt.Sprintf("projects/_/buckets/%s/storageLayout", bucketName),
 		Prefix:    sh.clientConfig.OnlyDir,
 		RequestId: uuid.NewString(),
 	}, callOptions...)
 
-	return stoargeLayout, err
+	return storageLayout, err
 }
 
 // NewStorageHandle creates control client and stores client config to allow dynamic

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -232,6 +233,9 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 
 	var notFoundError *gcs.NotFoundError
 	var testObject = "gcsfuse-dp-object"
+	if clientConfig.OnlyDir != "" {
+		testObject = clientConfig.OnlyDir + testObject
+	}
 	bucketHandle := sc.Bucket(bucketName)
 	if billingProject != "" {
 		bucketHandle = bucketHandle.UserProject(billingProject)
@@ -353,8 +357,13 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 // verifyNonHNSBucketAccess performs an Attrs call on a non-existent object
 // to verify bucket existence and authorization when HNS is disabled.
 func (sh *storageClient) verifyNonHNSBucketAccess(ctx context.Context, bucketHandle *storage.BucketHandle, bucketName string) error {
+	testObject := nonExistentObjectName
+	if sh.clientConfig.OnlyDir != "" {
+		testObject = sh.clientConfig.OnlyDir + testObject
+	}
+
 	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
-		return bucketHandle.Object(nonExistentObjectName).Attrs(attemptCtx)
+		return bucketHandle.Object(testObject).Attrs(attemptCtx)
 	}
 
 	retryConfig := storageutil.NewRetryConfig(&sh.clientConfig)
@@ -362,7 +371,7 @@ func (sh *storageClient) verifyNonHNSBucketAccess(ctx context.Context, bucketHan
 		ctx,
 		retryConfig,
 		"Attrs",
-		fmt.Sprintf("%s/%s", bucketName, nonExistentObjectName),
+		fmt.Sprintf("%s/%s", bucketName, testObject),
 		uuid.NewString(),
 		apiCall,
 		storageutil.ShouldRetryOnMount,
@@ -418,9 +427,10 @@ func (sh *storageClient) lookupBucketType(bucketName string) (*gcs.BucketType, e
 
 func (sh *storageClient) getStorageLayout(bucketName string) (*controlpb.StorageLayout, error) {
 	var callOptions []gax.CallOption
+
 	stoargeLayout, err := sh.storageControlClient.GetStorageLayout(context.Background(), &controlpb.GetStorageLayoutRequest{
 		Name:      fmt.Sprintf("projects/_/buckets/%s/storageLayout", bucketName),
-		Prefix:    "",
+		Prefix:    sh.clientConfig.OnlyDir,
 		RequestId: uuid.NewString(),
 	}, callOptions...)
 
@@ -430,6 +440,15 @@ func (sh *storageClient) getStorageLayout(bucketName string) (*controlpb.Storage
 // NewStorageHandle creates control client and stores client config to allow dynamic
 // creation of http or grpc client.
 func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClientConfig, billingProject string) (sh StorageHandle, err error) {
+	// Sanitize the onlyDir path for only-dir mounting
+	if clientConfig.OnlyDir != "" {
+		prefix := path.Clean(clientConfig.OnlyDir)
+		if prefix != "." && prefix != "/" {
+			clientConfig.OnlyDir = prefix + "/"
+		} else {
+			clientConfig.OnlyDir = ""
+		}
+	}
 	// The default protocol for the Go Storage control client's folders API is gRPC.
 	// gcsfuse will initially mirror this behavior due to the client's lack of HTTP support.
 	var controlClient StorageControlClient

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -443,8 +443,10 @@ func (sh *storageClient) getStorageLayout(bucketName string) (*controlpb.Storage
 func NewStorageHandle(ctx context.Context, clientConfig storageutil.StorageClientConfig, billingProject string) (sh StorageHandle, err error) {
 	// Sanitize the onlyDir path for only-dir mounting
 	if clientConfig.OnlyDir != "" {
-		prefix := path.Clean(clientConfig.OnlyDir)
-		if prefix != "." && prefix != "/" {
+		// Treat OnlyDir as absolute path to resolve any leading ".." to root.
+		prefix := path.Clean("/" + clientConfig.OnlyDir)
+		prefix = strings.TrimPrefix(prefix, "/")
+		if prefix != "" {
 			clientConfig.OnlyDir = prefix + "/"
 		} else {
 			clientConfig.OnlyDir = ""

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -217,6 +217,50 @@ func (testSuite *StorageHandleTest) TestLookupBucketType_PirloEnabled() {
 	assert.Equal(testSuite.T(), gcs.PirloStateRapidWritesEnabled, bt.Pirlo)
 }
 
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefix() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.OnlyDir = "foo/bar"
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+	require.NoError(testSuite.T(), err)
+	client := sh.(*storageClient)
+	client.storageControlClient = testSuite.mockClient
+	storageLayout := &controlpb.StorageLayout{
+		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		LocationType:          "regional",
+	}
+	// Verify that the prefix passed to GetStorageLayout is "foo/bar/" (cleaned and with trailing slash)
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return req.Prefix == "foo/bar/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+	}), mock.Anything).Return(storageLayout, nil)
+
+	bt, err := client.lookupBucketType(TestBucketName)
+
+	assert.NoError(testSuite.T(), err)
+	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixRoot() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.OnlyDir = "/." // Cleans to "/" which should be treated as root ("")
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+	require.NoError(testSuite.T(), err)
+	client := sh.(*storageClient)
+	client.storageControlClient = testSuite.mockClient
+	storageLayout := &controlpb.StorageLayout{
+		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		LocationType:          "regional",
+	}
+	// Verify that the prefix passed to GetStorageLayout is "" (root)
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return req.Prefix == "" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+	}), mock.Anything).Return(storageLayout, nil)
+
+	bt, err := client.lookupBucketType(TestBucketName)
+
+	assert.NoError(testSuite.T(), err)
+	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile) // by default http1 enabled
 
@@ -1047,4 +1091,55 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_Exhausts
 	assert.Nil(testSuite.T(), bh)
 	assert.ErrorContains(testSuite.T(), err, "bucket access check failed")
 	assert.Equal(testSuite.T(), testMaxRetryAttempts, *attempts, "expected max retry attempts to be exhausted")
+}
+
+// TestBucketHandle_NonHNS_AccessCheck_WithPrefix verifies that when GCSFuse mounts
+// a non-HNS bucket with a prefix restriction (--only-dir), the mount-time access
+// check (which performs a Stat/Attrs call on a non-existent object to verify bucket
+// existence and access) is correctly prefixed. This ensures the check does not
+// attempt to access the root of the bucket, which would fail with 403 Permission Denied
+// in prefix-restricted environments.
+func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_WithPrefix() {
+	testObject := "gcsfuse-nonexistent-object-check"
+	prefix := "foo/bar"
+	// We expect GCSFuse to check: <prefix>/gcsfuse-nonexistent-object-check
+	expectedObjectPath := prefix + "/" + testObject
+	expectedRequestPath := "/b/" + TestBucketName + "/o/" + url.PathEscape(expectedObjectPath)
+	// Set up a mock HTTP server to capture the outgoing GCS API request.
+	requestPathChan := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPathChan <- r.URL.EscapedPath()
+		// Mock a 404 response. For access verification, 404 (Not Found) means
+		// we have permission to access the path (otherwise we would get 403 Forbidden).
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error": {"code": 404, "message": "Not Found"}}`))
+	}))
+	defer server.Close()
+	// Configure GCSFuse client with the mock server URL and only-dir prefix.
+	scConfig := storageutil.StorageClientConfig{
+		ClientProtocol:     cfg.HTTP1,
+		EnableMountRetries: true, // Triggers verifyNonHNSBucketAccess during BucketHandle
+		MaxRetrySleep:      time.Microsecond,
+		RetryMultiplier:    1.0,
+		MaxRetryAttempts:   1,
+		OnlyDir:            prefix,
+		CustomEndpoint:     server.URL,
+		AnonymousAccess:    true, // Bypass real auth for mock server
+	}
+	sh, err := NewStorageHandle(testSuite.ctx, scConfig, "")
+	require.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), sh)
+
+	// Trigger bucket setup which runs the verification checks.
+	bh, err := sh.BucketHandle(testSuite.ctx, TestBucketName, "")
+
+	require.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), bh)
+	// Assert that the request path captured by the mock server matches our expected prefixed path.
+	select {
+	case reqPath := <-requestPathChan:
+		assert.Equal(testSuite.T(), expectedRequestPath, reqPath)
+	case <-time.After(time.Second):
+		testSuite.T().Fatal("Timeout waiting for request")
+	}
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -217,9 +217,9 @@ func (testSuite *StorageHandleTest) TestLookupBucketType_PirloEnabled() {
 	assert.Equal(testSuite.T(), gcs.PirloStateRapidWritesEnabled, bt.Pirlo)
 }
 
-func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefix() {
+func (testSuite *StorageHandleTest) runLookupBucketTypeTest(onlyDirInput, expectedPrefixInRequest string) {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	sc.OnlyDir = "foo/bar"
+	sc.OnlyDir = onlyDirInput
 	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
 	require.NoError(testSuite.T(), err)
 	client := sh.(*storageClient)
@@ -228,103 +228,35 @@ func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefix() {
 		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
 		LocationType:          "regional",
 	}
-	// Verify that the prefix passed to GetStorageLayout is "foo/bar/" (cleaned and with trailing slash)
+	// Verify that the prefix passed to GetStorageLayout matches expected value.
 	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
-		return req.Prefix == "foo/bar/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+		return req.Prefix == expectedPrefixInRequest && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
 	}), mock.Anything).Return(storageLayout, nil)
 
 	bt, err := client.lookupBucketType(TestBucketName)
 
 	assert.NoError(testSuite.T(), err)
 	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefix() {
+	testSuite.runLookupBucketTypeTest("foo/bar", "foo/bar/")
 }
 
 func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixRoot() {
-	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	sc.OnlyDir = "/." // Cleans to "/" which should be treated as root ("")
-	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
-	require.NoError(testSuite.T(), err)
-	client := sh.(*storageClient)
-	client.storageControlClient = testSuite.mockClient
-	storageLayout := &controlpb.StorageLayout{
-		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		LocationType:          "regional",
-	}
-	// Verify that the prefix passed to GetStorageLayout is "" (root)
-	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
-		return req.Prefix == "" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
-	}), mock.Anything).Return(storageLayout, nil)
-
-	bt, err := client.lookupBucketType(TestBucketName)
-
-	assert.NoError(testSuite.T(), err)
-	assert.True(testSuite.T(), bt.Hierarchical)
+	testSuite.runLookupBucketTypeTest("/.", "")
 }
 
 func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixDotDot() {
-	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	sc.OnlyDir = ".." // Should resolve to root ("")
-	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
-	require.NoError(testSuite.T(), err)
-	client := sh.(*storageClient)
-	client.storageControlClient = testSuite.mockClient
-	storageLayout := &controlpb.StorageLayout{
-		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		LocationType:          "regional",
-	}
-	// Verify that the prefix passed to GetStorageLayout is "" (root)
-	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
-		return req.Prefix == "" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
-	}), mock.Anything).Return(storageLayout, nil)
-
-	bt, err := client.lookupBucketType(TestBucketName)
-
-	assert.NoError(testSuite.T(), err)
-	assert.True(testSuite.T(), bt.Hierarchical)
+	testSuite.runLookupBucketTypeTest("..", "")
 }
 
 func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixLeadingDotDot() {
-	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	sc.OnlyDir = "../../foo" // Should resolve to "foo" (since you can't go above bucket root)
-	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
-	require.NoError(testSuite.T(), err)
-	client := sh.(*storageClient)
-	client.storageControlClient = testSuite.mockClient
-	storageLayout := &controlpb.StorageLayout{
-		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		LocationType:          "regional",
-	}
-	// Verify that the prefix passed to GetStorageLayout is "foo/"
-	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
-		return req.Prefix == "foo/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
-	}), mock.Anything).Return(storageLayout, nil)
-
-	bt, err := client.lookupBucketType(TestBucketName)
-
-	assert.NoError(testSuite.T(), err)
-	assert.True(testSuite.T(), bt.Hierarchical)
+	testSuite.runLookupBucketTypeTest("../../foo", "foo/")
 }
 
 func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixInternalDotDot() {
-	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	sc.OnlyDir = "foo/../bar" // Should resolve to "bar"
-	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
-	require.NoError(testSuite.T(), err)
-	client := sh.(*storageClient)
-	client.storageControlClient = testSuite.mockClient
-	storageLayout := &controlpb.StorageLayout{
-		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
-		LocationType:          "regional",
-	}
-	// Verify that the prefix passed to GetStorageLayout is "bar/"
-	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
-		return req.Prefix == "bar/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
-	}), mock.Anything).Return(storageLayout, nil)
-
-	bt, err := client.lookupBucketType(TestBucketName)
-
-	assert.NoError(testSuite.T(), err)
-	assert.True(testSuite.T(), bt.Hierarchical)
+	testSuite.runLookupBucketTypeTest("foo/../bar", "bar/")
 }
 
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -261,6 +261,72 @@ func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixRoot() {
 	assert.True(testSuite.T(), bt.Hierarchical)
 }
 
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixDotDot() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.OnlyDir = ".." // Should resolve to root ("")
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+	require.NoError(testSuite.T(), err)
+	client := sh.(*storageClient)
+	client.storageControlClient = testSuite.mockClient
+	storageLayout := &controlpb.StorageLayout{
+		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		LocationType:          "regional",
+	}
+	// Verify that the prefix passed to GetStorageLayout is "" (root)
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return req.Prefix == "" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+	}), mock.Anything).Return(storageLayout, nil)
+
+	bt, err := client.lookupBucketType(TestBucketName)
+
+	assert.NoError(testSuite.T(), err)
+	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixLeadingDotDot() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.OnlyDir = "../../foo" // Should resolve to "foo" (since you can't go above bucket root)
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+	require.NoError(testSuite.T(), err)
+	client := sh.(*storageClient)
+	client.storageControlClient = testSuite.mockClient
+	storageLayout := &controlpb.StorageLayout{
+		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		LocationType:          "regional",
+	}
+	// Verify that the prefix passed to GetStorageLayout is "foo/"
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return req.Prefix == "foo/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+	}), mock.Anything).Return(storageLayout, nil)
+
+	bt, err := client.lookupBucketType(TestBucketName)
+
+	assert.NoError(testSuite.T(), err)
+	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
+func (testSuite *StorageHandleTest) TestLookupBucketType_WithPrefixInternalDotDot() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	sc.OnlyDir = "foo/../bar" // Should resolve to "bar"
+	sh, err := NewStorageHandle(testSuite.ctx, sc, "")
+	require.NoError(testSuite.T(), err)
+	client := sh.(*storageClient)
+	client.storageControlClient = testSuite.mockClient
+	storageLayout := &controlpb.StorageLayout{
+		HierarchicalNamespace: &controlpb.StorageLayout_HierarchicalNamespace{Enabled: true},
+		LocationType:          "regional",
+	}
+	// Verify that the prefix passed to GetStorageLayout is "bar/"
+	testSuite.mockClient.On("GetStorageLayout", mock.Anything, mock.MatchedBy(func(req *controlpb.GetStorageLayoutRequest) bool {
+		return req.Prefix == "bar/" && req.Name == fmt.Sprintf("projects/_/buckets/%s/storageLayout", TestBucketName)
+	}), mock.Anything).Return(storageLayout, nil)
+
+	bt, err := client.lookupBucketType(TestBucketName)
+
+	assert.NoError(testSuite.T(), err)
+	assert.True(testSuite.T(), bt.Hierarchical)
+}
+
 func (testSuite *StorageHandleTest) TestNewStorageHandleHttp2Disabled() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile) // by default http1 enabled
 

--- a/internal/storage/storageutil/client.go
+++ b/internal/storage/storageutil/client.go
@@ -78,6 +78,8 @@ type StorageClientConfig struct {
 
 	// Enabling new API flow for HNS bucket.
 	EnableHNS bool
+	// Prefix to restrict access to (from only-dir config).
+	OnlyDir string
 	// EnableGoogleLibAuth indicates whether to use the google library authentication flow
 	EnableGoogleLibAuth bool
 

--- a/tools/integration_tests/managed_folders/restricted_permissions_test.go
+++ b/tools/integration_tests/managed_folders/restricted_permissions_test.go
@@ -1,0 +1,101 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package managed_folders
+
+import (
+	"log"
+	"os"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/suite"
+)
+
+type managedFoldersRestrictedPermission struct {
+	flags []string
+	suite.Suite
+}
+
+func (s *managedFoldersRestrictedPermission) SetupSuite() {
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(testEnv.cfg, s.flags, testEnv.mountFunc)
+	setup.SetMntDir(testEnv.mountDir)
+}
+
+func (s *managedFoldersRestrictedPermission) TearDownSuite() {
+	setup.UnmountGCSFuseWithConfig(testEnv.cfg)
+}
+
+func (s *managedFoldersRestrictedPermission) TestCreateAndReadObject() {
+	// We should be able to create and read objects in the mount directory
+	// because the mount directory is mapped to the managed folder where we have admin permission.
+	filePath := path.Join(setup.MntDir(), "restricted_test_file.txt")
+
+	// Create file
+	file, err := os.Create(filePath)
+	s.Require().NoError(err)
+	_, err = file.Write([]byte("hello restricted world"))
+	s.Require().NoError(err)
+	err = file.Close()
+	s.Require().NoError(err)
+
+	// Read file
+	content, err := os.ReadFile(filePath)
+	s.Require().NoError(err)
+	s.Assert().Equal("hello restricted world", string(content))
+
+	// Clean up file
+	err = os.Remove(filePath)
+	s.Require().NoError(err)
+}
+
+func TestManagedFolders_RestrictedPermission(t *testing.T) {
+	if setup.OnlyDirMounted() == "" {
+		t.Skip("Skipping restricted permissions test for non-only-dir mounting")
+	}
+
+	ts := &managedFoldersRestrictedPermission{}
+
+	// We need to ensure the SA has NO bucket level permissions.
+	// Revoke them just in case they were left over from previous tests.
+	creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, AdminPermission, setup.TestBucket())
+	creds_tests.RevokePermission(testEnv.ctx, testEnv.storageClient, testEnv.serviceAccount, ViewPermission, setup.TestBucket())
+	// Wait for revocation to propagate.
+	time.Sleep(60 * time.Second)
+
+	// Create the managed folder that we will mount.
+	// The only-dir mounted name is "TestManagedFolderOnlyDir/" (configured in TestMain).
+	folderPath := "TestManagedFolderOnlyDir"
+
+	// We use the testEnv.controlClient (which has admin permissions) to create the folder.
+	client.CreateManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, folderPath, setup.TestBucket())
+	defer client.DeleteManagedFoldersInBucket(testEnv.ctx, testEnv.controlClient, folderPath, setup.TestBucket())
+
+	// Grant Admin permission to the restricted SA ONLY on this managed folder.
+	providePermissionToManagedFolder(setup.TestBucket(), folderPath, testEnv.serviceAccount, IAMRoleForAdminPermission, t)
+	defer revokePermissionToManagedFolder(setup.TestBucket(), folderPath, testEnv.serviceAccount, IAMRoleForAdminPermission, t)
+
+	// Wait for policy propagation.
+	time.Sleep(60 * time.Second)
+
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, ts.flags = range flagsSet {
+		log.Printf("Running restricted permissions test with flags: %s", ts.flags)
+		suite.Run(t, ts)
+	}
+}

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -2005,6 +2005,22 @@ managed_folders:
             same_zone: true
             different_zone: false
         run_on_gke: false
+      - run: TestManagedFolders_RestrictedPermission
+        flags:
+          - "--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=5,--stat-cache-ttl=0,--client-protocol=http1"
+        compatible:
+          flat: true
+          hns: true
+          zonal: true
+        run_on_gke: false
+      - run: TestManagedFolders_RestrictedPermission
+        flags:
+          - "--experimental-enable-pirlo,--implicit-dirs,--key-file=${KEY_FILE},--rename-dir-limit=5,--stat-cache-ttl=0,--client-protocol=http1"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
 
 concurrent_operations:
   - mounted_directory: "${MOUNTED_DIR}"


### PR DESCRIPTION
We are doing getSTorageLayout for the bucket even incase of only-dir mounting. Instead also passing the directory name as part of getSTorageLayout call for only-dir mounting. This is important to avoid permission denied errors when user doesn't have access on bucket but has access to a specific folder inside the bucket (managed folder usecase)



### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
