### PR TITLE
test(operations): bifurcate write operations for rapid writes flagsets

### DIFF
--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/require"
 )
 
 // Create below directory structure.
@@ -113,9 +114,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	checkIfCopiedDirectoryHasCorrectData(destDir, s.T())
 }
@@ -142,9 +141,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -181,9 +178,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -248,9 +243,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	objs, err := os.ReadDir(destDir)
 	if err != nil {
@@ -301,9 +294,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInEmptyDirectory() {
 	operations.CreateDirectoryWithNFiles(0, destDir, "", s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
@@ -348,9 +339,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonExistingDirectory() {
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
-	if err != nil {
-		s.T().Errorf("Error in copying directory: %v", err)
-	}
+	require.NoError(s.T(), err, "Error in copying directory")
 
 	checkIfCopiedEmptyDirectoryHasNoData(destDir, s.T())
 }

--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -19,7 +19,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -30,11 +29,11 @@ import (
 // srcCopyDir               -- Dir
 // srcCopyDir/copy.txt      -- File
 // srcCopyDir/subSrcCopyDir -- Dir
-func createSrcDirectoryWithObjects(dirPath string, t *testing.T) string {
+func (s *operationsTestSuite) createSrcDirectoryWithObjects(dirPath string) string {
 	// testBucket/srcCopyDir
 	err := os.Mkdir(dirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", dirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", dirPath, err)
 		return ""
 	}
 
@@ -42,7 +41,7 @@ func createSrcDirectoryWithObjects(dirPath string, t *testing.T) string {
 	subDirPath := path.Join(dirPath, SubSrcCopyDirectory)
 	err = os.Mkdir(subDirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", subDirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", subDirPath, err)
 		return ""
 	}
 
@@ -51,21 +50,21 @@ func createSrcDirectoryWithObjects(dirPath string, t *testing.T) string {
 
 	file, err := os.Create(filePath)
 	if err != nil {
-		t.Errorf("Error in creating file %v:", err)
+		s.T().Errorf("Error in creating file %v:", err)
 	}
 
 	err = operations.WriteFile(file.Name(), SrcCopyFileContent)
 	if err != nil {
-		t.Errorf("File at %v", err)
+		s.T().Errorf("File at %v", err)
 	}
 
 	// Closing file at the end
-	defer operations.CloseFileShouldNotThrowError(t, file)
+	defer operations.CloseFileShouldNotThrowError(s.T(), file)
 
 	return dirPath
 }
 
-func checkIfCopiedDirectoryHasCorrectData(destDir string, t *testing.T) {
+func (s *operationsTestSuite) checkIfCopiedDirectoryHasCorrectData(destDir string) {
 	obj, err := os.ReadDir(destDir)
 	if err != nil {
 		log.Fatal(err)
@@ -73,30 +72,30 @@ func checkIfCopiedDirectoryHasCorrectData(destDir string, t *testing.T) {
 
 	// Comparing number of objects in the testBucket - 2
 	if len(obj) != NumberOfObjectsInSrcCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// Comparing first object name and type
 	// Name - testBucket/destCopyDir/copy.txt, Type - file
 	if obj[0].Name() != SrcCopyFile || obj[0].IsDir() == true {
-		t.Errorf("Object Listed for bucket directory is incorrect.")
+		s.T().Errorf("Object Listed for bucket directory is incorrect.")
 	}
 
 	// Comparing second object name and type
 	// Name - testBucket/destCopyDir/srcCopyDir, Type - dir
 	if obj[1].Name() != SubSrcCopyDirectory || obj[1].IsDir() != true {
-		t.Errorf("Object Listed for bucket directory is incorrect.")
+		s.T().Errorf("Object Listed for bucket directory is incorrect.")
 	}
 
 	destFile := path.Join(destDir, SrcCopyFile)
 
 	content, err := operations.ReadFile(destFile)
 	if err != nil {
-		t.Errorf("ReadAll: %v", err)
+		s.T().Errorf("ReadAll: %v", err)
 	}
 	if got, want := string(content), SrcCopyFileContent; got != want {
-		t.Errorf("File content %q not match %q", got, want)
+		s.T().Errorf("File content %q not match %q", got, want)
 	}
 }
 
@@ -110,13 +109,13 @@ func checkIfCopiedDirectoryHasCorrectData(destDir string, t *testing.T) {
 // destCopyDir/subSrcCopyDir -- Dir
 func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
+	srcDir := s.createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory))
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	err := operations.CopyDir(srcDir, destDir)
 	require.NoError(s.T(), err, "Error in copying directory")
 
-	checkIfCopiedDirectoryHasCorrectData(destDir, s.T())
+	s.checkIfCopiedDirectoryHasCorrectData(destDir)
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -130,7 +129,7 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 // destCopyDir/srcCopyDir/subSrcCopyDir -- Dir
 func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
+	srcDir := s.createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory))
 
 	// Create below directory
 	// destCopyDir               -- Dir
@@ -157,25 +156,25 @@ func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
+	s.checkIfCopiedDirectoryHasCorrectData(destSrc)
 }
 
-func createDestNonEmptyDirectory(dirPath string, t *testing.T) string {
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+func (s *operationsTestSuite) createDestNonEmptyDirectory(dirPath string) string {
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 
 	destSubDir := path.Join(dirPath, SubDirInNonEmptyDestCopyDirectory)
-	operations.CreateDirectoryWithNFiles(0, destSubDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, destSubDir, "", s.T())
 
 	return dirPath
 }
 
 func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
+	srcDir := s.createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory))
 
 	// Create below directory
 	// destCopyDir               -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
+	destDir := s.createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory))
 
 	err := operations.CopyDir(srcDir, destDir)
 	require.NoError(s.T(), err, "Error in copying directory")
@@ -207,17 +206,17 @@ func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
+	s.checkIfCopiedDirectoryHasCorrectData(destSrc)
 }
 
-func checkIfCopiedEmptyDirectoryHasNoData(destSrc string, t *testing.T) {
+func (s *operationsTestSuite) checkIfCopiedEmptyDirectoryHasNoData(destSrc string) {
 	objs, err := os.ReadDir(destSrc)
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	if len(objs) != 0 {
-		t.Errorf("Directory has incorrect data.")
+		s.T().Errorf("Directory has incorrect data.")
 	}
 }
 
@@ -240,7 +239,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	// Create below directory
 	// destNonEmptyCopyDirectory                                                -- Dir
 	// destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory              -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
+	destDir := s.createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory))
 
 	err := operations.CopyDir(srcDir, destDir)
 	require.NoError(s.T(), err, "Error in copying directory")
@@ -272,7 +271,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
+	s.checkIfCopiedEmptyDirectoryHasNoData(copyDirPath)
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -316,7 +315,7 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInEmptyDirectory() {
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
+	s.checkIfCopiedEmptyDirectoryHasNoData(copyDirPath)
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -341,5 +340,5 @@ func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonExistingDirectory() {
 	err = operations.CopyDir(srcDir, destDir)
 	require.NoError(s.T(), err, "Error in copying directory")
 
-	checkIfCopiedEmptyDirectoryHasNoData(destDir, s.T())
+	s.checkIfCopiedEmptyDirectoryHasNoData(destDir)
 }

--- a/tools/integration_tests/operations/copy_dir_test.go
+++ b/tools/integration_tests/operations/copy_dir_test.go
@@ -107,17 +107,17 @@ func checkIfCopiedDirectoryHasCorrectData(destDir string, t *testing.T) {
 // destCopyDir               -- Dir
 // destCopyDir/copy.txt      -- File
 // destCopyDir/subSrcCopyDir -- Dir
-func TestCopyDirectoryInNonExistingDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInNonExistingDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
-	checkIfCopiedDirectoryHasCorrectData(destDir, t)
+	checkIfCopiedDirectoryHasCorrectData(destDir, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -129,21 +129,21 @@ func TestCopyDirectoryInNonExistingDirectory(t *testing.T) {
 // destCopyDir/srcCopyDir               -- Dir
 // destCopyDir/srcCopyDir/copy.txt      -- File
 // destCopyDir/srcCopyDir/subSrcCopyDir -- Dir
-func TestCopyDirectoryInEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
 	destDir := path.Join(testDir, DestCopyDirectory)
 	err := os.Mkdir(destDir, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Error in creating directory: %v", err)
+		s.T().Errorf("Error in creating directory: %v", err)
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -155,12 +155,12 @@ func TestCopyDirectoryInEmptyDirectory(t *testing.T) {
 	// destCopyDirectory
 	// destCopyDirectory/srcCopyDirectory
 	if len(obj) != 1 || obj[0].Name() != SrcCopyDirectory || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, t)
+	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
 }
 
 func createDestNonEmptyDirectory(dirPath string, t *testing.T) string {
@@ -172,17 +172,17 @@ func createDestNonEmptyDirectory(dirPath string, t *testing.T) string {
 	return dirPath
 }
 
-func TestCopyDirectoryInNonEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyDirectoryInNonEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), t)
+	srcDir := createSrcDirectoryWithObjects(path.Join(testDir, SrcCopyDirectory), s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), t)
+	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -195,24 +195,24 @@ func TestCopyDirectoryInNonEmptyDirectory(t *testing.T) {
 	// destCopyDirectory/srcCopyDirectory
 	// destCopyDirectory/subDestCopyDirectory
 	if len(obj) != NumberOfObjectsInNonEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destCopyDirectory/srcCopyDirectory  - Dir
 	if obj[0].Name() != SrcCopyDirectory || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	// destCopyDirectory/subDirInNonEmptyDestCopyDirectory  - Dir
 	if obj[1].Name() != SubDirInNonEmptyDestCopyDirectory || obj[1].IsDir() != true {
-		t.Errorf("Existing object affected.")
+		s.T().Errorf("Existing object affected.")
 		return
 	}
 
 	destSrc := path.Join(destDir, SrcCopyDirectory)
-	checkIfCopiedDirectoryHasCorrectData(destSrc, t)
+	checkIfCopiedDirectoryHasCorrectData(destSrc, s.T())
 }
 
 func checkIfCopiedEmptyDirectoryHasNoData(destSrc string, t *testing.T) {
@@ -236,20 +236,20 @@ func checkIfCopiedEmptyDirectoryHasNoData(destSrc string, t *testing.T) {
 // destNonEmptyCopyDirectory
 // destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory
 // destNonEmptyCopyDirectory/emptySrcDirectoryCopyTest
-func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// Create below directory
 	// destNonEmptyCopyDirectory                                                -- Dir
 	// destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory              -- Dir
-	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), t)
+	destDir := createDestNonEmptyDirectory(path.Join(testDir, DestNonEmptyCopyDirectory), s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	objs, err := os.ReadDir(destDir)
@@ -262,24 +262,24 @@ func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
 	// destNonEmptyCopyDirectory/emptyDirectoryCopyTest           - Dir
 	// destNonEmptyCopyDirectory/subDestCopyDirectory             - Dir
 	if len(objs) != NumberOfObjectsInNonEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destNonEmptyCopyDirectory/srcCopyDirectory  - Dir
 	if objs[0].Name() != EmptySrcDirectoryCopyTest || objs[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	// destNonEmptyCopyDirectory/subDirInNonEmptyDestCopyDirectory  - Dir
 	if objs[1].Name() != SubDirInNonEmptyDestCopyDirectory || objs[1].IsDir() != true {
-		t.Errorf("Existing object affected.")
+		s.T().Errorf("Existing object affected.")
 		return
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, t)
+	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -289,20 +289,20 @@ func TestCopyEmptyDirectoryInNonEmptyDirectory(t *testing.T) {
 
 // Output
 // destEmptyCopyDirectory/emptySrcDirectoryCopyTest
-func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInEmptyDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// Create below directory
 	// destCopyDir               -- Dir
 	destDir := path.Join(testDir, DestEmptyCopyDirectory)
-	operations.CreateDirectoryWithNFiles(0, destDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, destDir, "", s.T())
 
 	err := operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
 	obj, err := os.ReadDir(destDir)
@@ -314,18 +314,18 @@ func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
 	// destEmptyCopyDirectory
 	// destEmptyCopyDirectory/emptyDirectoryCopyTest
 	if len(obj) != NumberOfObjectsInEmptyDestCopyDirectory {
-		t.Errorf("The number of objects in the current directory doesn't match.")
+		s.T().Errorf("The number of objects in the current directory doesn't match.")
 		return
 	}
 
 	// destEmptyCopyDirectory/srcCopyDirectory  - Dir
 	if obj[0].Name() != EmptySrcDirectoryCopyTest || obj[0].IsDir() != true {
-		t.Errorf("Error in copying directory.")
+		s.T().Errorf("Error in copying directory.")
 		return
 	}
 
 	copyDirPath := path.Join(destDir, EmptySrcDirectoryCopyTest)
-	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, t)
+	checkIfCopiedEmptyDirectoryHasNoData(copyDirPath, s.T())
 }
 
 // Copy SrcDirectory in DestDirectory
@@ -333,24 +333,24 @@ func TestCopyEmptyDirectoryInEmptyDirectory(t *testing.T) {
 
 // Output
 // destCopyDirectoryNotExist
-func TestCopyEmptyDirectoryInNonExistingDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestCopyEmptyDirectoryInNonExistingDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	srcDir := path.Join(testDir, EmptySrcDirectoryCopyTest)
-	operations.CreateDirectoryWithNFiles(0, srcDir, "", t)
+	operations.CreateDirectoryWithNFiles(0, srcDir, "", s.T())
 
 	// destCopyDirectoryNotExist             -- Dir
 	destDir := path.Join(testDir, DestCopyDirectoryNotExist)
 
 	_, err := os.Stat(destDir)
 	if err == nil {
-		t.Errorf("destCopyDirectoryNotExist directory exist.")
+		s.T().Errorf("destCopyDirectoryNotExist directory exist.")
 	}
 
 	err = operations.CopyDir(srcDir, destDir)
 	if err != nil {
-		t.Errorf("Error in copying directory: %v", err)
+		s.T().Errorf("Error in copying directory: %v", err)
 	}
 
-	checkIfCopiedEmptyDirectoryHasNoData(destDir, t)
+	checkIfCopiedEmptyDirectoryHasNoData(destDir, s.T())
 }

--- a/tools/integration_tests/operations/copy_file_test.go
+++ b/tools/integration_tests/operations/copy_file_test.go
@@ -18,37 +18,36 @@ package operations_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestCopyFile(t *testing.T) {
+func (s *operationsTestSuite) TestCopyFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName+setup.GenerateRandomString(5))
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 	defer os.Remove(fileName)
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {
-		t.Errorf("Read: %v", err)
+		s.T().Errorf("Read: %v", err)
 	}
 
 	newFileName := fileName + "Copy"
 	if _, err := os.Stat(newFileName); err == nil {
-		t.Errorf("Copied file %s already present", newFileName)
+		s.T().Errorf("Copied file %s already present", newFileName)
 	}
 
 	err = operations.CopyFile(fileName, newFileName)
 	if err != nil {
-		t.Errorf("Error : %v", err)
+		s.T().Errorf("Error : %v", err)
 	}
 	defer os.Remove(newFileName)
 
 	// Check if the data in the copied file matches the original file,
 	// and the data in original file is unchanged.
-	setup.CompareFileContents(t, newFileName, string(content))
-	setup.CompareFileContents(t, fileName, string(content))
+	setup.CompareFileContents(s.T(), newFileName, string(content))
+	setup.CompareFileContents(s.T(), fileName, string(content))
 }

--- a/tools/integration_tests/operations/create_three_level_dir_test.go
+++ b/tools/integration_tests/operations/create_three_level_dir_test.go
@@ -22,13 +22,12 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestCreateThreeLevelDirectories(t *testing.T) {
+func (s *operationsTestSuite) TestCreateThreeLevelDirectories() {
 	// Directory structure
 	// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest                                                                       -- Dir
 	// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest                                       -- Dir
@@ -39,19 +38,19 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 
 	dirPath := path.Join(testDir, DirOneInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 
 	subDirPath := path.Join(dirPath, DirTwoInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(0, subDirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, subDirPath, "", s.T())
 
 	subDirPath2 := path.Join(subDirPath, DirThreeInCreateThreeLevelDirTest)
 
-	operations.CreateDirectoryWithNFiles(1, subDirPath2, PrefixFileInDirThreeInCreateThreeLevelDirTest, t)
+	operations.CreateDirectoryWithNFiles(1, subDirPath2, PrefixFileInDirThreeInCreateThreeLevelDirTest, s.T())
 	filePath := path.Join(subDirPath2, FileInDirThreeInCreateThreeLevelDirTest)
 	err := operations.WriteFileInAppendMode(filePath, ContentInFileInDirThreeInCreateThreeLevelDirTest)
 	if err != nil {
-		t.Errorf("Write file error: %v", err)
+		s.T().Errorf("Write file error: %v", err)
 	}
 
 	// Recursively walk into directory and test.
@@ -75,12 +74,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dirPath == testDir {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInBucketDirectoryCreateTest {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest   -- Dir
 			if objs[0].Name() != DirOneInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 		}
 
@@ -88,12 +87,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirOneInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirOneInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirOneInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirOneInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest    -- Dir
 			if objs[0].Name() != DirTwoInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 			return nil
 		}
@@ -102,12 +101,12 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirTwoInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirTwoInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirTwoInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirTwoInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest/dirThreeInCreateThreeLevelDirTest    -- Dir
 			if objs[0].Name() != DirThreeInCreateThreeLevelDirTest || objs[0].IsDir() != true {
-				t.Errorf("Directory is not created.")
+				s.T().Errorf("Directory is not created.")
 			}
 			return nil
 		}
@@ -116,23 +115,23 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirThreeInCreateThreeLevelDirTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInDirThreeInCreateThreeLevelDirTest {
-				t.Errorf("Incorrect number of objects in the dirThreeInCreateThreeLevelDirTest.")
+				s.T().Errorf("Incorrect number of objects in the dirThreeInCreateThreeLevelDirTest.")
 			}
 
 			// testBucket/dirForOperationTests/dirOneInCreateThreeLevelDirTest/dirTwoInCreateThreeLevelDirTest/dirThreeInCreateThreeLevelDirTest/fileInDirThreeInCreateThreeLevelDirTest     -- File
 			if objs[0].Name() != FileInDirThreeInCreateThreeLevelDirTest || objs[0].IsDir() != false {
-				t.Errorf("Incorrect object exist in the dirThreeInCreateThreeLevelDirTest directory.")
+				s.T().Errorf("Incorrect object exist in the dirThreeInCreateThreeLevelDirTest directory.")
 			}
 
 			// Check if the content of the file is correct.
 			filePath := path.Join(dirPath, objs[0].Name())
 			content, err := operations.ReadFile(filePath)
 			if err != nil {
-				t.Errorf("Error in reading file:%v", err)
+				s.T().Errorf("Error in reading file:%v", err)
 			}
 
 			if got, want := string(content), ContentInFileInDirThreeInCreateThreeLevelDirTest; got != want {
-				t.Errorf("File content %q not match %q", got, want)
+				s.T().Errorf("File content %q not match %q", got, want)
 			}
 
 			return nil
@@ -141,7 +140,7 @@ func TestCreateThreeLevelDirectories(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }

--- a/tools/integration_tests/operations/delete_dir_test.go
+++ b/tools/integration_tests/operations/delete_dir_test.go
@@ -18,101 +18,100 @@ package operations_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestDeleteEmptyExplicitDir(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteEmptyExplicitDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, EmptyExplicitDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {
-		t.Errorf("Error in deleting empty explicit directory.")
+		s.T().Errorf("Error in deleting empty explicit directory.")
 	}
 
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.Name() == EmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
-		t.Errorf("Directory is not deleted.")
+		s.T().Errorf("Directory is not deleted.")
 	}
 }
 
-func TestDeleteNonEmptyExplicitDir(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteNonEmptyExplicitDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, NonEmptyExplicitDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest, dirPath, PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitDirectoryForDeleteTest, dirPath, PrefixFilesInNonEmptyExplicitDirectoryForDeleteTest, s.T())
 
 	subDirPath := path.Join(dirPath, NonEmptyExplicitSubDirectoryForDeleteTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest, subDirPath, PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInNonEmptyExplicitSubDirectoryForDeleteTest, subDirPath, PrefixFilesInNonEmptyExplicitSubDirectoryForDeleteTest, s.T())
 
 	err := os.RemoveAll(dirPath)
 	if err != nil {
-		t.Errorf("Error in deleting empty explicit directory.")
+		s.T().Errorf("Error in deleting empty explicit directory.")
 	}
 
 	dir, err := os.Stat(dirPath)
 	if err == nil && dir.Name() == NonEmptyExplicitDirectoryForDeleteTest && dir.IsDir() {
-		t.Errorf("Directory is not deleted.")
+		s.T().Errorf("Directory is not deleted.")
 	}
 }
 
-func TestRmDirAlreadyDeletedExplicitDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirAlreadyDeletedExplicitDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "explicit_dir_double_delete")
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 	// Delete explicit directory first time.
 	err := os.Remove(dirPath)
 	if err != nil {
-		t.Fatalf("Error in deleting empty explicit directory: %v", err)
+		s.T().Fatalf("Error in deleting empty explicit directory: %v", err)
 	}
 
 	// Delete it again via RmDir, which must return os.ErrNotExist (ENOENT).
 	err = os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when deleting non-existent explicit directory, got nil")
+		s.T().Errorf("Expected ENOENT error when deleting non-existent explicit directory, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error when deleting non-existent explicit directory, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error when deleting non-existent explicit directory, got: %v", err)
 	}
 }
 
