### PR TITLE
test(implicit_dir): bifurcate implicit_dir tests for rapid writes flagsets

### DIFF
--- a/tools/integration_tests/implicit_dir/delete_test.go
+++ b/tools/integration_tests/implicit_dir/delete_test.go
@@ -17,7 +17,6 @@ package implicit_dir_test
 
 import (
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
@@ -28,14 +27,14 @@ import (
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                               -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
-func TestDeleteNonEmptyImplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitDir() {
 	testDirName := "testDeleteNonEmptyImplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -43,14 +42,14 @@ func TestDeleteNonEmptyImplicitDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                               -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                             -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2          -- File
-func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteNonEmptyImplicitSubDir() {
 	testDirName := "testDeleteNonEmptyImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	subDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(subDirPath, implicit_and_explicit_dir_setup.ImplicitSubDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(subDirPath, implicit_and_explicit_dir_setup.ImplicitSubDirectory, s.T())
 }
 
 // Directory Structure
@@ -60,18 +59,18 @@ func TestDeleteNonEmptyImplicitSubDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/fileInImplicitDir1                                                 -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory                                               -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2                            -- File
-func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirWithExplicitSubDir() {
 	testDirName := "testDeleteImplicitDirWithExplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, ExplicitDirInImplicitDir)
 
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitDir, explicitDirPath, PrefixFileInExplicitDirInImplicitDir, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitDir, explicitDirPath, PrefixFileInExplicitDirInImplicitDir, s.T())
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -81,17 +80,17 @@ func TestDeleteImplicitDirWithExplicitSubDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/fileInImplicitDir2                                                 -- File
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir                                           -- Dir
 // testBucket/dirForImplicitDirTests/testDir/implicitDirectory/implicitSubDirectory/explicitDirInImplicitDir/fileInExplicitDirInImplicitDir            -- File
-func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir() {
 	testDirName := "testDeleteImplicitDirWithImplicitSubDirContainingExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 	explicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, implicit_and_explicit_dir_setup.ImplicitSubDirectory, ExplicitDirInImplicitSubDir)
 
-	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, t)
+	operations.CreateDirectoryWithNFiles(NumberOfFilesInExplicitDirInImplicitSubDir, explicitDirPath, PrefixFileInExplicitDirInImplicitSubDir, s.T())
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -103,14 +102,14 @@ func TestDeleteImplicitDirWithImplicitSubDirContainingExplicitDir(t *testing.T) 
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/fileInImplicitDir1                              -- File
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
-func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteImplicitDirInExplicitDir() {
 	testDirName := "testDeleteImplicitDirInExplicitDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, implicit_and_explicit_dir_setup.ImplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ImplicitDirectory, s.T())
 }
 
 // Directory Structure
@@ -122,12 +121,12 @@ func TestDeleteImplicitDirInExplicitDir(t *testing.T) {
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/fileInImplicitDir1                              -- File
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory                            -- Dir
 // testBucket/dirForImplicitDirTests/testDir/explicitDirectory/implicitDirectory/implicitSubDirectory/fileInImplicitDir2         -- File
-func TestDeleteExplicitDirContainingImplicitSubDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestDeleteExplicitDirContainingImplicitSubDir() {
 	testDirName := "testDeleteExplicitDirContainingImplicitSubDir"
 	testDirPath := setupTestDir(testDirName)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryInExplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
 
 	dirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ExplicitDirectory)
 
-	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, t)
+	implicit_and_explicit_dir_setup.RemoveAndCheckIfDirIsDeleted(dirPath, implicit_and_explicit_dir_setup.ExplicitDirectory, s.T())
 }

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -20,13 +20,16 @@ import (
 	"log"
 	"os"
 	"path"
+	"strings"
 	"testing"
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/persistent_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/suite"
 )
 
 const ExplicitDirInImplicitDir = "explicitDirInImplicitDir"
@@ -45,9 +48,50 @@ type env struct {
 	storageClient *storage.Client
 	ctx           context.Context
 	testDirPath   string
+	cfg           *test_suite.TestConfig
+	bucketType    string
 }
 
 var testEnv env
+
+type implicitDirTestSuite struct {
+	suite.Suite
+}
+
+func (s *implicitDirTestSuite) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(s.T())
+}
+
+func runImplicitDirSuite(t *testing.T, runSuiteFunc func()) {
+	// Run tests for mounted directory if the flag is set. This assumes that run flag is properly passed by GKE team as per the config.
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		runSuiteFunc()
+		return
+	}
+
+	// Run tests for GCE environment otherwise.
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			// 1. Static mounting
+			t.Run("Static", func(t *testing.T) {
+				static_mounting.RunSuiteForStaticMounting(testEnv.cfg, flags, t, runSuiteFunc)
+			})
+
+			// 2. Persistent mounting
+			t.Run("Persistent", func(t *testing.T) {
+				persistent_mounting.RunSuiteForPersistentMounting(testEnv.cfg, flags, t, runSuiteFunc)
+			})
+		})
+	}
+}
+
+func TestImplicitDirBase(t *testing.T) {
+	runImplicitDirSuite(t, func() {
+		suite.Run(t, new(implicitDirTestSuite))
+		suite.Run(t, &implicitDirLocalFileTest{isRapidWritesEnabled: false})
+	})
+}
 
 func setupTestDir(dirName string) string {
 	dir := setup.SetupTestDirectory(DirForImplicitDirTests)
@@ -71,7 +115,8 @@ func TestMain(m *testing.M) {
 
 	// 2. Create storage client before running tests.
 	testEnv.ctx = context.Background()
-	bucketType := setup.TestEnvironment(testEnv.ctx, &cfg.ImplicitDir[0])
+	testEnv.bucketType = setup.TestEnvironment(testEnv.ctx, &cfg.ImplicitDir[0])
+	testEnv.cfg = &cfg.ImplicitDir[0]
 	closeStorageClient := client.CreateStorageClientWithCancel(&testEnv.ctx, &testEnv.storageClient)
 	defer func() {
 		err := closeStorageClient()
@@ -80,11 +125,12 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// 3. Build the flag sets dynamically from the config.
-	flags := setup.BuildFlagSets(cfg.ImplicitDir[0], bucketType, "")
+	// 3. Set up test directory for test bucket.
+	setup.SetUpTestDirForTestBucket(testEnv.cfg)
+	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
-	// 4. Run tests with the dynamically generated flags.
-	successCode := implicit_and_explicit_dir_setup.RunTestsForExplicitAndImplicitDir(&cfg.ImplicitDir[0], flags, m)
+	// 4. Run tests.
+	successCode := m.Run()
 	setup.SaveLogFileInCaseOfFailure(successCode)
 
 	// 5. Clean up test directory created.

--- a/tools/integration_tests/implicit_dir/implicit_dir_test.go
+++ b/tools/integration_tests/implicit_dir/implicit_dir_test.go
@@ -125,11 +125,16 @@ func TestMain(m *testing.M) {
 		}
 	}()
 
-	// 3. Set up test directory for test bucket.
+	// 3. To run mountedDirectory tests, we need both testBucket and mountedDirectory
+	if testEnv.cfg.GKEMountedDirectory != "" && testEnv.cfg.TestBucket != "" {
+		os.Exit(setup.RunTestsForMountedDirectory(testEnv.cfg.GKEMountedDirectory, m))
+	}
+
+	// 4. Set up test directory for test bucket.
 	setup.SetUpTestDirForTestBucket(testEnv.cfg)
 	setup.OverrideFilePathsInFlagSet(testEnv.cfg, setup.TestDir())
 
-	// 4. Run tests.
+	// 5. Run tests.
 	successCode := m.Run()
 	setup.SaveLogFileInCaseOfFailure(successCode)
 

--- a/tools/integration_tests/implicit_dir/list_test.go
+++ b/tools/integration_tests/implicit_dir/list_test.go
@@ -21,14 +21,13 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup/implicit_and_explicit_dir_setup"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestListImplicitObjectsFromBucket(t *testing.T) {
+func (s *implicitDirTestSuite) TestListImplicitObjectsFromBucket() {
 	testDirName := "testListImplicitObjectsFromBucket"
 	testDirPath := setupTestDir(testDirName)
 	// Directory Structure
@@ -41,8 +40,8 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir1                               -- File
 	// testBucket/dirForImplicitDirTests/testDir/explicitDirectory/fileInExplicitDir2                               -- File
 
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
-	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), t)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, path.Join(DirForImplicitDirTests, testDirName))
+	implicit_and_explicit_dir_setup.CreateExplicitDirectoryStructure(path.Join(DirForImplicitDirTests, testDirName), s.T())
 
 	err := filepath.WalkDir(testDirPath, func(path string, dir fs.DirEntry, err error) error {
 		if err != nil {
@@ -64,21 +63,21 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 		if path == testDirPath {
 			// numberOfObjects - 3
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfTotalObjects {
-				t.Errorf("Incorrect number of objects in the bucket.")
+				s.T().Errorf("Incorrect number of objects in the bucket.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir     -- Dir
 			if objs[0].Name() != implicit_and_explicit_dir_setup.ExplicitDirectory || objs[0].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			// testBucket/dirForImplicitDirTests/testDir/explicitFile    -- File
 			if objs[1].Name() != implicit_and_explicit_dir_setup.ExplicitFile || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir     -- Dir
 			if objs[2].Name() != implicit_and_explicit_dir_setup.ImplicitDirectory || objs[2].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 		}
 
@@ -86,17 +85,17 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ExplicitDirectory {
 			// numberOfObjects - 2
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInExplicitDirectory {
-				t.Errorf("Incorrect number of objects in the explicitDirectory.")
+				s.T().Errorf("Incorrect number of objects in the explicitDirectory.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir/fileInExplicitDir1   -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FirstFileInExplicitDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/explicitDir/fileInExplicitDir2    -- File
 			if objs[1].Name() != implicit_and_explicit_dir_setup.SecondFileInExplicitDirectory || objs[1].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
@@ -105,16 +104,16 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ImplicitDirectory {
 			// numberOfObjects - 2
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInImplicitDirectory {
-				t.Errorf("Incorrect number of objects in the implicitDirectory.")
+				s.T().Errorf("Incorrect number of objects in the implicitDirectory.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/fileInImplicitDir1  -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FileInImplicitDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/implicitSubDirectory  -- Dir
 			if objs[1].Name() != implicit_and_explicit_dir_setup.ImplicitSubDirectory || objs[1].IsDir() != true {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
@@ -123,37 +122,37 @@ func TestListImplicitObjectsFromBucket(t *testing.T) {
 		if dir.IsDir() && dir.Name() == implicit_and_explicit_dir_setup.ImplicitSubDirectory {
 			// numberOfObjects - 1
 			if len(objs) != implicit_and_explicit_dir_setup.NumberOfFilesInImplicitSubDirectory {
-				t.Errorf("Incorrect number of objects in the implicitSubDirectoryt.")
+				s.T().Errorf("Incorrect number of objects in the implicitSubDirectoryt.")
 			}
 
 			// testBucket/dirForImplicitDirTests/testDir/implicitDir/implicitSubDir/fileInImplicitDir2   -- File
 			if objs[0].Name() != implicit_and_explicit_dir_setup.FileInImplicitSubDirectory || objs[0].IsDir() != false {
-				t.Errorf("Listed incorrect object")
+				s.T().Errorf("Listed incorrect object")
 			}
 			return nil
 		}
 		return nil
 	})
 	if err != nil {
-		t.Errorf("error walking the path : %v\n", err)
+		s.T().Errorf("error walking the path : %v\n", err)
 		return
 	}
 }
 
-func TestStatImplicitDirAfterList(t *testing.T) {
+func (s *implicitDirTestSuite) TestStatImplicitDirAfterList() {
 	testDirPath := setup.SetupTestDirectory(DirForImplicitDirTests)
-	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, t, testEnv.storageClient, DirForImplicitDirTests)
+	implicit_and_explicit_dir_setup.CreateImplicitDirectoryStructureUsingStorageClient(testEnv.ctx, s.T(), testEnv.storageClient, DirForImplicitDirTests)
 
 	// List the directory
 	_, err := os.ReadDir(testDirPath)
 	if err != nil {
-		t.Fatalf("ReadDir failed: %v", err)
+		s.T().Fatalf("ReadDir failed: %v", err)
 	}
 
 	// Stat the implicit directory
 	implicitDirPath := path.Join(testDirPath, implicit_and_explicit_dir_setup.ImplicitDirectory)
 	f, err := os.Stat(implicitDirPath)
-	if assert.NoError(t, err) {
-		assert.True(t, f.IsDir())
+	if assert.NoError(s.T(), err) {
+		assert.True(s.T(), f.IsDir())
 	}
 }

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -40,7 +40,7 @@ func (i *implicitDirLocalFileTest) TearDownTest() {
 	setup.SaveGCSFuseLogFileInCaseOfFailure(i.T())
 }
 
-func TestImplicitDirLocalFileRapidWritesEnabled(t *testing.T) {
+func TestImplicitDirRapidWritesEnabled(t *testing.T) {
 	if !setup.IsPirloBucketRun() {
 		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
 	}

--- a/tools/integration_tests/implicit_dir/local_file_test.go
+++ b/tools/integration_tests/implicit_dir/local_file_test.go
@@ -22,66 +22,86 @@ import (
 	. "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 const (
 	testDirName = "ImplicitDirTest"
 )
 
+type implicitDirLocalFileTest struct {
+	isRapidWritesEnabled bool
+	suite.Suite
+}
+
+func (i *implicitDirLocalFileTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(i.T())
+}
+
+func TestImplicitDirLocalFileRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	runImplicitDirSuite(t, func() {
+		suite.Run(t, &implicitDirLocalFileTest{isRapidWritesEnabled: true})
+	})
+}
+
 // //////////////////////////////////////////////////////////////////////
 // Tests
 // //////////////////////////////////////////////////////////////////////
 
-func TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose(t *testing.T) {
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+func (i *implicitDirLocalFileTest) TestNewFileUnderImplicitDirectoryShouldNotGetSyncedToGCSTillClose() {
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
 	fileName := path.Join(ImplicitDirName, FileName1)
 
-	_, fh := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName, t)
-	operations.WriteWithoutClose(fh, FileContents, t)
-	if !setup.IsZonalBucketRun() {
-		// For non-zonal buckets, the object is not visible until the file is closed.
-		ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, t)
-	} else {
-		// For zonal buckets, the object is unfinalized, but visible.
-		// A zonal bucket object written without sync would be recognized as having zero-size.
-		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", t)
+	_, fh := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName, i.T())
+	operations.WriteWithoutClose(fh, FileContents, i.T())
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && i.isRapidWritesEnabled) {
+		// For appendable objects, the object is unfinalized, but visible.
+		// An object written without sync would be recognized as having zero-size.
+		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, "", i.T())
 
-		// A zonal bucket object written with sync can be fully read.
+		// An appendable object written with sync can be fully read.
 		err := fh.Sync()
-		require.NoError(t, err)
-		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, t)
+		require.NoError(i.T(), err)
+		ValidateObjectContentsFromGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, FileContents, i.T())
+	} else {
+		// For non-appendable objects, the object is not visible until the file is closed.
+		ValidateObjectNotFoundErrOnGCS(testEnv.ctx, testEnv.storageClient, testBaseDirName, fileName, i.T())
 	}
 
 	// Validate.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh, testBaseDirName, fileName, FileContents, t)
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh, testBaseDirName, fileName, FileContents, i.T())
 }
 
-func TestReadDirForImplicitDirWithLocalFile(t *testing.T) {
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+func (i *implicitDirLocalFileTest) TestReadDirForImplicitDirWithLocalFile() {
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
 	fileName1 := path.Join(ImplicitDirName, FileName1)
 	fileName2 := path.Join(ImplicitDirName, FileName2)
-	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName1, t)
-	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, t)
+	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName1, i.T())
+	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, i.T())
 
 	// Attempt to list implicit directory.
-	entries := operations.ReadDirectory(path.Join(testEnv.testDirPath, ImplicitDirName), t)
+	entries := operations.ReadDirectory(path.Join(testEnv.testDirPath, ImplicitDirName), i.T())
 
 	// Verify entries received successfully.
-	operations.VerifyCountOfDirectoryEntries(3, len(entries), t)
-	operations.VerifyFileEntry(entries[0], FileName1, 0, t)
-	operations.VerifyFileEntry(entries[1], FileName2, 0, t)
-	operations.VerifyFileEntry(entries[2], ImplicitFileName1, GCSFileSize, t)
+	operations.VerifyCountOfDirectoryEntries(3, len(entries), i.T())
+	operations.VerifyFileEntry(entries[0], FileName1, 0, i.T())
+	operations.VerifyFileEntry(entries[1], FileName2, 0, i.T())
+	operations.VerifyFileEntry(entries[2], ImplicitFileName1, GCSFileSize, i.T())
 	// Close the local files.
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, fileName1, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", t)
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, fileName1, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", i.T())
 }
 
-func TestRecursiveListingWithLocalFiles(t *testing.T) {
+func (i *implicitDirLocalFileTest) TestRecursiveListingWithLocalFiles() {
 	// Structure
 	// mntDir/
 	// mntDir/foo1 										--- file
@@ -91,18 +111,18 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 	// mntDir/implicit/foo2  					--- file
 	// mntDir/implicit/implicitFile1	--- file
 
-	testBaseDirName := path.Join(testDirName, operations.GetRandomName(t))
+	testBaseDirName := path.Join(testDirName, operations.GetRandomName(i.T()))
 	testEnv.testDirPath = setup.SetupTestDirectoryRecursive(testBaseDirName)
 	fileName2 := path.Join(ExplicitDirName, ExplicitFileName1)
 	fileName3 := path.Join(ImplicitDirName, FileName2)
 	// Create local file in mnt/ dir.
-	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, FileName1, t)
+	_, fh1 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, FileName1, i.T())
 	// Create explicit dir with 1 local file.
-	operations.CreateDirectory(path.Join(testEnv.testDirPath, ExplicitDirName), t)
-	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, t)
+	operations.CreateDirectory(path.Join(testEnv.testDirPath, ExplicitDirName), i.T())
+	_, fh2 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName2, i.T())
 	// Create implicit dir with 1 local file1 and 1 synced file.
-	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, t)
-	_, fh3 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName3, t)
+	CreateImplicitDir(testEnv.ctx, testEnv.storageClient, testBaseDirName, i.T())
+	_, fh3 := CreateLocalFileInTestDir(testEnv.ctx, testEnv.storageClient, testEnv.testDirPath, fileName3, i.T())
 
 	// Recursively list mntDir/ directory.
 	err := filepath.WalkDir(testEnv.testDirPath,
@@ -115,39 +135,37 @@ func TestRecursiveListingWithLocalFiles(t *testing.T) {
 				return nil
 			}
 
-			objs := operations.ReadDirectory(walkPath, t)
+			objs := operations.ReadDirectory(walkPath, i.T())
 
 			// Check if mntDir has correct objects.
 			if walkPath == setup.MntDir() {
 				// numberOfObjects = 3
-				operations.VerifyCountOfDirectoryEntries(3, len(objs), t)
-				operations.VerifyDirectoryEntry(objs[0], ExplicitDirName, t)
-				operations.VerifyFileEntry(objs[1], FileName1, 0, t)
-				operations.VerifyDirectoryEntry(objs[2], ImplicitDirName, t)
+				operations.VerifyCountOfDirectoryEntries(3, len(objs), i.T())
+				operations.VerifyDirectoryEntry(objs[0], ExplicitDirName, i.T())
+				operations.VerifyFileEntry(objs[1], FileName1, 0, i.T())
+				operations.VerifyDirectoryEntry(objs[2], ImplicitDirName, i.T())
 			}
 
 			// Check if mntDir/explicitFoo/ has correct objects.
 			if walkPath == path.Join(testEnv.testDirPath, ExplicitDirName) {
 				// numberOfObjects = 1
-				operations.VerifyCountOfDirectoryEntries(1, len(objs), t)
-				operations.VerifyFileEntry(objs[0], ExplicitFileName1, 0, t)
+				operations.VerifyCountOfDirectoryEntries(1, len(objs), i.T())
+				operations.VerifyFileEntry(objs[0], ExplicitFileName1, 0, i.T())
 			}
 
 			// Check if mntDir/implicitFoo/ has correct objects.
 			if walkPath == path.Join(testEnv.testDirPath, ImplicitDirName) {
 				// numberOfObjects = 2
-				operations.VerifyCountOfDirectoryEntries(2, len(objs), t)
-				operations.VerifyFileEntry(objs[0], FileName2, 0, t)
-				operations.VerifyFileEntry(objs[1], ImplicitFileName1, GCSFileSize, t)
+				operations.VerifyCountOfDirectoryEntries(2, len(objs), i.T())
+				operations.VerifyFileEntry(objs[0], FileName2, 0, i.T())
+				operations.VerifyFileEntry(objs[1], ImplicitFileName1, GCSFileSize, i.T())
 			}
 			return nil
 		})
 
 	// Validate and close the files.
