### PR TITLE
test(readonly_creds): bifurcate readonly_creds tests for rapid writes flagsets

### DIFF
--- a/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
+++ b/tools/integration_tests/readonly_creds/failure_during_file_sync_test.go
@@ -15,11 +15,13 @@
 package readonly_creds
 
 import (
+	"log"
 	"os"
 	"path"
 	"strings"
 	"testing"
 
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/stretchr/testify/assert"
@@ -32,7 +34,8 @@ import (
 ////////////////////////////////////////////////////////////////////////
 
 type readOnlyCredsTest struct {
-	testDirPath string
+	testDirPath          string
+	isRapidWritesEnabled bool
 	suite.Suite
 }
 
@@ -41,6 +44,7 @@ func (r *readOnlyCredsTest) SetupTest() {
 }
 
 func (r *readOnlyCredsTest) TearDownTest() {
+	setup.SaveGCSFuseLogFileInCaseOfFailure(r.T())
 }
 
 ////////////////////////////////////////////////////////////////////////
@@ -72,10 +76,11 @@ func (r *readOnlyCredsTest) TestEmptyCreateFileFails_FailedFileNotInListing() {
 	filePath := path.Join(r.testDirPath, testFileName)
 
 	fh, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, operations.FilePermission_0777)
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && r.isRapidWritesEnabled) {
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
+		require.NoError(r.T(), err)
 		r.assertFileSyncFailsWithPermissionError(fh, r.T())
 	}
 
@@ -86,10 +91,11 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 	filePath := path.Join(r.testDirPath, testFileName)
 
 	fh, err := os.OpenFile(filePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, operations.FilePermission_0777)
-	if setup.IsZonalBucketRun() {
+	if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && r.isRapidWritesEnabled) {
 		require.Error(r.T(), err)
 		assert.True(r.T(), strings.Contains(err.Error(), permissionDeniedError))
 	} else {
+		require.NoError(r.T(), err)
 		operations.WriteWithoutClose(fh, content, r.T())
 		operations.WriteWithoutClose(fh, content, r.T())
 		r.assertFileSyncFailsWithPermissionError(fh, r.T())
@@ -102,9 +108,27 @@ func (r *readOnlyCredsTest) TestNonEmptyCreateFileFails_FailedFileNotInListing()
 // Test Function (Runs once before all tests)
 ////////////////////////////////////////////////////////////////////////
 
-func TestReadOnlyTest(t *testing.T) {
-	ts := &readOnlyCredsTest{}
+func runReadOnlyCredsTest(t *testing.T, ts *readOnlyCredsTest) {
+	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
+	for _, flags := range flagsSet {
+		t.Run(strings.Join(flags, "_"), func(t *testing.T) {
+			log.Printf("Running %s with flags: %s", t.Name(), flags)
+			creds_tests.RunSuiteForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", t, func() {
+				suite.Run(t, ts)
+			})
+		})
+	}
+}
 
-	// Run tests.
-	suite.Run(t, ts)
+func TestReadOnlyCredsBase(t *testing.T) {
+	ts := &readOnlyCredsTest{isRapidWritesEnabled: false}
+	runReadOnlyCredsTest(t, ts)
+}
+
+func TestReadOnlyCredsRapidWritesEnabled(t *testing.T) {
+	if !setup.IsPirloBucketRun() {
+		t.Skip("Rapid writes tests are only applicable to Pirlo buckets")
+	}
+	ts := &readOnlyCredsTest{isRapidWritesEnabled: true}
+	runReadOnlyCredsTest(t, ts)
 }

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -23,7 +23,6 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/client"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/creds_tests"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
 	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
 )
@@ -95,9 +94,7 @@ func TestMain(m *testing.M) {
 	// Save mount and root directory variables.
 	mountDir, rootDir = testEnv.cfg.GCSFuseMountedDirectory, testEnv.cfg.GCSFuseMountedDirectory
 
-	flags := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, "")
-	// Test for viewer permission on test bucket.
-	successCode := creds_tests.RunTestsForDifferentAuthMethods(testEnv.ctx, testEnv.cfg, testEnv.storageClient, flags, "objectViewer", m)
+	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
 	os.Exit(successCode)

--- a/tools/integration_tests/readonly_creds/readonly_creds_test.go
+++ b/tools/integration_tests/readonly_creds/readonly_creds_test.go
@@ -97,5 +97,6 @@ func TestMain(m *testing.M) {
 	successCode := m.Run()
 
 	setup.CleanupDirectoryOnGCS(testEnv.ctx, testEnv.storageClient, path.Join(testEnv.cfg.TestBucket, testDirName))
+	setup.SaveLogFileInCaseOfFailure(successCode)
 	os.Exit(successCode)
 }

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1148,8 +1148,7 @@ readonly_creds:
         run_on_gke: false
         run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true"
         run_on_pirlo:
           hns:
             same_zone: true
@@ -1157,8 +1156,7 @@ readonly_creds:
         run_on_gke: false
         run: TestReadOnlyCredsRapidWritesEnabled
       - flags:
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
-          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false"
         run_on_pirlo:
           hns:
             same_zone: true

--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -1146,14 +1146,25 @@ readonly_creds:
           hns: true
           zonal: true
         run_on_gke: false
+        run: TestReadOnlyCredsBase
       - flags:
-          - "--experimental-enable-pirlo,--implicit-dirs=true,--client-protocol=http1"
-          - "--experimental-enable-pirlo,--implicit-dirs=false,--client-protocol=http1"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=true,--implicit-dirs=false"
         run_on_pirlo:
           hns:
             same_zone: true
             different_zone: false
         run_on_gke: false
+        run: TestReadOnlyCredsRapidWritesEnabled
+      - flags:
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=true"
+          - "--experimental-enable-pirlo,--enable-rapid-writes=false,--implicit-dirs=false"
+        run_on_pirlo:
+          hns:
+            same_zone: true
+            different_zone: false
+        run_on_gke: false
+        run: TestReadOnlyCredsBase
 
 mount_timeout:
   - mounted_directory: "${MOUNTED_DIR}"


### PR DESCRIPTION
### Description
Bifurcates readonly_creds tests into TestReadOnlyCredsBase and TestReadOnlyCredsRapidWritesEnabled and adds RunSuiteForDifferentAuthMethods helper to support multi-auth execution.

### Testing details
1. Unit tests - NA
2. Integration tests - Done

### Any backward incompatible change? If so, please explain.
No