-func TestRmDirNonExistentDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirNonExistentDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "non_existent_dir_rmdir_enoent")
 
 	err := os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when calling RmDir on non-existent path, got nil")
+		s.T().Errorf("Expected ENOENT error when calling RmDir on non-existent path, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error when calling RmDir on non-existent path, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error when calling RmDir on non-existent path, got: %v", err)
 	}
 }
 
-func TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT(t *testing.T) {
+func (s *operationsTestSuite) TestRmDirOutOfBandDeletedExplicitDirReturnsENOENT() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirName := "oob_deleted_explicit_dir"
 	dirPath := path.Join(testDir, dirName)
-	operations.CreateDirectoryWithNFiles(0, dirPath, "", t)
+	operations.CreateDirectoryWithNFiles(0, dirPath, "", s.T())
 	if _, err := os.Stat(dirPath); err != nil {
-		t.Fatalf("Error statting explicit directory: %v", err)
+		s.T().Fatalf("Error statting explicit directory: %v", err)
 	}
 	client.DeleteDirOnGCS(ctx, storageClient, path.Join(DirForOperationTests, dirName))
 
 	err := os.Remove(dirPath)
 
 	if err == nil {
-		t.Errorf("Expected ENOENT error when deleting out-of-band deleted explicit directory, got nil")
+		s.T().Errorf("Expected ENOENT error when deleting out-of-band deleted explicit directory, got nil")
 	}
 	if !os.IsNotExist(err) {
-		t.Errorf("Expected os.ErrNotExist (ENOENT) error, got: %v", err)
+		s.T().Errorf("Expected os.ErrNotExist (ENOENT) error, got: %v", err)
 	}
 }

--- a/tools/integration_tests/operations/delete_file_test.go
+++ b/tools/integration_tests/operations/delete_file_test.go
@@ -18,7 +18,6 @@ package operations_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -28,27 +27,27 @@ const DirNameInTestBucket = "A"               // testBucket/A
 const FileNameInTestBucket = "A.txt"          // testBucket/A.txt
 const FileNameInDirectoryTestBucket = "a.txt" // testBucket/A/a.txt
 
-func checkIfFileDeletionSucceeded(filePath string, t *testing.T) {
+func (s *operationsTestSuite) checkIfFileDeletionSucceeded(filePath string) {
 	err := os.Remove(filePath)
 
 	if err != nil {
-		t.Errorf("File deletion failed: %v", err)
+		s.T().Errorf("File deletion failed: %v", err)
 	}
 
 	file, err := os.Stat(filePath)
 	if err == nil && file.IsDir() == false {
-		t.Errorf("File is not deleted.")
+		s.T().Errorf("File is not deleted.")
 	}
 }
 
-func createFile(filePath string, t *testing.T) {
+func (s *operationsTestSuite) createFile(filePath string) {
 	file, err := os.Create(filePath)
 	if err != nil {
-		t.Errorf("Error in creating file: %v", err)
+		s.T().Errorf("Error in creating file: %v", err)
 	}
 
 	// Closing file at the end
-	operations.CloseFileShouldNotThrowError(t, file)
+	operations.CloseFileShouldNotThrowError(s.T(), file)
 }
 
 // Remove testBucket/A.txt
@@ -57,9 +56,9 @@ func (s *operationsTestSuite) TestDeleteFileFromBucket() {
 
 	filePath := path.Join(testDir, FileNameInTestBucket)
 
-	createFile(filePath, s.T())
+	s.createFile(filePath)
 
-	checkIfFileDeletionSucceeded(filePath, s.T())
+	s.checkIfFileDeletionSucceeded(filePath)
 }
 
 // Remove testBucket/A/a.txt
@@ -73,7 +72,7 @@ func (s *operationsTestSuite) TestDeleteFileFromBucketDirectory() {
 	}
 
 	filePath := path.Join(dirPath, FileNameInDirectoryTestBucket)
-	createFile(filePath, s.T())
+	s.createFile(filePath)
 
-	checkIfFileDeletionSucceeded(filePath, s.T())
+	s.checkIfFileDeletionSucceeded(filePath)
 }

--- a/tools/integration_tests/operations/delete_file_test.go
+++ b/tools/integration_tests/operations/delete_file_test.go
@@ -52,28 +52,28 @@ func createFile(filePath string, t *testing.T) {
 }
 
 // Remove testBucket/A.txt
-func TestDeleteFileFromBucket(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteFileFromBucket() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	filePath := path.Join(testDir, FileNameInTestBucket)
 
-	createFile(filePath, t)
+	createFile(filePath, s.T())
 
-	checkIfFileDeletionSucceeded(filePath, t)
+	checkIfFileDeletionSucceeded(filePath, s.T())
 }
 
 // Remove testBucket/A/a.txt
-func TestDeleteFileFromBucketDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestDeleteFileFromBucketDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	dirPath := path.Join(testDir, DirNameInTestBucket)
 	err := os.Mkdir(dirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Error in creating directory: %v", err)
+		s.T().Errorf("Error in creating directory: %v", err)
 	}
 
 	filePath := path.Join(dirPath, FileNameInDirectoryTestBucket)
-	createFile(filePath, t)
+	createFile(filePath, s.T())
 
-	checkIfFileDeletionSucceeded(filePath, t)
+	checkIfFileDeletionSucceeded(filePath, s.T())
 }

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
@@ -35,7 +34,7 @@ const (
 	retryDuration              = 3 * time.Minute
 )
 
-func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCreateTime time.Time, byteSize int64, t *testing.T) error {
+func (s *operationsTestSuite) checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCreateTime time.Time, byteSize int64) error {
 	oStat, err := os.Stat(objName)
 
 	if err != nil {
@@ -54,7 +53,7 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	if oStat.Size() != byteSize {
 		return fmt.Errorf("object size mismatch: got %d bytes, want %d bytes", oStat.Size(), byteSize)
 	}
-	t.Logf("Attributes for %q are correct. ModTime: %v (expected range: [%v, %v])", objName, statModTime, preCreateTime, postCreateTime)
+	s.T().Logf("Attributes for %q are correct. ModTime: %v (expected range: [%v, %v])", objName, statModTime, preCreateTime, postCreateTime)
 	return nil
 }
 
@@ -73,7 +72,7 @@ func (s *operationsTestSuite) TestFileAttributes() {
 
 		// The file size in createTempFile() is BytesWrittenInFile bytes
 		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
-		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, s.T())
+		err := s.checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile)
 		return err == nil, err
 	})
 }
@@ -91,7 +90,7 @@ func (s *operationsTestSuite) TestEmptyDirAttributes() {
 		operations.CreateDirectoryWithNFiles(0, dirName, "", s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
+		err := s.checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0)
 		return err == nil, err
 	})
 }
@@ -109,7 +108,7 @@ func (s *operationsTestSuite) TestNonEmptyDirAttributes() {
 		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
+		err := s.checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0)
 		return err == nil, err
 	})
 }

--- a/tools/integration_tests/operations/file_and_dir_attributes_test.go
+++ b/tools/integration_tests/operations/file_and_dir_attributes_test.go
@@ -58,58 +58,58 @@ func checkIfObjectAttrIsCorrect(objName string, preCreateTime time.Time, postCre
 	return nil
 }
 
-func TestFileAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestFileAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Logf("Verifying file attributes. Expecting: correct name, size = %d bytes, and mod time within window.", BytesWrittenInFile)
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		fileName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Logf("Verifying file attributes. Expecting: correct name, size = %d bytes, and mod time within window.", BytesWrittenInFile)
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		fileName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+		operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 		postCreateTime := time.Now().Add(+operations.TimeSlop)
 
 		// The file size in createTempFile() is BytesWrittenInFile bytes
 		// https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/util/setup/setup.go#L124