-	if err != nil {
-		t.Errorf("filepath.WalkDir() err: %v", err)
-	}
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, FileName1, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", t)
-	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh3, testBaseDirName, fileName3, "", t)
+	assert.NoError(i.T(), err, "filepath.WalkDir failed")
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh1, testBaseDirName, FileName1, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh2, testBaseDirName, fileName2, "", i.T())
+	CloseFileAndValidateContentFromGCS(testEnv.ctx, testEnv.storageClient, fh3, testBaseDirName, fileName3, "", i.T())
 }

--- a/tools/integration_tests/implicit_dir/rename_sym_link_test.go
+++ b/tools/integration_tests/implicit_dir/rename_sym_link_test.go
@@ -17,7 +17,6 @@ package implicit_dir_test
 import (
 	"os"
 	"path"
-	"testing"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
@@ -25,32 +24,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestRenameSymlinkToImplicitDir(t *testing.T) {
+func (s *implicitDirTestSuite) TestRenameSymlinkToImplicitDir() {
 	testDir := setup.SetupTestDirectory(DirForImplicitDirTests)
 	implicitDirName := "implicit_dir"
 	// Create an object that defines an implicit directory. This creates `implicit_dir/`.
 	objectNameInGCS := path.Join(DirForImplicitDirTests, implicitDirName, "placeholder")
 	err := client.CreateObjectOnGCS(testEnv.ctx, testEnv.storageClient, objectNameInGCS, "")
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	implicitDirPath := path.Join(testDir, implicitDirName)
 	oldSymlinkPath := path.Join(testDir, "symlink_old")
 	err = os.Symlink(implicitDirPath, oldSymlinkPath)
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	newSymlinkPath := path.Join(testDir, "symlink_new")
 
 	err = os.Rename(oldSymlinkPath, newSymlinkPath)
 
-	require.NoError(t, err)
+	require.NoError(s.T(), err)
 	_, err = os.Lstat(oldSymlinkPath)
-	require.Error(t, err)
-	assert.True(t, os.IsNotExist(err))
+	require.Error(s.T(), err)
+	assert.True(s.T(), os.IsNotExist(err))
 	fi, err := os.Lstat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, os.ModeSymlink, fi.Mode()&os.ModeType)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), os.ModeSymlink, fi.Mode()&os.ModeType)
 	targetRead, err := os.Readlink(newSymlinkPath)