-		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, t)
+		err := checkIfObjectAttrIsCorrect(fileName, preCreateTime, postCreateTime, BytesWrittenInFile, s.T())
 		return err == nil, err
 	})
 }
 
-func TestEmptyDirAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestEmptyDirAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Log("Verifying empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		dirName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Log("Verifying empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateDirectoryWithNFiles(0, dirName, "", t)
+		operations.CreateDirectoryWithNFiles(0, dirName, "", s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
 		return err == nil, err
 	})
 }
 
-func TestNonEmptyDirAttributes(t *testing.T) {
+func (s *operationsTestSuite) TestNonEmptyDirAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
-	t.Log("Verifying non-empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
-	operations.RetryUntil(context.Background(), t, retryFrequency, retryDuration, func() (bool, error) {
-		dirName := path.Join(testDir, operations.GetRandomName(t))
+	s.T().Log("Verifying non-empty directory attributes. Expecting: correct name, size = 0 bytes, and mod time within window.")
+	operations.RetryUntil(context.Background(), s.T(), retryFrequency, retryDuration, func() (bool, error) {
+		dirName := path.Join(testDir, operations.GetRandomName(s.T()))
 		// kernel time can be slightly out of sync of time.Now(), so using
 		// operations.TimeSlop to adjust pre and post create time.
 		// Ref: https://github.com/golang/go/issues/33510
 		preCreateTime := time.Now().Add(-operations.TimeSlop)
-		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, t)
+		operations.CreateDirectoryWithNFiles(NumberOfFilesInDirAttrTest, dirName, PrefixFileInDirAttrTest, s.T())
 		postCreateTime := time.Now().Add(operations.TimeSlop)
 
-		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, t)
+		err := checkIfObjectAttrIsCorrect(dirName, preCreateTime, postCreateTime, 0, s.T())
 		return err == nil, err
 	})
 }

--- a/tools/integration_tests/operations/list_dir_test.go
+++ b/tools/integration_tests/operations/list_dir_test.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"syscall"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
@@ -32,7 +31,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createDirectoryStructureForTest(t *testing.T) {
+func (s *operationsTestSuite) createDirectoryStructureForTest() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	// Directory structure
@@ -48,29 +47,29 @@ func createDirectoryStructureForTest(t *testing.T) {
 	// testBucket/dirForOperationTests/directoryForListTest
 	// testBucket/dirForOperationTests/directoryForListTest/fileInFirstSubDirectoryForListTest1
 	dirPath := path.Join(testDir, DirectoryForListTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirectoryForListTest, dirPath, PrefixFileInDirectoryForListTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInDirectoryForListTest, dirPath, PrefixFileInDirectoryForListTest, s.T())
 
 	// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest
 	// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest/fileInFirstSubDirectoryForListTest1
 	subDirPath := path.Join(dirPath, FirstSubDirectoryForListTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInFirstSubDirectoryForListTest, subDirPath, PrefixFileInFirstSubDirectoryForListTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInFirstSubDirectoryForListTest, subDirPath, PrefixFileInFirstSubDirectoryForListTest, s.T())
 
 	// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest
 	// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest1
 	// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest2
 	subDirPath = path.Join(dirPath, SecondSubDirectoryForListTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInSecondSubDirectoryForListTest, subDirPath, PrefixFileInSecondSubDirectoryForListTest, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInSecondSubDirectoryForListTest, subDirPath, PrefixFileInSecondSubDirectoryForListTest, s.T())
 
 	// testBucket/dirForOperationTests/directoryForListTest/emptySubDirInDirectoryForListTest
 	subDirPath = path.Join(dirPath, EmptySubDirInDirectoryForListTest)
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptySubDirInDirectoryForListTest, subDirPath, "", t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptySubDirInDirectoryForListTest, subDirPath, "", s.T())
 }
 
 func (s *operationsTestSuite) TestListDirectoryRecursively() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	// Create directory structure for testing.
-	createDirectoryStructureForTest(s.T())
+	s.createDirectoryStructureForTest()
 
 	// Recursively walk into directory and test.
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {

--- a/tools/integration_tests/operations/list_dir_test.go
+++ b/tools/integration_tests/operations/list_dir_test.go
@@ -66,11 +66,11 @@ func createDirectoryStructureForTest(t *testing.T) {
 	operations.CreateDirectoryWithNFiles(NumberOfFilesInEmptySubDirInDirectoryForListTest, subDirPath, "", t)
 }
 
-func TestListDirectoryRecursively(t *testing.T) {
+func (s *operationsTestSuite) TestListDirectoryRecursively() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	// Create directory structure for testing.
-	createDirectoryStructureForTest(t)
+	createDirectoryStructureForTest(s.T())
 
 	// Recursively walk into directory and test.
 	err := filepath.WalkDir(testDir, func(path string, dir fs.DirEntry, err error) error {
@@ -93,12 +93,12 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if path == testDir {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInBucketDirectoryListTest {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest   -- Dir
 			if objs[0].Name() != DirectoryForListTest || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 		}
 
@@ -106,27 +106,27 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == DirectoryForListTest {
 			// numberOfObjects - 4
 			if len(objs) != NumberOfObjectsInDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the directoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the directoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/emptySubDirectoryForListTest   -- Dir
 			if objs[0].Name() != EmptySubDirInDirectoryForListTest || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/fileInDirectoryForListTest1     -- File
 			if objs[1].Name() != FileInDirectoryForListTest || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest   -- Dir
 			if objs[2].Name() != FirstSubDirectoryForListTest || objs[2].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest  -- Dir
 			if objs[3].Name() != SecondSubDirectoryForListTest || objs[3].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -136,12 +136,12 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == FirstSubDirectoryForListTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInFirstSubDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the firstSubDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the firstSubDirectoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/firstSubDirectoryForListTest/fileInFirstSubDirectoryForListTest1     -- File
 			if objs[0].Name() != FileInFirstSubDirectoryForListTest || objs[0].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -151,17 +151,17 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == SecondSubDirectoryForListTest {
 			// numberOfObjects - 1
 			if len(objs) != NumberOfObjectsInSecondSubDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the secondSubDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the secondSubDirectoryForListTest.")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest1    -- File
 			if objs[0].Name() != FirstFileInSecondSubDirectoryForListTest || objs[0].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForOperationTests/directoryForListTest/secondSubDirectoryForListTest/fileInSecondSubDirectoryForListTest2   -- File
 			if objs[1].Name() != SecondFileInSecondSubDirectoryForListTest || objs[1].IsDir() == true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			return nil
@@ -171,7 +171,7 @@ func TestListDirectoryRecursively(t *testing.T) {
 		if dir.IsDir() && dir.Name() == EmptySubDirInDirectoryForListTest {
 			// numberOfObjects - 0
 			if len(objs) != NumberOfObjectsInEmptySubDirInDirectoryForListTest {
-				t.Errorf("Incorrect number of objects in the emptySubDirInDirectoryForListTest.")
+				s.T().Errorf("Incorrect number of objects in the emptySubDirInDirectoryForListTest.")
 			}
 
 			return nil
@@ -180,22 +180,22 @@ func TestListDirectoryRecursively(t *testing.T) {
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }
 
-func TestReadFileWorksAfterListDir(t *testing.T) {
+func (s *operationsTestSuite) TestReadFileWorksAfterListDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	obj1 := t.Name() + "-1"
+	obj1 := s.T().Name() + "-1"
 	var objSize int64 = 5
-	client.SetupFileInTestDirectory(ctx, storageClient, DirForOperationTests, obj1, objSize, t)
+	client.SetupFileInTestDirectory(ctx, storageClient, DirForOperationTests, obj1, objSize, s.T())
 
-	_ = operations.ReadDirectory(testDir, t)
+	_ = operations.ReadDirectory(testDir, s.T())
 	fh, err := os.OpenFile(path.Join(testDir, obj1), syscall.O_DIRECT, operations.FilePermission_0600)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	content, err := operations.ReadFileSequentially(fh, util.MiB)
 
-	require.NoError(t, err)
-	require.EqualValues(t, objSize, len(content))
+	require.NoError(s.T(), err)
+	require.EqualValues(s.T(), objSize, len(content))
 }

--- a/tools/integration_tests/operations/list_dir_test.go
+++ b/tools/integration_tests/operations/list_dir_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
@@ -186,7 +187,7 @@ func (s *operationsTestSuite) TestListDirectoryRecursively() {
 
 func (s *operationsTestSuite) TestReadFileWorksAfterListDir() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
-	obj1 := s.T().Name() + "-1"
+	obj1 := strings.ReplaceAll(s.T().Name(), "/", "_") + "-1"
 	var objSize int64 = 5
 	client.SetupFileInTestDirectory(ctx, storageClient, DirForOperationTests, obj1, objSize, s.T())
 

--- a/tools/integration_tests/operations/move_file_test.go
+++ b/tools/integration_tests/operations/move_file_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -29,43 +28,43 @@ import (
 // Create below directory and file.
 // Test               -- Directory
 // Test/move.txt      -- File
-func createSrcDirectoryAndFile(dirPath string, filePath string, t *testing.T) {
+func (s *operationsTestSuite) createSrcDirectoryAndFile(dirPath string, filePath string) {
 	err := os.Mkdir(dirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", dirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", dirPath, err)
 		return
 	}
 
 	file, err := os.Create(filePath)
 	if err != nil {
-		t.Errorf("Error in creating file %v:", err)
+		s.T().Errorf("Error in creating file %v:", err)
 	}
 
 	// Closing file at the end.
-	defer operations.CloseFileShouldNotThrowError(t, file)
+	defer operations.CloseFileShouldNotThrowError(s.T(), file)
 
 	err = operations.WriteFile(file.Name(), MoveFileContent)
 	if err != nil {
-		t.Errorf("File at %v", err)
+		s.T().Errorf("File at %v", err)
 	}
 }
 
-func checkIfFileMoveOperationSucceeded(srcFilePath string, destDirPath string, t *testing.T) {
+func (s *operationsTestSuite) checkIfFileMoveOperationSucceeded(srcFilePath string, destDirPath string) {
 	// Move file from Test/move.txt to destination.
 	err := operations.Move(srcFilePath, destDirPath)
 	if err != nil {
-		t.Errorf("Error in moving file: %v", err)
+		s.T().Errorf("Error in moving file: %v", err)
 	}
 
 	// Check if the file content matches.
 	moveFilePath := path.Join(destDirPath, MoveFile)
 	content, err := operations.ReadFile(moveFilePath)
 	if err != nil {
-		t.Errorf("ReadAll: %v", err)
+		s.T().Errorf("ReadAll: %v", err)
 	}
 
 	if got, want := string(content), MoveFileContent; got != want {
-		t.Errorf("File content %q not match %q", got, want)
+		s.T().Errorf("File content %q not match %q", got, want)
 	}
 }
 
@@ -75,7 +74,7 @@ func (s *operationsTestSuite) TestMoveFileWithinSameDirectory() {
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, s.T())
+	s.createSrcDirectoryAndFile(dirPath, filePath)
 
 	destDirPath := path.Join(dirPath, "a")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
@@ -83,7 +82,7 @@ func (s *operationsTestSuite) TestMoveFileWithinSameDirectory() {
 		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
+	s.checkIfFileMoveOperationSucceeded(filePath, destDirPath)
 }
 
 // Move file from Test/move.txt to Test1/move.txt
@@ -92,7 +91,7 @@ func (s *operationsTestSuite) TestMoveFileWithinDifferentDirectory() {
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, s.T())
+	s.createSrcDirectoryAndFile(dirPath, filePath)
 
 	destDirPath := path.Join(testDir, "Test2")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
@@ -100,7 +99,7 @@ func (s *operationsTestSuite) TestMoveFileWithinDifferentDirectory() {
 		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
+	s.checkIfFileMoveOperationSucceeded(filePath, destDirPath)
 }
 
 // Rename file from Test/move1.txt to Test/move2.txt

--- a/tools/integration_tests/operations/move_file_test.go
+++ b/tools/integration_tests/operations/move_file_test.go
@@ -70,58 +70,58 @@ func checkIfFileMoveOperationSucceeded(srcFilePath string, destDirPath string, t
 }
 
 // Move file from Test/move.txt to Test/a/move.txt
-func TestMoveFileWithinSameDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithinSameDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, t)
+	createSrcDirectoryAndFile(dirPath, filePath, s.T())
 
 	destDirPath := path.Join(dirPath, "a")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", destDirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, t)
+	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
 }
 
 // Move file from Test/move.txt to Test1/move.txt
-func TestMoveFileWithinDifferentDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithinDifferentDirectory() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	dirPath := path.Join(testDir, "Test")
 	filePath := path.Join(dirPath, MoveFile)
 
-	createSrcDirectoryAndFile(dirPath, filePath, t)
+	createSrcDirectoryAndFile(dirPath, filePath, s.T())
 
 	destDirPath := path.Join(testDir, "Test2")
 	err := os.Mkdir(destDirPath, setup.FilePermission_0600)
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", destDirPath, err)
+		s.T().Errorf("Mkdir at %q: %v", destDirPath, err)
 	}
 
-	checkIfFileMoveOperationSucceeded(filePath, destDirPath, t)
+	checkIfFileMoveOperationSucceeded(filePath, destDirPath, s.T())
 }
 
 // Rename file from Test/move1.txt to Test/move2.txt
-func TestMoveFileWithDestFileExist(t *testing.T) {
+func (s *operationsTestSuite) TestMoveFileWithDestFileExist() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Define source and destination file names.
 	srcFilePath := path.Join(testDir, "move1.txt")
 	destFilePath := path.Join(testDir, "move2.txt")
 	// Create the source and dest file with some content.
-	operations.CreateFileWithContent(srcFilePath, setup.FilePermission_0600, Content, t)
-	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, "Hello from dest file", t)
+	operations.CreateFileWithContent(srcFilePath, setup.FilePermission_0600, Content, s.T())
+	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, "Hello from dest file", s.T())
 
 	// Move the file.
 	err := operations.Move(srcFilePath, destFilePath)
 
-	assert.NoError(t, err, "error in file moving")
+	assert.NoError(s.T(), err, "error in file moving")
 	// Verify the file was renamed and content is preserved.
-	setup.CompareFileContents(t, destFilePath, Content)
+	setup.CompareFileContents(s.T(), destFilePath, Content)
 	// Verify the old file is removed.
 	_, err = os.Stat(srcFilePath)
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no such file or directory"))
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "no such file or directory"))
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -56,12 +56,17 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
 				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
 				require.NoError(t, err, "Static mount failed")
+				defer func() {
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+				}()
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
+
+			if setup.TestOnTPCEndPoint() {
+				return
+			}
 
 			// 2. Only-dir mounting
 			t.Run("OnlyDir", func(t *testing.T) {
@@ -72,6 +77,8 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 						log.Printf("Error deleting object on GCS: %v", err)
 					}
 					setup.SetOnlyDirMounted("")
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
 				}()
 
 				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
@@ -79,9 +86,6 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				require.NoError(t, err, "Only dir mount failed")
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
 
 			// 3. Persistent mounting
@@ -89,11 +93,12 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
 				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
 				require.NoError(t, err, "Persistent mount failed")
+				defer func() {
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+				}()
 
 				runSuiteFunc()
-
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
 			})
 
 			// 4. Dynamic mounting
@@ -104,18 +109,19 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
 				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
 				require.NoError(t, err, "Dynamic mount failed")
+				defer func() {
+					setup.SetMntDir(rootMntDir)
+					operationsConfig.GCSFuseMountedDirectory = rootMntDir
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(operationsConfig)
+					setup.SetDynamicBucketMounted("")
+				}()
 
 				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
 				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
 				setup.SetMntDir(mntDirOfTestBucket)
 
 				runSuiteFunc()
-
-				setup.SetMntDir(rootMntDir)
-				operationsConfig.GCSFuseMountedDirectory = rootMntDir
-				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-				setup.UnmountGCSFuseWithConfig(operationsConfig)
-				setup.SetDynamicBucketMounted("")
 			})
 
 			// 5. Creds tests (runs for different auth methods)
@@ -226,11 +232,6 @@ func TestMain(m *testing.M) {
 	// 4. Override GKE specific paths with GCSFuse paths if running in GCE environment.
 	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
 	setup.SetUpTestDirForTestBucket(operationsConfig)
-
-	if setup.TestOnTPCEndPoint() {
-		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "TestOperationsBase")
-		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
-	}
 
 	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -38,6 +38,10 @@ type operationsTestSuite struct {
 	suite.Suite
 }
 
+func (s *operationsTestSuite) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
 func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
@@ -182,5 +186,7 @@ func TestMain(m *testing.M) {
 	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
 	setup.SetUpTestDirForTestBucket(operationsConfig)
 
-	os.Exit(m.Run())
+	successCode := m.Run()
+	setup.SaveLogFileInCaseOfFailure(successCode)
+	os.Exit(successCode)
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -225,5 +225,10 @@ func TestMain(m *testing.M) {
 	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
 	setup.SetUpTestDirForTestBucket(operationsConfig)
 
+	if setup.TestOnTPCEndPoint() {
+		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "")
+		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
+	}
+
 	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"log"
 	"os"
-	"path"
 	"strings"
 	"testing"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
-	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -53,15 +51,7 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
 			// 1. Static mounting
 			t.Run("Static", func(t *testing.T) {
-				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
-				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Static mount failed")
-				defer func() {
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				runSuiteFunc()
+				static_mounting.RunSuiteForStaticMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			if setup.TestOnTPCEndPoint() {
@@ -70,58 +60,17 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 			// 2. Only-dir mounting
 			t.Run("OnlyDir", func(t *testing.T) {
-				setup.SetOnlyDirMounted(onlyDirMounted)
-				client.SetupTestDirectory(ctx, storageClient, onlyDirMounted)
-				defer func() {
-					if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, onlyDirMounted); err != nil {
-						log.Printf("Error deleting object on GCS: %v", err)
-					}
-					setup.SetOnlyDirMounted("")
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
-				err := only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Only dir mount failed")
-
-				runSuiteFunc()
+				only_dir_mounting.RunSuiteForOnlyDirMounting(ctx, storageClient, operationsConfig, flags, onlyDirMounted, t, runSuiteFunc)
 			})
 
 			// 3. Persistent mounting
 			t.Run("Persistent", func(t *testing.T) {
-				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
-				require.NoError(t, err, "Persistent mount failed")
-				defer func() {
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-				}()
-
-				runSuiteFunc()
+				persistent_mounting.RunSuiteForPersistentMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			// 4. Dynamic mounting
 			t.Run("Dynamic", func(t *testing.T) {
-				rootMntDir := operationsConfig.GCSFuseMountedDirectory
-				setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
-
-				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
-				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
-				require.NoError(t, err, "Dynamic mount failed")
-				defer func() {
-					setup.SetMntDir(rootMntDir)
-					operationsConfig.GCSFuseMountedDirectory = rootMntDir
-					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-					setup.UnmountGCSFuseWithConfig(operationsConfig)
-					setup.SetDynamicBucketMounted("")
-				}()
-
-				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
-				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-				setup.SetMntDir(mntDirOfTestBucket)
-
-				runSuiteFunc()
+				dynamic_mounting.RunSuiteForDynamicMounting(operationsConfig, flags, t, runSuiteFunc)
 			})
 
 			// 5. Creds tests (runs for different auth methods)

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -41,11 +41,13 @@ type operationsTestSuite struct {
 }
 
 func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
 	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
 		runSuiteFunc()
 		return
 	}
 
+	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
 	for _, flags := range flagsSet {
 		t.Run(strings.Join(flags, "_"), func(t *testing.T) {

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"log"
 	"os"
+	"path"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -30,7 +31,84 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type operationsTestSuite struct {
+	suite.Suite
+}
+
+func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
+	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
+		runSuiteFunc()
+		return
+	}
+
+	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
+	for _, flags := range flagsSet {
+		// 1. Static mounting
+		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Static mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+
+		// 2. Only-dir mounting
+		setup.SetOnlyDirMounted(onlyDirMounted)
+		log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+		err = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Only dir mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+		setup.SetOnlyDirMounted("")
+
+		// 3. Persistent mounting
+		log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+		err = persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
+		require.NoError(t, err, "Persistent mount failed")
+
+		runSuiteFunc()
+
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+
+		// 4. Dynamic mounting
+		rootMntDir := operationsConfig.GCSFuseMountedDirectory
+		mntDirOfTestBucket := path.Join(operationsConfig.GCSFuseMountedDirectory, operationsConfig.TestBucket)
+		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+		setup.SetMntDir(mntDirOfTestBucket)
+		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
+
+		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
+		require.NoError(t, err, "Dynamic mount failed")
+
+		runSuiteFunc()
+
+		setup.SetMntDir(rootMntDir)
+		operationsConfig.GCSFuseMountedDirectory = rootMntDir
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(operationsConfig)
+		setup.SetDynamicBucketMounted("")
+
+		// 5. Creds tests (runs for different auth methods)
+		creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
+	}
+}
+
+func TestOperationsBase(t *testing.T) {
+	runOperationsSuite(t, func() {
+		suite.Run(t, new(operationsTestSuite))
+		suite.Run(t, &writeOperationsTest{isRapidWritesEnabled: false})
+	})
+}
 
 const DirForOperationTests = "dirForOperationsTest"
 const MoveFile = "move.txt"
@@ -89,8 +167,10 @@ const Content = "line 1\nline 2\n"
 const onlyDirMounted = "OnlyDirMountOperations"
 
 var (
-	storageClient *storage.Client
-	ctx           context.Context
+	storageClient    *storage.Client
+	ctx              context.Context
+	operationsConfig *test_suite.TestConfig
+	bucketType       string
 )
 
 func TestMain(m *testing.M) {
@@ -103,7 +183,8 @@ func TestMain(m *testing.M) {
 	}
 
 	ctx = context.Background()
-	bucketType := setup.TestEnvironment(ctx, &cfg.Operations[0])
+	operationsConfig = &cfg.Operations[0]
+	bucketType = setup.TestEnvironment(ctx, operationsConfig)
 
 	// 2. Create storage client before running tests.
 	var err error
@@ -115,41 +196,13 @@ func TestMain(m *testing.M) {
 	defer storageClient.Close()
 
 	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
-	if cfg.Operations[0].GKEMountedDirectory != "" && cfg.Operations[0].TestBucket != "" {
-		os.Exit(setup.RunTestsForMountedDirectory(cfg.Operations[0].GKEMountedDirectory, m))
+	if operationsConfig.GKEMountedDirectory != "" && operationsConfig.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(operationsConfig.GKEMountedDirectory, m))
 	}
 
 	// 4. Override GKE specific paths with GCSFuse paths if running in GCE environment.
-	setup.OverrideFilePathsInFlagSet(&cfg.Operations[0], setup.TestDir())
+	setup.OverrideFilePathsInFlagSet(operationsConfig, setup.TestDir())
+	setup.SetUpTestDirForTestBucket(operationsConfig)
 
-	// Run tests for testBucket
-	// 5. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.Operations[0], bucketType, "")
-	setup.SetUpTestDirForTestBucket(&cfg.Operations[0])
-
-	if setup.TestOnTPCEndPoint() {
-		os.Exit(static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m))
-	}
-
-	successCode := static_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-
-	if successCode == 0 {
-		successCode = only_dir_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, onlyDirMounted, m)
-	}
-
-	if successCode == 0 {
-		successCode = persistent_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-	}
-
-	if successCode == 0 {
-		successCode = dynamic_mounting.RunTestsWithConfigFile(&cfg.Operations[0], flags, m)
-	}
-
-	if successCode == 0 {
-		// Test for admin permission on test bucket.
-		log.Printf("Running cred tests...")
-		successCode = creds_tests.RunTestsForDifferentAuthMethods(ctx, &cfg.Operations[0], storageClient, flags, "objectAdmin", m)
-	}
-
-	os.Exit(successCode)
+	os.Exit(m.Run())
 }

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -20,6 +20,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
@@ -47,60 +48,79 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 	flagsSet := setup.BuildFlagSets(*operationsConfig, bucketType, t.Name())
 	for _, flags := range flagsSet {
-		// 1. Static mounting
-		log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
-		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Static mount failed")
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			// 1. Static mounting
+			t.Run("Static", func(t *testing.T) {
+				log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
+				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Static mount failed")
 
-		runSuiteFunc()
+				runSuiteFunc()
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		// 2. Only-dir mounting
-		setup.SetOnlyDirMounted(onlyDirMounted)
-		log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
-		err = only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Only dir mount failed")
+			// 2. Only-dir mounting
+			t.Run("OnlyDir", func(t *testing.T) {
+				setup.SetOnlyDirMounted(onlyDirMounted)
+				client.SetupTestDirectory(ctx, storageClient, onlyDirMounted)
+				defer func() {
+					if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, onlyDirMounted); err != nil {
+						log.Printf("Error deleting object on GCS: %v", err)
+					}
+					setup.SetOnlyDirMounted("")
+				}()
 
-		runSuiteFunc()
+				log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+				err := only_dir_mounting.MountGcsfuseWithOnlyDirWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Only dir mount failed")
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
-		setup.SetOnlyDirMounted("")
+				runSuiteFunc()
 
-		// 3. Persistent mounting
-		log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-		err = persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
-		require.NoError(t, err, "Persistent mount failed")
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		runSuiteFunc()
+			// 3. Persistent mounting
+			t.Run("Persistent", func(t *testing.T) {
+				log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+				err := persistent_mounting.MountGcsfuseWithPersistentMountingWithConfigFile(operationsConfig, flags)
+				require.NoError(t, err, "Persistent mount failed")
 
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
+				runSuiteFunc()
 
-		// 4. Dynamic mounting
-		rootMntDir := operationsConfig.GCSFuseMountedDirectory
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+			})
 
-		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
-		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
-		require.NoError(t, err, "Dynamic mount failed")
+			// 4. Dynamic mounting
+			t.Run("Dynamic", func(t *testing.T) {
+				rootMntDir := operationsConfig.GCSFuseMountedDirectory
+				setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
-		mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
-		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-		setup.SetMntDir(mntDirOfTestBucket)
-		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
+				log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+				err := dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
+				require.NoError(t, err, "Dynamic mount failed")
 
-		runSuiteFunc()
+				mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
+				operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+				setup.SetMntDir(mntDirOfTestBucket)
 
-		setup.SetMntDir(rootMntDir)
-		operationsConfig.GCSFuseMountedDirectory = rootMntDir
-		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-		setup.UnmountGCSFuseWithConfig(operationsConfig)
-		setup.SetDynamicBucketMounted("")
+				runSuiteFunc()
 
-		// 5. Creds tests (runs for different auth methods)
-		creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
+				setup.SetMntDir(rootMntDir)
+				operationsConfig.GCSFuseMountedDirectory = rootMntDir
+				setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+				setup.UnmountGCSFuseWithConfig(operationsConfig)
+				setup.SetDynamicBucketMounted("")
+			})
+
+			// 5. Creds tests (runs for different auth methods)
+			t.Run("Creds", func(t *testing.T) {
+				creds_tests.RunSuiteForDifferentAuthMethods(ctx, operationsConfig, storageClient, flags, "objectAdmin", t, runSuiteFunc)
+			})
+		})
 	}
 }
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -228,7 +228,7 @@ func TestMain(m *testing.M) {
 	setup.SetUpTestDirForTestBucket(operationsConfig)
 
 	if setup.TestOnTPCEndPoint() {
-		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "")
+		flags := setup.BuildFlagSets(*operationsConfig, bucketType, "TestOperationsBase")
 		os.Exit(static_mounting.RunTestsWithConfigFile(operationsConfig, flags, m))
 	}
 

--- a/tools/integration_tests/operations/operations_test.go
+++ b/tools/integration_tests/operations/operations_test.go
@@ -81,14 +81,15 @@ func runOperationsSuite(t *testing.T, runSuiteFunc func()) {
 
 		// 4. Dynamic mounting
 		rootMntDir := operationsConfig.GCSFuseMountedDirectory
-		mntDirOfTestBucket := path.Join(operationsConfig.GCSFuseMountedDirectory, operationsConfig.TestBucket)
-		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
-		setup.SetMntDir(mntDirOfTestBucket)
-		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
 		log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
 		err = dynamic_mounting.MountGcsfuseWithDynamicMountingWithConfig(operationsConfig, flags)
 		require.NoError(t, err, "Dynamic mount failed")
+
+		mntDirOfTestBucket := path.Join(rootMntDir, operationsConfig.TestBucket)
+		operationsConfig.GCSFuseMountedDirectory = mntDirOfTestBucket
+		setup.SetMntDir(mntDirOfTestBucket)
+		setup.SetDynamicBucketMounted(operationsConfig.TestBucket)
 
 		runSuiteFunc()
 

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -51,7 +51,7 @@ type testDirStrucure struct {
 //	explicitDir2Name/file1InExplicitDir2Name
 //
 // Also returns the path to test directory.
-func createDirStructure(s *operationsTestSuite) testDirStrucure {
+func (s *operationsTestSuite) createDirStructure() testDirStrucure {
 	var tds testDirStrucure
 	tds.testDir = setup.SetupTestDirectory(DirForOperationTests + "-" + setup.GenerateRandomString(5))
 
@@ -109,7 +109,7 @@ func lookUpFileStat(wg *sync.WaitGroup, filePath string, result *os.FileInfo, er
 
 func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -148,7 +148,7 @@ func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 
 func (s *operationsTestSuite) TestParallelReadDirs() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -200,7 +200,7 @@ func (s *operationsTestSuite) TestParallelReadDirs() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	deleteFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -232,7 +232,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 
 func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -275,7 +275,7 @@ func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 
 func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -315,7 +315,7 @@ func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	deleteFileFunc := func(wg *sync.WaitGroup, filePath string, err *error) {
 		defer wg.Done()
@@ -350,7 +350,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	renameFunc := func(wg *sync.WaitGroup, oldFilePath string, newFilePath string, err *error) {
 		defer wg.Done()
@@ -388,7 +388,7 @@ func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 
 func (s *operationsTestSuite) TestParallelLookUpAndMkdirSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(s)
+	tds := s.createDirStructure()
 	defer deleteDirStructure(tds)
 	mkdirFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()

--- a/tools/integration_tests/operations/parallel_dirops_test.go
+++ b/tools/integration_tests/operations/parallel_dirops_test.go
@@ -23,7 +23,6 @@ import (
 	"path"
 	"path/filepath"
 	"sync"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -52,35 +51,35 @@ type testDirStrucure struct {
 //	explicitDir2Name/file1InExplicitDir2Name
 //
 // Also returns the path to test directory.
-func createDirStructure(t *testing.T) testDirStrucure {
+func createDirStructure(s *operationsTestSuite) testDirStrucure {
 	var tds testDirStrucure
 	tds.testDir = setup.SetupTestDirectory(DirForOperationTests + "-" + setup.GenerateRandomString(5))
 
 	// Create explicitDir1 structure
 	tds.explicitDir1Name = "explicitDir1-" + setup.GenerateRandomString(5)
 	explicitDir1 := path.Join(tds.testDir, tds.explicitDir1Name)
-	operations.CreateDirectory(explicitDir1, t)
+	operations.CreateDirectory(explicitDir1, s.T())
 	tds.file1InExplicitDir1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 := path.Join(explicitDir1, tds.file1InExplicitDir1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(5, filePath1, s.T())
 	tds.file2InExplicitDir1Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 := path.Join(explicitDir1, tds.file2InExplicitDir1Name)
-	operations.CreateFileOfSize(10, filePath2, t)
+	operations.CreateFileOfSize(10, filePath2, s.T())
 
 	// Create explicitDir2 structure
 	tds.explicitDir2Name = "explicitDir2-" + setup.GenerateRandomString(5)
 	explicitDir2 := path.Join(tds.testDir, tds.explicitDir2Name)
-	operations.CreateDirectory(explicitDir2, t)
+	operations.CreateDirectory(explicitDir2, s.T())
 	tds.file1InExplicitDir2Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(explicitDir2, tds.file1InExplicitDir2Name)
-	operations.CreateFileOfSize(11, filePath1, t)
+	operations.CreateFileOfSize(11, filePath1, s.T())
 
 	tds.file1Name = "file1-" + setup.GenerateRandomString(5) + ".txt"
 	filePath1 = path.Join(tds.testDir, tds.file1Name)
-	operations.CreateFileOfSize(5, filePath1, t)
+	operations.CreateFileOfSize(5, filePath1, s.T())
 	tds.file2Name = "file2-" + setup.GenerateRandomString(5) + ".txt"
 	filePath2 = path.Join(tds.testDir, tds.file2Name)
-	operations.CreateFileOfSize(3, filePath2, t)
+	operations.CreateFileOfSize(3, filePath2, s.T())
 
 	return tds
 }
@@ -108,9 +107,9 @@ func lookUpFileStat(wg *sync.WaitGroup, filePath string, result *os.FileInfo, er
 	*err = lookupErr
 }
 
-func TestParallelLookUpsForSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpsForSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -124,12 +123,12 @@ func TestParallelLookUpsForSameFile(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(5), stat2.Size())
-	assert.Contains(t, filePath, stat1.Name())
-	assert.Contains(t, filePath, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(5), stat2.Size())
+	assert.Contains(s.T(), filePath, stat1.Name())
+	assert.Contains(s.T(), filePath, stat2.Name())
 
 	// Parallel lookups of file under a directory in mount.
 	filePath = path.Join(tds.testDir, tds.explicitDir1Name, tds.file2InExplicitDir1Name)
@@ -139,17 +138,17 @@ func TestParallelLookUpsForSameFile(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(10), stat1.Size())
-	assert.Equal(t, int64(10), stat2.Size())
-	assert.Contains(t, filePath, stat1.Name())
-	assert.Contains(t, filePath, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(10), stat1.Size())
+	assert.Equal(s.T(), int64(10), stat2.Size())
+	assert.Contains(s.T(), filePath, stat1.Name())
+	assert.Contains(s.T(), filePath, stat2.Name())
 }
 
-func TestParallelReadDirs(t *testing.T) {
+func (s *operationsTestSuite) TestParallelReadDirs() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -168,14 +167,14 @@ func TestParallelReadDirs(t *testing.T) {
 	wg.Wait()
 
 	// Assert both readDirs passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, 2, len(dirEntries1))
-	assert.Equal(t, 2, len(dirEntries2))
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries1[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries1[1].Name())
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries2[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries2[1].Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), 2, len(dirEntries1))
+	assert.Equal(s.T(), 2, len(dirEntries2))
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries1[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries1[1].Name())
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries2[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries2[1].Name())
 
 	// Parallel readDirs of a directory and its parent directory.
 	dirPath = path.Join(tds.testDir, tds.explicitDir1Name)
@@ -187,21 +186,21 @@ func TestParallelReadDirs(t *testing.T) {
 	wg.Wait()
 
 	// Assert both readDirs passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, 2, len(dirEntries1))
-	assert.Equal(t, 4, len(dirEntries2))
-	assert.Contains(t, tds.file1InExplicitDir1Name, dirEntries1[0].Name())
-	assert.Contains(t, tds.file2InExplicitDir1Name, dirEntries1[1].Name())
-	assert.Contains(t, tds.explicitDir1Name, dirEntries2[0].Name())
-	assert.Contains(t, tds.explicitDir2Name, dirEntries2[1].Name())
-	assert.Contains(t, tds.file1Name, dirEntries2[2].Name())
-	assert.Contains(t, tds.file2Name, dirEntries2[3].Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), 2, len(dirEntries1))
+	assert.Equal(s.T(), 4, len(dirEntries2))
+	assert.Contains(s.T(), tds.file1InExplicitDir1Name, dirEntries1[0].Name())
+	assert.Contains(s.T(), tds.file2InExplicitDir1Name, dirEntries1[1].Name())
+	assert.Contains(s.T(), tds.explicitDir1Name, dirEntries2[0].Name())
+	assert.Contains(s.T(), tds.explicitDir2Name, dirEntries2[1].Name())
+	assert.Contains(s.T(), tds.file1Name, dirEntries2[2].Name())
+	assert.Contains(s.T(), tds.file2Name, dirEntries2[3].Name())
 }
 
-func TestParallelLookUpAndDeleteSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	deleteFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -218,22 +217,22 @@ func TestParallelLookUpAndDeleteSameDir(t *testing.T) {
 	go deleteFunc(&wg, dirPath, &deleteErr)
 	wg.Wait()
 
-	assert.NoError(t, deleteErr)
+	assert.NoError(s.T(), deleteErr)
 	_, err := os.Stat(dirPath)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(s.T(), os.IsNotExist(err))
 	// Assert either dir is looked up first or deleted first
 	if lookUpErr == nil {
-		assert.NotNil(t, statInfo, "statInfo should not be nil when lookUpErr is nil")
-		assert.Contains(t, statInfo.Name(), tds.explicitDir1Name)
-		assert.True(t, statInfo.IsDir(), "The created path should be a directory")
+		assert.NotNil(s.T(), statInfo, "statInfo should not be nil when lookUpErr is nil")
+		assert.Contains(s.T(), statInfo.Name(), tds.explicitDir1Name)
+		assert.True(s.T(), statInfo.IsDir(), "The created path should be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpsForDifferentFiles(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpsForDifferentFiles() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	var stat1, stat2 os.FileInfo
 	var err1, err2 error
@@ -249,12 +248,12 @@ func TestParallelLookUpsForDifferentFiles(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(3), stat2.Size())
-	assert.Contains(t, filePath1, stat1.Name())
-	assert.Contains(t, filePath2, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(3), stat2.Size())
+	assert.Contains(s.T(), filePath1, stat1.Name())
+	assert.Contains(s.T(), filePath2, stat2.Name())
 
 	// Parallel lookups of two files under a directory in mount.
 	filePath1 = path.Join(tds.testDir, tds.explicitDir1Name, tds.file1InExplicitDir1Name)
@@ -266,17 +265,17 @@ func TestParallelLookUpsForDifferentFiles(t *testing.T) {
 	wg.Wait()
 
 	// Assert both stats passed and give correct information
-	assert.NoError(t, err1)
-	assert.NoError(t, err2)
-	assert.Equal(t, int64(5), stat1.Size())
-	assert.Equal(t, int64(10), stat2.Size())
-	assert.Contains(t, filePath1, stat1.Name())
-	assert.Contains(t, filePath2, stat2.Name())
+	assert.NoError(s.T(), err1)
+	assert.NoError(s.T(), err2)
+	assert.Equal(s.T(), int64(5), stat1.Size())
+	assert.Equal(s.T(), int64(10), stat2.Size())
+	assert.Contains(s.T(), filePath1, stat1.Name())
+	assert.Contains(s.T(), filePath2, stat2.Name())
 }
 
-func TestParallelReadDirAndMkdirInsideSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelReadDirAndMkdirInsideSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	readDirFunc := func(wg *sync.WaitGroup, dirPath string, dirEntries *[]os.DirEntry, err *error) {
 		defer wg.Done()
@@ -301,22 +300,22 @@ func TestParallelReadDirAndMkdirInsideSameDir(t *testing.T) {
 	wg.Wait()
 
 	// Assert both listing and mkdir succeeded
-	assert.NoError(t, readDirErr)
-	assert.NoError(t, mkdirErr)
+	assert.NoError(s.T(), readDirErr)
+	assert.NoError(s.T(), mkdirErr)
 	dirStatInfo, err := os.Stat(newDirPath)
-	assert.NoError(t, err)
-	assert.True(t, dirStatInfo.IsDir(), "The created path should be a directory")
+	assert.NoError(s.T(), err)
+	assert.True(s.T(), dirStatInfo.IsDir(), "The created path should be a directory")
 	// List should happen either before or after creation of newDir.
-	assert.GreaterOrEqual(t, len(dirEntries), 8)
-	assert.LessOrEqual(t, len(dirEntries), 9)
+	assert.GreaterOrEqual(s.T(), len(dirEntries), 8)
+	assert.LessOrEqual(s.T(), len(dirEntries), 9)
 	if len(dirEntries) == 9 {
-		assert.Contains(t, dirEntries[8].Name(), "newDir")
+		assert.Contains(s.T(), dirEntries[8].Name(), "newDir")
 	}
 }
 
-func TestParallelLookUpAndDeleteSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndDeleteSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	deleteFileFunc := func(wg *sync.WaitGroup, filePath string, err *error) {
 		defer wg.Done()
@@ -335,23 +334,23 @@ func TestParallelLookUpAndDeleteSameFile(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, deleteErr)
+	assert.NoError(s.T(), deleteErr)
 	_, err := os.Stat(filePath)
-	assert.True(t, os.IsNotExist(err))
+	assert.True(s.T(), os.IsNotExist(err))
 	// Assert either file is looked up first or deleted first
 	if lookUpErr == nil {
-		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
-		assert.Equal(t, int64(5), fileInfo.Size())
-		assert.Contains(t, fileInfo.Name(), tds.file1InExplicitDir1Name)
-		assert.False(t, fileInfo.IsDir(), "The created path should not be a directory")
+		assert.NotNil(s.T(), fileInfo, "fileInfo should not be nil when lookUpErr is nil")
+		assert.Equal(s.T(), int64(5), fileInfo.Size())
+		assert.Contains(s.T(), fileInfo.Name(), tds.file1InExplicitDir1Name)
+		assert.False(s.T(), fileInfo.IsDir(), "The created path should not be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpAndRenameSameFile(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndRenameSameFile() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	renameFunc := func(wg *sync.WaitGroup, oldFilePath string, newFilePath string, err *error) {
 		defer wg.Done()
@@ -370,26 +369,26 @@ func TestParallelLookUpAndRenameSameFile(t *testing.T) {
 
 	wg.Wait()
 
-	assert.NoError(t, renameErr)
+	assert.NoError(s.T(), renameErr)
 	newFileInfo, err := os.Stat(newFilePath)
-	assert.NoError(t, err)
-	assert.Contains(t, newFileInfo.Name(), "newFile.txt")
-	assert.False(t, newFileInfo.IsDir())
-	assert.Equal(t, int64(5), newFileInfo.Size())
+	assert.NoError(s.T(), err)
+	assert.Contains(s.T(), newFileInfo.Name(), "newFile.txt")
+	assert.False(s.T(), newFileInfo.IsDir())
+	assert.Equal(s.T(), int64(5), newFileInfo.Size())
 	// Assert either file is renamed first or looked up first
 	if lookUpErr == nil {
-		assert.NotNil(t, fileInfo, "fileInfo should not be nil when lookUpErr is nil")
-		assert.Equal(t, int64(5), fileInfo.Size())
-		assert.Contains(t, fileInfo.Name(), tds.file1InExplicitDir1Name)
-		assert.False(t, fileInfo.IsDir(), "The created path should not be a directory")
+		assert.NotNil(s.T(), fileInfo, "fileInfo should not be nil when lookUpErr is nil")
+		assert.Equal(s.T(), int64(5), fileInfo.Size())
+		assert.Contains(s.T(), fileInfo.Name(), tds.file1InExplicitDir1Name)
+		assert.False(s.T(), fileInfo.IsDir(), "The created path should be a directory")
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr))
+		assert.True(s.T(), os.IsNotExist(lookUpErr))
 	}
 }
 
-func TestParallelLookUpAndMkdirSameDir(t *testing.T) {
+func (s *operationsTestSuite) TestParallelLookUpAndMkdirSameDir() {
 	// Create directory structure for testing.
-	tds := createDirStructure(t)
+	tds := createDirStructure(s)
 	defer deleteDirStructure(tds)
 	mkdirFunc := func(wg *sync.WaitGroup, dirPath string, err *error) {
 		defer wg.Done()
@@ -408,16 +407,16 @@ func TestParallelLookUpAndMkdirSameDir(t *testing.T) {
 	wg.Wait()
 
 	// Assert either directory is created first or looked up first
-	assert.NoError(t, mkdirErr, "mkdirFunc should not fail")
+	assert.NoError(s.T(), mkdirErr, "mkdirFunc should not fail")
 
 	if lookUpErr == nil {
-		assert.NotNil(t, statInfo, "statInfo should not be nil when lookUpErr is nil")
-		assert.Contains(t, statInfo.Name(), "newDir")
-		assert.True(t, statInfo.IsDir())
+		assert.NotNil(s.T(), statInfo, "statInfo should not be nil when lookUpErr is nil")
+		assert.Contains(s.T(), statInfo.Name(), "newDir")
+		assert.True(s.T(), statInfo.IsDir())
 	} else {
-		assert.True(t, os.IsNotExist(lookUpErr), "lookUpErr should indicate directory does not exist")
+		assert.True(s.T(), os.IsNotExist(lookUpErr), "lookUpErr should indicate directory does not exist")
 		dirStatInfo, err := os.Stat(dirPath)
-		assert.NoError(t, err, "os.Stat should succeed after directory creation")
-		assert.True(t, dirStatInfo.IsDir(), "The created path should be a directory")
+		assert.NoError(s.T(), err, "os.Stat should succeed after directory creation")
+		assert.True(s.T(), dirStatInfo.IsDir(), "The created path should be a directory")
 	}
 }

--- a/tools/integration_tests/operations/read_test.go
+++ b/tools/integration_tests/operations/read_test.go
@@ -17,43 +17,42 @@ package operations_test
 
 import (
 	"os"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 )
 
-func TestReadAfterWrite(t *testing.T) {
+func (s *operationsTestSuite) TestReadAfterWrite() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	tmpDir, err := os.MkdirTemp(testDir, "tmpDir")
 	if err != nil {
-		t.Errorf("Mkdir at %q: %v", testDir, err)
+		s.T().Errorf("Mkdir at %q: %v", testDir, err)
 		return
 	}
 	for range 10 {
 		tmpFile, err := os.CreateTemp(tmpDir, tempFileName)
 		if err != nil {
-			t.Errorf("Create file at %q: %v", tmpDir, err)
+			s.T().Errorf("Create file at %q: %v", tmpDir, err)
 			return
 		}
 
 		// Closing file at the end
-		operations.CloseFileShouldNotThrowError(t, tmpFile)
+		operations.CloseFileShouldNotThrowError(s.T(), tmpFile)
 
 		fileName := tmpFile.Name()
 
 		err = operations.WriteFileInAppendMode(fileName, "line 1\n")
 		if err != nil {
-			t.Errorf("AppendString: %v", err)
+			s.T().Errorf("AppendString: %v", err)
 		}
 
 		content, err := operations.ReadFile(fileName)
 		if err != nil {
-			t.Errorf("ReadAll: %v", err)
+			s.T().Errorf("ReadAll: %v", err)
 		}
 		if got, want := string(content), "line 1\n"; got != want {
-			t.Errorf("File content %q not match %q", got, want)
+			s.T().Errorf("File content %q not match %q", got, want)
 		}
 	}
 }

--- a/tools/integration_tests/operations/rename_dir_test.go
+++ b/tools/integration_tests/operations/rename_dir_test.go
@@ -19,44 +19,43 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestRenameDirToNonEmptyDestDirectory(t *testing.T) {
+func (s *operationsTestSuite) TestRenameDirToNonEmptyDestDirectory() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create source directory.
 	srcDirPath := path.Join(testDir, "srcDir")
 	err := os.Mkdir(srcDirPath, 0700)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	// Create destination directory and put a file in it.
 	destDirPath := path.Join(testDir, "destDir")
 	err = os.Mkdir(destDirPath, 0700)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	destFilePath := path.Join(destDirPath, "file.txt")
-	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(destFilePath, setup.FilePermission_0600, Content, s.T())
 	// Attempt to rename the source directory to the destination directory.
 	err = os.Rename(srcDirPath, destDirPath)
 	// Assert that an error occurred (because destination is not empty).
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "file exists") || strings.Contains(err.Error(), "directory not empty") || strings.Contains(err.Error(), "not empty"), "Error message should mention file exists or not empty, but got: %v", err)
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "file exists") || strings.Contains(err.Error(), "directory not empty") || strings.Contains(err.Error(), "not empty"), "Error message should mention file exists or not empty, but got: %v", err)
 
 	// Perform operations on source and destination to ensure they are healthy.
 	// Context: https://b.corp.google.com/issues/504921217
 	_, err = os.Stat(srcDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	_, err = os.Stat(destDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 
 	// Delete both directories successfully
 	err = os.Remove(destFilePath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	err = os.Remove(destDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 	err = os.Remove(srcDirPath)
-	assert.NoError(t, err)
+	assert.NoError(s.T(), err)
 }

--- a/tools/integration_tests/operations/rename_file_test.go
+++ b/tools/integration_tests/operations/rename_file_test.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path"
 	"strings"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -27,28 +26,28 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenameFile(t *testing.T) {
+func (s *operationsTestSuite) TestRenameFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, s.T())
 
 	content, err := operations.ReadFile(fileName)
 	if err != nil {
-		t.Errorf("Read: %v", err)
+		s.T().Errorf("Read: %v", err)
 	}
 
 	newFileName := fileName + "Rename"
 
 	err = operations.RenameFile(fileName, newFileName)
 	if err != nil {
-		t.Errorf("Error in file renaming: %v", err)
+		s.T().Errorf("Error in file renaming: %v", err)
 	}
 	// Check if the data in the file is the same after renaming.
-	setup.CompareFileContents(t, newFileName, string(content))
+	setup.CompareFileContents(s.T(), newFileName, string(content))
 }
 
-func TestRenameFileWithSrcFileDoesNoExist(t *testing.T) {
+func (s *operationsTestSuite) TestRenameFileWithSrcFileDoesNoExist() {
 	// Set up the test directory.
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Define source and destination file names.
@@ -59,34 +58,34 @@ func TestRenameFileWithSrcFileDoesNoExist(t *testing.T) {
 	err := operations.RenameFile(srcFilePath, destFilePath)
 
 	// Assert that an error occurred.
-	assert.Error(t, err)
-	assert.True(t, strings.Contains(err.Error(), "no such file or directory"))
+	assert.Error(s.T(), err)
+	assert.True(s.T(), strings.Contains(err.Error(), "no such file or directory"))
 }
 
-func TestRenameSymlinkToFile(t *testing.T) {
+func (s *operationsTestSuite) TestRenameSymlinkToFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	targetName := "target.txt"
 	targetPath := path.Join(testDir, targetName)
 	err := os.WriteFile(targetPath, []byte("taco"), setup.FilePermission_0600)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	oldSymlinkPath := path.Join(testDir, "symlink_old")
 	err = os.Symlink(targetPath, oldSymlinkPath)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	newSymlinkPath := path.Join(testDir, "symlink_new")
 
 	err = os.Rename(oldSymlinkPath, newSymlinkPath)
 
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	_, err = os.Lstat(oldSymlinkPath)
-	require.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.Error(s.T(), err)
+	assert.True(s.T(), os.IsNotExist(err))
 	fi, err := os.Lstat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.ModeSymlink, fi.Mode()&os.ModeType)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), os.ModeSymlink, fi.Mode()&os.ModeType)
 	targetRead, err := os.Readlink(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, targetPath, targetRead)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), targetPath, targetRead)
 	content, err := operations.ReadFile(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, "taco", string(content))
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), "taco", string(content))
 }

--- a/tools/integration_tests/operations/stat_file_test.go
+++ b/tools/integration_tests/operations/stat_file_test.go
@@ -17,18 +17,17 @@ package operations_test
 import (
 	"os"
 	"syscall"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatWithTrailingNewline(t *testing.T) {
+func (s *operationsTestSuite) TestStatWithTrailingNewline() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 
 	_, err := os.Stat(testDir + "/\n")
 
-	require.Error(t, err)
-	assert.Equal(t, err.(*os.PathError).Err, syscall.ENOENT)
+	require.Error(s.T(), err)
+	assert.Equal(s.T(), err.(*os.PathError).Err, syscall.ENOENT)
 }

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -30,7 +30,24 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
+
+type writeOperationsTest struct {
+	isRapidWritesEnabled bool
+	suite.Suite
+}
+
+func TestWriteOperationsRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	runOperationsSuite(t, func() {
+		suite.Run(t, &writeOperationsTest{isRapidWritesEnabled: true})
+	})
+}
 
 const tempFileName = "tmpFile"
 const appendContent = "Content"
@@ -45,191 +62,173 @@ func validateExtendedObjectAttributesNonEmpty(objectName string, t *testing.T) *
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
-		if err != nil {
-			t.Errorf("closeStorageClient failed: %v", err)
-		}
+		assert.NoError(t, err, "closeStorageClient failed")
 	}()
 
 	attrs, err := client.StatObject(ctx, storageClient, objectName)
-	if err != nil {
-		t.Errorf("Could not fetch object attributes: %v", err)
-	}
+	require.NoError(t, err, "Could not fetch object attributes")
 	o := storageutil.ObjectAttrsToBucketObject(attrs)
 	e := storageutil.ConvertObjToExtendedObjectAttributes(o)
 
-	if e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}) {
-		t.Errorf("Received nil/empty extended object attributes.")
-	}
+	require.False(t, e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}), "Received nil/empty extended object attributes.")
 	return attrs
 }
 
-func validateObjectAttributes(attr1, attr2 *storage.ObjectAttrs, t *testing.T) {
+func (w *writeOperationsTest) validateObjectAttributes(attr1, attr2 *storage.ObjectAttrs) {
 	const contentType = "text/plain; charset=utf-8"
 	const componentCount = 0
 	const sizeBeforeOperation = int64(len(tempFileContent))
 	const sizeAfterOperation = sizeBeforeOperation + int64(len(appendContent))
 	storageClass := "STANDARD"
 	if attr1 == nil || attr2 == nil {
-		t.Fatalf("attr1 or attr2 is nil. attr1: %v, attr2: %v", attr1, attr2)
+		w.T().Fatalf("attr1 or attr2 is nil. attr1: %v, attr2: %v", attr1, attr2)
 	}
 
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && w.isRapidWritesEnabled) {
 		storageClass = "RAPID"
 	}
 
 	if attr1.ContentType != contentType || attr2.ContentType != contentType {
-		t.Errorf("Expected content type: %s, Got: %s, %s", contentType, attr1.ContentType, attr2.ContentType)
+		w.T().Errorf("Expected content type: %s, Got: %s, %s", contentType, attr1.ContentType, attr2.ContentType)
 	}
 	if attr1.ComponentCount != componentCount || attr2.ComponentCount != componentCount {
-		t.Errorf("Expected component count: %d, Got: %d, %d", componentCount, attr1.ComponentCount, attr2.ComponentCount)
+		w.T().Errorf("Expected component count: %d, Got: %d, %d", componentCount, attr1.ComponentCount, attr2.ComponentCount)
 	}
 	if attr1.Name != attr2.Name {
-		t.Errorf("Object name mismatch: %s, %s", attr1.Name, attr2.Name)
+		w.T().Errorf("Object name mismatch: %s, %s", attr1.Name, attr2.Name)
 	}
 	if attr1.Bucket != attr2.Bucket {
-		t.Errorf("Bucket name mismatch: %s, %s", attr1.Bucket, attr2.Bucket)
+		w.T().Errorf("Bucket name mismatch: %s, %s", attr1.Bucket, attr2.Bucket)
 	}
 	if attr1.EventBasedHold != false || attr2.EventBasedHold != false {
-		t.Errorf("Expected EventBasedHold: false, Got: %v %v", attr1.EventBasedHold, attr2.EventBasedHold)
+		w.T().Errorf("Expected EventBasedHold: false, Got: %v %v", attr1.EventBasedHold, attr2.EventBasedHold)
 	}
 	if attr1.Size != sizeBeforeOperation {
-		t.Errorf("Expected size before file operation: %d, Got: %d", sizeBeforeOperation, attr1.Size)
+		w.T().Errorf("Expected size before file operation: %d, Got: %d", sizeBeforeOperation, attr1.Size)
 	}
 	if attr2.Size != sizeAfterOperation {
-		t.Errorf("Expected size after file operation: %d, Got: %d", sizeAfterOperation, attr2.Size)
+		w.T().Errorf("Expected size after file operation: %d, Got: %d", sizeAfterOperation, attr2.Size)
 	}
 	if reflect.DeepEqual(attr1.MD5, []byte{}) || reflect.DeepEqual(attr2.MD5, []byte{}) {
-		t.Error("Expected MD5 attributes to be non empty")
+		w.T().Error("Expected MD5 attributes to be non empty")
 	}
 	if attr1.CRC32C == 0 || attr2.CRC32C == 0 {
-		t.Error("Expected CRC32 attributes to be non 0")
+		w.T().Error("Expected CRC32 attributes to be non 0")
 	}
 	if attr1.MediaLink == "" || attr2.MediaLink == "" {
-		if setup.IsZonalBucketRun() {
-			t.Logf("media link is empty, but it is a known limitation in RAPID/zonal buckets.")
+		if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && w.isRapidWritesEnabled) {
+			w.T().Logf("media link is empty, but it is a known limitation in RAPID/zonal buckets.")
 		} else {
-			t.Errorf("Expected media link to be non empty")
+			w.T().Errorf("Expected media link to be non empty")
 		}
 	}
 	if attr1.StorageClass != storageClass || attr2.StorageClass != storageClass {
-		t.Errorf("Expected storage class to be %q, but found attr1.StorageClass = %q (bucketName = %q), attr2.StorageClass = %q (bucketName = %q)", storageClass, attr1.StorageClass, attr1.Bucket, attr2.StorageClass, attr2.Bucket)
+		w.T().Errorf("Expected storage class to be %q, but found attr1.StorageClass = %q (bucketName = %q), attr2.StorageClass = %q (bucketName = %q)", storageClass, attr1.StorageClass, attr1.Bucket, attr2.StorageClass, attr2.Bucket)
 	}
 	attr1MTime, _ := time.Parse(time.RFC3339Nano, attr1.Metadata[gcs.MtimeMetadataKey])
 	attr2MTime, _ := time.Parse(time.RFC3339Nano, attr2.Metadata[gcs.MtimeMetadataKey])
 	if attr2MTime.Before(attr1MTime) {
-		t.Errorf("Unexpected MTime received. After operation1: %v, After operation2: %v", attr1MTime, attr2MTime)
+		w.T().Errorf("Unexpected MTime received. After operation1: %v, After operation2: %v", attr1MTime, attr2MTime)
 	}
 }
 
 // //////////////////////////////////////////////////////////////////////
 // Tests
 // //////////////////////////////////////////////////////////////////////
-func TestWriteAtEndOfFile(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtEndOfFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	err := operations.WriteFileInAppendMode(fileName, "line 3\n")
-	if err != nil {
-		t.Errorf("AppendString: %v", err)
-	}
+	require.NoError(w.T(), err, "AppendString failed")
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 2\nline 3\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\nline 3\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestWriteAtStartOfFile(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtStartOfFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	err := operations.WriteFile(fileName, "line 4\n")
-	if err != nil {
-		t.Errorf("WriteString-Start: %v", err)
-	}
+	require.NoError(w.T(), err, "WriteString-Start failed")
 
-	setup.CompareFileContents(t, fileName, "line 4\nline 2\n")
+	setup.CompareFileContents(w.T(), fileName, "line 4\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestWriteAtRandom(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtRandom() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	f, err := os.OpenFile(fileName, os.O_WRONLY|syscall.O_DIRECT, setup.FilePermission_0600)
-	if err != nil {
-		t.Errorf("Open file for write at random: %v", err)
-	}
+	require.NoError(w.T(), err, "Open file for write at random failed")
 
 	// Write at 7th byte which corresponds to the start of 2nd line
 	// thus changing line2\n with line5\n.
-	if _, err = f.WriteAt([]byte("line 5\n"), 7); err != nil {
-		t.Errorf("WriteString-Random: %v", err)
-	}
+	_, err = f.WriteAt([]byte("line 5\n"), 7)
+	require.NoError(w.T(), err, "WriteString-Random failed")
 	// Closing file at the end
-	operations.CloseFileShouldNotThrowError(t, f)
+	operations.CloseFileShouldNotThrowError(w.T(), f)
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 5\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 5\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestCreateFile(t *testing.T) {
+func (w *writeOperationsTest) TestCreateFile() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
 
 	// Stat the file to check if it exists.
-	if _, err := os.Stat(fileName); err != nil {
-		t.Errorf("File not found, %v", err)
-	}
+	_, err := os.Stat(fileName)
+	require.NoError(w.T(), err, "File not found")
 
-	setup.CompareFileContents(t, fileName, "line 1\nline 2\n")
+	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 }
 
-func TestAppendFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
+func (w *writeOperationsTest) TestAppendFileOperationsDoesNotChangeObjectAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 	// Append to the file.
 	err := operations.WriteFileInAppendMode(fileName, appendContent)
-	if err != nil {
-		t.Errorf("Could not append to file: %v", err)
-	}
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	require.NoError(w.T(), err, "Could not append to file")
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 
 	// Validate object attributes are as expected.
-	validateObjectAttributes(attr1, attr2, t)
+	w.validateObjectAttributes(attr1, attr2)
 }
 
-func TestWriteAtFileOperationsDoesNotChangeObjectAttributes(t *testing.T) {
+func (w *writeOperationsTest) TestWriteAtFileOperationsDoesNotChangeObjectAttributes() {
 	testDir := setup.SetupTestDirectory(DirForOperationTests)
 	// Create file.
 	fileName := path.Join(testDir, tempFileName)
 
-	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, t)
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
+	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 	// Over-write the file.
 	fh, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
-	if err != nil {
-		t.Fatalf("Could not open file %s after creation.", fileName)
-	}
-	operations.WriteAt(tempFileContent+appendContent, 0, fh, t)
-	operations.CloseFileShouldNotThrowError(t, fh)
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), t)
+	require.NoError(w.T(), err, "Could not open file after creation")
+	operations.WriteAt(tempFileContent+appendContent, 0, fh, w.T())
+	operations.CloseFileShouldNotThrowError(w.T(), fh)
+	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
 
 	// Validate object attributes are as expected.
-	validateObjectAttributes(attr1, attr2, t)
+	w.validateObjectAttributes(attr1, attr2)
 }

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -40,6 +40,10 @@ type writeOperationsTest struct {
 	suite.Suite
 }
 
+func (w *writeOperationsTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(w.T())
+}
+
 func TestWriteOperationsRapidWritesEnabled(t *testing.T) {
 	if !setup.IsPirloBucketRun() {
 		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")

--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -56,21 +56,21 @@ const tempFileContent = "line 1\nline 2\n"
 // //////////////////////////////////////////////////////////////////////
 // Helpers
 // //////////////////////////////////////////////////////////////////////
-func validateExtendedObjectAttributesNonEmpty(objectName string, t *testing.T) *storage.ObjectAttrs {
+func (w *writeOperationsTest) validateExtendedObjectAttributesNonEmpty(objectName string) *storage.ObjectAttrs {
 	ctx := context.Background()
 	var storageClient *storage.Client
 	closeStorageClient := client.CreateStorageClientWithCancel(&ctx, &storageClient)
 	defer func() {
 		err := closeStorageClient()
-		assert.NoError(t, err, "closeStorageClient failed")
+		assert.NoError(w.T(), err, "closeStorageClient failed")
 	}()
 
 	attrs, err := client.StatObject(ctx, storageClient, objectName)
-	require.NoError(t, err, "Could not fetch object attributes")
+	require.NoError(w.T(), err, "Could not fetch object attributes")
 	o := storageutil.ObjectAttrsToBucketObject(attrs)
 	e := storageutil.ConvertObjToExtendedObjectAttributes(o)
 
-	require.False(t, e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}), "Received nil/empty extended object attributes.")
+	require.False(w.T(), e == nil || reflect.DeepEqual(*e, gcs.ExtendedObjectAttributes{}), "Received nil/empty extended object attributes.")
 	return attrs
 }
 
@@ -146,7 +146,7 @@ func (w *writeOperationsTest) TestWriteAtEndOfFile() {
 
 	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\nline 3\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 }
 
 func (w *writeOperationsTest) TestWriteAtStartOfFile() {
@@ -160,7 +160,7 @@ func (w *writeOperationsTest) TestWriteAtStartOfFile() {
 
 	setup.CompareFileContents(w.T(), fileName, "line 4\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 }
 
 func (w *writeOperationsTest) TestWriteAtRandom() {
@@ -181,7 +181,7 @@ func (w *writeOperationsTest) TestWriteAtRandom() {
 
 	setup.CompareFileContents(w.T(), fileName, "line 1\nline 5\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 }
 
 func (w *writeOperationsTest) TestCreateFile() {
@@ -196,7 +196,7 @@ func (w *writeOperationsTest) TestCreateFile() {
 
 	setup.CompareFileContents(w.T(), fileName, "line 1\nline 2\n")
 	// Validate that extended object attributes are non nil/ non-empty.
-	validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 }
 
 func (w *writeOperationsTest) TestAppendFileOperationsDoesNotChangeObjectAttributes() {
@@ -205,11 +205,11 @@ func (w *writeOperationsTest) TestAppendFileOperationsDoesNotChangeObjectAttribu
 	fileName := path.Join(testDir, tempFileName)
 
 	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	attr1 := w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 	// Append to the file.
 	err := operations.WriteFileInAppendMode(fileName, appendContent)
 	require.NoError(w.T(), err, "Could not append to file")
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	attr2 := w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 
 	// Validate object attributes are as expected.
 	w.validateObjectAttributes(attr1, attr2)
@@ -221,13 +221,13 @@ func (w *writeOperationsTest) TestWriteAtFileOperationsDoesNotChangeObjectAttrib
 	fileName := path.Join(testDir, tempFileName)
 
 	operations.CreateFileWithContent(fileName, setup.FilePermission_0600, Content, w.T())
-	attr1 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	attr1 := w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 	// Over-write the file.
 	fh, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC|syscall.O_DIRECT, operations.FilePermission_0600)
 	require.NoError(w.T(), err, "Could not open file after creation")
 	operations.WriteAt(tempFileContent+appendContent, 0, fh, w.T())
 	operations.CloseFileShouldNotThrowError(w.T(), fh)
-	attr2 := validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName), w.T())
+	attr2 := w.validateExtendedObjectAttributesNonEmpty(path.Join(DirForOperationTests, tempFileName))
 
 	// Validate object attributes are as expected.
 	w.validateObjectAttributes(attr1, attr2)

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -114,7 +114,7 @@ operations:
         run: TestOperationsBase
       - flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -123,7 +123,7 @@ operations:
         run: TestWriteOperationsRapidWritesEnabled
       - flags:
           - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -36,13 +36,23 @@ implicit_dir:
           hns: true
           zonal: true
         run_on_gke: true
+        run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
+        run_on_gke: false
+        run: TestImplicitDirLocalFileRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestImplicitDirBase
       - flags:
           - "--implicit-dirs,--client-protocol=grpc"
         compatible:
@@ -50,6 +60,7 @@ implicit_dir:
           hns: true
           zonal: false
         run_on_gke: true
+        run: TestImplicitDirBase
 
 list_large_dir:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -111,14 +122,25 @@ operations:
           hns: true
           zonal: true
         run_on_gke: true
+        run: TestOperationsBase
       - flags:
-          - "--experimental-enable-pirlo,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
+        run_on_gke: false
+        run: TestWriteOperationsRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--metadata-cache-ttl-secs=0,--enable-streaming-writes=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--kernel-list-cache-ttl-secs=-1,--implicit-dirs,--enable-metadata-prefetch"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestOperationsBase
       - flags:
           - "--enable-atomic-rename-object=true,--client-protocol=http1"
           - "--experimental-enable-json-read=true,--client-protocol=http1"
@@ -130,6 +152,7 @@ operations:
           zonal: true
         tpc: true
         run_on_gke: false
+        run: TestOperationsBase
 
 write_large_files:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -450,25 +473,34 @@ read_cache:
         run_on_gke: true
         run: TestRangeReadWithParallelDownloadsTest
       - flags:
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
-        run: TestLocalModificationTest
+        run: TestLocalModificationBase
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--enable-kernel-reader=false"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
-        run: TestLocalModificationTest
+        run_on_gke: false
+        run: TestLocalModificationRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestLocalModificationBase
       - flags:
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
@@ -1134,14 +1166,25 @@ readonly_creds:
           hns: true
           zonal: true
         run_on_gke: false
+        run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs=true,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
         run_on_gke: false
+        run: TestReadOnlyCredsRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestReadOnlyCredsBase
 
 mount_timeout:
   - mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -36,23 +36,13 @@ implicit_dir:
           hns: true
           zonal: true
         run_on_gke: true
-        run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs"
+          - "--experimental-enable-pirlo,--implicit-dirs,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: false
-        run: TestImplicitDirLocalFileRapidWritesEnabled
-      - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs"
-        run_on_pirlo:
-          hns:
-            same_zone: true
-            different_zone: false
-        run_on_gke: false
-        run: TestImplicitDirBase
+        run_on_gke: true
       - flags:
           - "--implicit-dirs,--client-protocol=grpc"
         compatible:
@@ -60,7 +50,6 @@ implicit_dir:
           hns: true
           zonal: false
         run_on_gke: true
-        run: TestImplicitDirBase
 
 list_large_dir:
   - mounted_directory: "${MOUNTED_DIR}"
@@ -473,34 +462,25 @@ read_cache:
         run_on_gke: true
         run: TestRangeReadWithParallelDownloadsTest
       - flags:
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
-          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--client-protocol=grpc,--enable-kernel-reader=false"
+          - "--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--client-protocol=grpc,--enable-kernel-reader=false"
         compatible:
           flat: true
           hns: true
           zonal: true
-        run: TestLocalModificationBase
+        run: TestLocalModificationTest
         run_on_gke: true
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled,--log-file=/gcsfuse-tmp/TestLocalModificationRapidWritesEnabled.log,--log-severity=TRACE,--enable-kernel-reader=false"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationTest,--log-file=/gcsfuse-tmp/TestLocalModificationTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: false
-        run: TestLocalModificationRapidWritesEnabled
-      - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestLocalModificationBase,--log-file=/gcsfuse-tmp/TestLocalModificationBase.log,--log-severity=TRACE,--enable-kernel-reader=false"
-        run_on_pirlo:
-          hns:
-            same_zone: true
-            different_zone: false
-        run_on_gke: false
-        run: TestLocalModificationBase
+        run_on_gke: true
+        run: TestLocalModificationTest
       - flags:
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads=false,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--implicit-dirs,--enable-kernel-reader=false,--client-protocol=http1"
           - "--stat-cache-ttl=0s,--file-cache-max-size-mb=9,--file-cache-enable-parallel-downloads,--cache-dir=/gcsfuse-tmp/TestDisabledCacheTTLTest,--log-file=/gcsfuse-tmp/TestDisabledCacheTTLTest.log,--log-severity=TRACE,--enable-kernel-reader=false,--client-protocol=http1"
@@ -1166,25 +1146,14 @@ readonly_creds:
           hns: true
           zonal: true
         run_on_gke: false
-        run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
+          - "--experimental-enable-pirlo,--implicit-dirs=true,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
         run_on_gke: false
-        run: TestReadOnlyCredsRapidWritesEnabled
-      - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
-        run_on_pirlo:
-          hns:
-            same_zone: true
-            different_zone: false
-        run_on_gke: false
-        run: TestReadOnlyCredsBase
 
 mount_timeout:
   - mounted_directory: "${MOUNTED_DIR}"

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -225,6 +225,10 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
+	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
+	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
+	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
+
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
 	t.Run("EnvVar", func(t *testing.T) {
 		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -231,7 +231,9 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 
 	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
 	require.NoError(t, err, "Error setting environment variable")
-	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	defer func() {
+		_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	}()
 
 	keyFileFlag := "--key-file=" + localKeyFilePath
 	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -161,7 +161,7 @@ func RevokeCustomRoleFromServiceAccountOnBucket(ctx context.Context, storageClie
 	RevokeRoleFromServiceAccountOnBucket(ctx, storageClient, serviceAccount, fmt.Sprintf("projects/%s/roles/%s", projectID, customRoleName), bucket)
 }
 
-func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
+func runWithCredentialsSetup(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, permission string, testFunc func(localKeyFilePath string)) {
 	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
 	defer func() {
 		if err := os.Remove(localKeyFilePath); err != nil {
@@ -171,112 +171,94 @@ func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
-	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
-	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
-	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
+	testFunc(localKeyFilePath)
+}
 
-	// Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
-	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
-	}
+func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, testFlagSet [][]string, permission string, m *testing.M) (successCode int) {
+	runWithCredentialsSetup(ctx, cfg, storageClient, permission, func(localKeyFilePath string) {
+		// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
+		// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
+		// https://github.com/golang/oauth2/blob/master/google/default.go#L160
 
-	successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
+		// Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		if err != nil {
+			setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
+		}
+		defer func() {
+			_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		}()
 
-	if successCode != 0 {
-		return
-	}
+		successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
 
-	// Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
-	keyFileFlag := "--key-file=" + localKeyFilePath
+		if successCode != 0 {
+			return
+		}
 
-	for i := range testFlagSet {
-		testFlagSet[i] = append(testFlagSet[i], keyFileFlag)
-	}
+		// Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
+		keyFileFlag := "--key-file=" + localKeyFilePath
 
-	successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
+		for i := range testFlagSet {
+			testFlagSet[i] = append(testFlagSet[i], keyFileFlag)
+		}
 
-	if successCode != 0 {
-		return
-	}
+		successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
 
-	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
-	}
+		if successCode != 0 {
+			return
+		}
 
-	// Testing with --key-file flag only.
-	successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
+		err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		if err != nil {
+			setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
+		}
 
-	if successCode != 0 {
-		return
-	}
+		// Testing with --key-file flag only.
+		successCode = static_mounting.RunTestsWithConfigFile(cfg, testFlagSet, m)
+	})
 
 	return successCode
 }
 
 func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, flags []string, permission string, t *testing.T, runSuiteFunc func()) {
-	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
-	defer func() {
-		if err := os.Remove(localKeyFilePath); err != nil {
-			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+	runWithCredentialsSetup(ctx, cfg, storageClient, permission, func(localKeyFilePath string) {
+		// Without --key-file flag and GOOGLE_APPLICATION_CREDENTIALS
+		// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
+		// https://github.com/golang/oauth2/blob/master/google/default.go#L160
+
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		require.NoError(t, err, "Error setting environment variable")
+		defer func() {
+			_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		}()
+
+		keyFileFlag := "--key-file=" + localKeyFilePath
+		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+
+		runTestCase := func(name, description string, testFlags []string) {
+			t.Run(name, func(t *testing.T) {
+				log.Printf("Running creds tests with %s and flags: %s", description, testFlags)
+				err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, testFlags)
+				require.NoError(t, err, fmt.Sprintf("Creds mount with %s failed", description))
+				defer func() {
+					setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+					setup.UnmountGCSFuseWithConfig(cfg)
+				}()
+
+				runSuiteFunc()
+			})
 		}
-	}()
-	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
-	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
-	// Without --key-file flag and GOOGLE_APPLICATION_CREDENTIALS
-	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
-	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
+		// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
+		runTestCase("EnvVar", "GOOGLE_APPLICATION_CREDENTIALS", flags)
 
-	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-	require.NoError(t, err, "Error setting environment variable")
-	defer func() {
-		_ = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	}()
+		// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
+		runTestCase("KeyFileAndEnvVar", "--key-file + GOOGLE_APPLICATION_CREDENTIALS", flagsWithKeyFile)
 
-	keyFileFlag := "--key-file=" + localKeyFilePath
-	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
-
-	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
-	t.Run("EnvVar", func(t *testing.T) {
-		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
-		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
-		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
-		defer func() {
-			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-			setup.UnmountGCSFuseWithConfig(cfg)
-		}()
-
-		runSuiteFunc()
-	})
-
-	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
-	t.Run("KeyFileAndEnvVar", func(t *testing.T) {
-		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
-		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
-		defer func() {
-			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-			setup.UnmountGCSFuseWithConfig(cfg)
-		}()
-
-		runSuiteFunc()
-	})
-
-	// 3. Testing with --key-file flag only.
-	t.Run("KeyFileOnly", func(t *testing.T) {
-		err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		// 3. Testing with --key-file flag only.
+		err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 		require.NoError(t, err, "Error unsetting environment variable")
 
-		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
-		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-		require.NoError(t, err, "Creds mount with --key-file failed")
-		defer func() {
-			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-			setup.UnmountGCSFuseWithConfig(cfg)
-		}()
-
-		runSuiteFunc()
+		runTestCase("KeyFileOnly", "--key-file only", flagsWithKeyFile)
 	})
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -34,6 +34,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 const NameOfServiceAccount = "creds-integration-tests"
@@ -212,4 +213,58 @@ func RunTestsForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	}
 
 	return successCode
+}
+
+func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestConfig, storageClient *storage.Client, flags []string, permission string, t *testing.T, runSuiteFunc func()) {
+	serviceAccount, localKeyFilePath := CreateCredentials(ctx)
+	defer func() {
+		if err := os.Remove(localKeyFilePath); err != nil {
+			log.Printf("Failed to delete temp credentials file %s: %v", localKeyFilePath, err)
+		}
+	}()
+	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
+	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
+
+	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
+	}
+
+	log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+	require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
+
+	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
+	keyFileFlag := "--key-file=" + localKeyFilePath
+	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+
+	log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+	require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
+
+	// 3. Testing with --key-file flag only.
+	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+	if err != nil {
+		setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
+	}
+
+	log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
+	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+	require.NoError(t, err, "Creds mount with --key-file failed")
+
+	runSuiteFunc()
+
+	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+	setup.UnmountGCSFuseWithConfig(cfg)
 }

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -229,13 +229,17 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
 	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
 
+	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+	require.NoError(t, err, "Error setting environment variable")
+	defer os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+
+	keyFileFlag := "--key-file=" + localKeyFilePath
+	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
 	t.Run("EnvVar", func(t *testing.T) {
-		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-		require.NoError(t, err, "Error setting environment variable")
-
 		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
-		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
 		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
 		defer func() {
 			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
@@ -247,14 +251,8 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 
 	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
 	t.Run("KeyFileAndEnvVar", func(t *testing.T) {
-		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-		require.NoError(t, err, "Error setting environment variable")
-
-		keyFileFlag := "--key-file=" + localKeyFilePath
-		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
-
 		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
-		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		err := static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
 		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
 		defer func() {
 			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
@@ -268,9 +266,6 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	t.Run("KeyFileOnly", func(t *testing.T) {
 		err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
 		require.NoError(t, err, "Error unsetting environment variable")
-
-		keyFileFlag := "--key-file=" + localKeyFilePath
-		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
 		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
 		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -225,7 +225,7 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	ApplyPermissionToServiceAccount(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
-	// Without –key-file flag and GOOGLE_APPLICATION_CREDENTIALS
+	// Without --key-file flag and GOOGLE_APPLICATION_CREDENTIALS
 	// This case will not get covered as gcsfuse internally authenticates from a metadata server on GCE VM.
 	// https://github.com/golang/oauth2/blob/master/google/default.go#L160
 

--- a/tools/integration_tests/util/creds_tests/creds.go
+++ b/tools/integration_tests/util/creds_tests/creds.go
@@ -226,45 +226,56 @@ func RunSuiteForDifferentAuthMethods(ctx context.Context, cfg *test_suite.TestCo
 	defer RevokePermission(ctx, storageClient, serviceAccount, permission, cfg.TestBucket)
 
 	// 1. Testing with GOOGLE_APPLICATION_CREDENTIALS env variable
-	err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in setting environment variable: %v", err))
-	}
+	t.Run("EnvVar", func(t *testing.T) {
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		require.NoError(t, err, "Error setting environment variable")
 
-	log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
-	require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+		log.Printf("Running creds tests with GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flags)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flags)
+		require.NoError(t, err, "Creds mount with GOOGLE_APPLICATION_CREDENTIALS failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
-	runSuiteFunc()
-
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		runSuiteFunc()
+	})
 
 	// 2. Testing with --key-file and GOOGLE_APPLICATION_CREDENTIALS env variable set
-	keyFileFlag := "--key-file=" + localKeyFilePath
-	flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
+	t.Run("KeyFileAndEnvVar", func(t *testing.T) {
+		err := os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", localKeyFilePath)
+		require.NoError(t, err, "Error setting environment variable")
 
-	log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-	require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+		keyFileFlag := "--key-file=" + localKeyFilePath
+		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
-	runSuiteFunc()
+		log.Printf("Running creds tests with --key-file + GOOGLE_APPLICATION_CREDENTIALS and flags: %s", flagsWithKeyFile)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		require.NoError(t, err, "Creds mount with --key-file + GOOGLE_APPLICATION_CREDENTIALS failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		runSuiteFunc()
+	})
 
 	// 3. Testing with --key-file flag only.
-	err = os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
-	if err != nil {
-		setup.LogAndExit(fmt.Sprintf("Error in unsetting environment variable: %v", err))
-	}
+	t.Run("KeyFileOnly", func(t *testing.T) {
+		err := os.Unsetenv("GOOGLE_APPLICATION_CREDENTIALS")
+		require.NoError(t, err, "Error unsetting environment variable")
 
-	log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
-	err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
-	require.NoError(t, err, "Creds mount with --key-file failed")
+		keyFileFlag := "--key-file=" + localKeyFilePath
+		flagsWithKeyFile := append(slices.Clone(flags), keyFileFlag)
 
-	runSuiteFunc()
+		log.Printf("Running creds tests with --key-file only and flags: %s", flagsWithKeyFile)
+		err = static_mounting.MountGcsfuseWithStaticMountingWithConfigFile(cfg, flagsWithKeyFile)
+		require.NoError(t, err, "Creds mount with --key-file failed")
+		defer func() {
+			setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+			setup.UnmountGCSFuseWithConfig(cfg)
+		}()
 
-	setup.SaveGCSFuseLogFileInCaseOfFailure(t)
-	setup.UnmountGCSFuseWithConfig(cfg)
+		runSuiteFunc()
+	})
 }

--- a/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
+++ b/tools/integration_tests/util/mounting/dynamic_mounting/dynamic_mounting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 func MountGcsfuseWithDynamicMountingWithConfig(cfg *test_suite.TestConfig, flags []string) (err error) {
@@ -86,4 +87,26 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForDynamicMounting(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForDynamicMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	rootMntDir := config.GCSFuseMountedDirectory
+	setup.SetDynamicBucketMounted(config.TestBucket)
+
+	log.Printf("Running dynamic mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithDynamicMountingWithConfig(config, flags)
+	require.NoError(t, err, "Dynamic mount failed")
+	defer func() {
+		setup.SetMntDir(rootMntDir)
+		config.GCSFuseMountedDirectory = rootMntDir
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+		setup.SetDynamicBucketMounted("")
+	}()
+
+	mntDirOfTestBucket := path.Join(rootMntDir, config.TestBucket)
+	config.GCSFuseMountedDirectory = mntDirOfTestBucket
+	setup.SetMntDir(mntDirOfTestBucket)
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
+++ b/tools/integration_tests/util/mounting/only_dir_mounting/only_dir_mounting.go
@@ -15,16 +15,17 @@
 package only_dir_mounting
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"testing"
 
-	"context"
-
+	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 func MountGcsfuseWithOnlyDirWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
@@ -98,4 +99,23 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForOnlyDirMounting(config, flagsSet, dirName, m)
 	return successCode
+}
+
+func RunSuiteForOnlyDirMounting(ctx context.Context, storageClient *storage.Client, config *test_suite.TestConfig, flags []string, dirName string, t *testing.T, runSuiteFunc func()) {
+	setup.SetOnlyDirMounted(dirName)
+	client.SetupTestDirectory(ctx, storageClient, dirName)
+	defer func() {
+		if err := client.DeleteAllObjectsWithPrefix(ctx, storageClient, dirName); err != nil {
+			log.Printf("Error deleting object on GCS: %v", err)
+		}
+		setup.SetOnlyDirMounted("")
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	log.Printf("Running only dir mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithOnlyDirWithConfigFile(config, flags)
+	require.NoError(t, err, "Only dir mount failed")
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -43,7 +43,7 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 	return
 }
 
-func MountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
+func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{config.TestBucket,
 		config.GCSFuseMountedDirectory,
 		"-o",
@@ -68,7 +68,7 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 	var err error
 
 	for i := range flagsSet {
-		if err = MountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
+		if err = mountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])
@@ -89,7 +89,7 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 
 func RunSuiteForPersistentMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
 	log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
-	err := MountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
+	err := mountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
 	require.NoError(t, err, "Persistent mount failed")
 	defer func() {
 		setup.SaveGCSFuseLogFileInCaseOfFailure(t)

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -23,6 +23,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 // Change e.g --log_severity=trace to log_severity=trace
@@ -84,4 +85,16 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForPersistentMountingWithConfigFile(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForPersistentMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	log.Printf("Running persistent mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithPersistentMountingWithConfigFile(config, flags)
+	require.NoError(t, err, "Persistent mount failed")
+	defer func() {
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	runSuiteFunc()
 }

--- a/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
+++ b/tools/integration_tests/util/mounting/persistent_mounting/perisistent_mounting.go
@@ -42,7 +42,7 @@ func makePersistentMountingArgs(flags []string) (args []string) {
 	return
 }
 
-func mountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
+func MountGcsfuseWithPersistentMountingWithConfigFile(config *test_suite.TestConfig, flags []string) (err error) {
 	defaultArg := []string{config.TestBucket,
 		config.GCSFuseMountedDirectory,
 		"-o",
@@ -67,7 +67,7 @@ func executeTestsForPersistentMountingWithConfigFile(config *test_suite.TestConf
 	var err error
 
 	for i := range flagsSet {
-		if err = mountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
+		if err = MountGcsfuseWithPersistentMountingWithConfigFile(config, flagsSet[i]); err != nil {
 			setup.LogAndExit(fmt.Sprintf("mountGcsfuse: %v\n", err))
 		}
 		log.Printf("Running persistent mounting tests with flags: %s", flagsSet[i])

--- a/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
+++ b/tools/integration_tests/util/mounting/static_mounting/static_mounting.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/require"
 )
 
 // TODO(b/438068132): cleanup deprecated methods after migration is complete.
@@ -76,4 +77,16 @@ func RunTestsWithConfigFile(config *test_suite.TestConfig, flagsSet [][]string, 
 	log.Printf("GCSFuse Log File for test: %s\n", config.LogFile)
 	successCode = executeTestsForStaticMounting(config, flagsSet, m)
 	return successCode
+}
+
+func RunSuiteForStaticMounting(config *test_suite.TestConfig, flags []string, t *testing.T, runSuiteFunc func()) {
+	log.Printf("Running static mounting %s with flags: %s", t.Name(), flags)
+	err := MountGcsfuseWithStaticMountingWithConfigFile(config, flags)
+	require.NoError(t, err, "Static mount failed")
+	defer func() {
+		setup.SaveGCSFuseLogFileInCaseOfFailure(t)
+		setup.UnmountGCSFuseWithConfig(config)
+	}()
+
+	runSuiteFunc()
 }


### PR DESCRIPTION
### Description
Bifurcates write operations into TestOperationsBase and TestOperationsRapidWritesEnabled to support per-suite flagsets for rapid writes enabled vs base runs across all 5 mounting modes (static, only-dir, persistent, dynamic, and creds).

### Testing details
1. Unit tests - NA
2. Integration tests - Done

### Any backward incompatible change? If so, please explain.
No