-	require.NoError(t, err)
-	assert.Equal(t, implicitDirPath, targetRead)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), implicitDirPath, targetRead)
 	targetFi, err := os.Stat(newSymlinkPath)
-	require.NoError(t, err)
-	assert.True(t, targetFi.IsDir())
+	require.NoError(s.T(), err)
+	assert.True(s.T(), targetFi.IsDir())
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -38,7 +38,7 @@ implicit_dir:
         run_on_gke: true
         run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true"
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-rapid-writes=true"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -46,7 +46,7 @@ implicit_dir:
         run_on_gke: false
         run: TestImplicitDirRapidWritesEnabled
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false"
+          - "--experimental-enable-pirlo,--implicit-dirs,--enable-rapid-writes=false"
         run_on_pirlo:
           hns:
             same_zone: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -36,13 +36,23 @@ implicit_dir:
           hns: true
           zonal: true
         run_on_gke: true
+        run: TestImplicitDirBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
-        run_on_gke: true
+        run_on_gke: false
+        run: TestImplicitDirRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestImplicitDirBase
       - flags:
           - "--implicit-dirs,--client-protocol=grpc"
         compatible:
@@ -50,6 +60,7 @@ implicit_dir:
           hns: true
           zonal: false
         run_on_gke: true
+        run: TestImplicitDirBase
 
 list_large_dir:
   - mounted_directory: "${MOUNTED_DIR}"


### PR DESCRIPTION
### Description
Bifurcates implicit_dir tests into TestImplicitDirBase and TestImplicitDirLocalFileRapidWritesEnabled while preserving both static and persistent mounting.

### Testing details
1. Unit tests - NA
2. Integration tests - Done

### Any backward incompatible change? If so, please explain.
No