### PR TITLE
fix(storage): do not enforce DirectPath for Rapid buckets

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -188,7 +188,7 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isBucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -200,9 +200,9 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available.
+	// Add DirectPath enforcement - operations performed via the client will fail if DirectPath is not available.
 	// Rapid buckets do not support DirectPath enforcement headers.
-	if !isbucketRapid {
+	if !isBucketRapid {
 		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
 	}
 
@@ -217,14 +217,15 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 
-	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
-	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
-		if !isbucketRapid {
+	// Skip DirectPath verification for Rapid buckets as DirectPath is not supported/enforced.
+	if !isBucketRapid {
+		// DirectPath verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
+		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
+			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
 			return nil, verifyErr
+		} else {
+			logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 		}
-	} else {
-		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
 
 	return sc, nil

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -200,8 +200,11 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	// Add DirectPath enforcement - client creation will fail if DirectPath is not available.
+	// Rapid buckets do not support DirectPath enforcement headers.
+	if !isbucketRapid {
+		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	}
 
 	sc, err := storage.NewGRPCClient(ctx, clientOpts...)
 	if err != nil {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1129,11 +1129,12 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_RapidBucket() {
 	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
-	// For rapid buckets (isbucketRapid = true), createGRPCClientHandle should omit WithDirectConnectivityEnforced
-	// and should not return an error when verifyDirectPathConnectivity fails.
+	// For rapid buckets (isBucketRapid = true), createGRPCClientHandle should omit WithDirectConnectivityEnforced
+	// and skip verifyDirectPathConnectivity entirely.
 	client, err := createGRPCClientHandle(testSuite.ctx, &sc, true, true, TestBucketName, "")
-	assert.NoError(testSuite.T(), err)
-	assert.NotNil(testSuite.T(), client)
+	require.NoError(testSuite.T(), err)
+	require.NotNil(testSuite.T(), client)
+	defer client.Close()
 }
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_NonRapidBucket() {
@@ -1144,4 +1145,3 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_NonRapidBucket() 
 	assert.Error(testSuite.T(), err)
 	assert.Nil(testSuite.T(), client)
 }
-

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1126,3 +1126,22 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnFolderAPIs, "Retries should be enabled for folder APIs on zonal buckets")
 	assert.Same(testSuite.T(), mockRawControlClientWithoutRetries, controlClientWithRetry.raw)
 }
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_RapidBucket() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	// For rapid buckets (isbucketRapid = true), createGRPCClientHandle should omit WithDirectConnectivityEnforced
+	// and should not return an error when verifyDirectPathConnectivity fails.
+	client, err := createGRPCClientHandle(testSuite.ctx, &sc, true, true, TestBucketName, "")
+	assert.NoError(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), client)
+}
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_NonRapidBucket() {
+	sc := storageutil.GetDefaultStorageClientConfig(keyFile)
+	// For non-rapid buckets (isbucketRapid = false), createGRPCClientHandle includes WithDirectConnectivityEnforced
+	// and returns an error when verifyDirectPathConnectivity fails in unit test environment.
+	client, err := createGRPCClientHandle(testSuite.ctx, &sc, false, false, TestBucketName, "")
+	assert.Error(testSuite.T(), err)
+	assert.Nil(testSuite.T(), client)
+}
+


### PR DESCRIPTION
### Description
In GCSFuse, `createGRPCClientHandle` in `internal/storage/storage_handle.go` previously attached `experimental.WithDirectConnectivityEnforced()` unconditionally for all gRPC clients.

For Rapid buckets, DirectPath is not supported/enforced. Forcing DirectPath headers causes GCS servers to reject non-DirectPath requests once DirectPath enforcement is active.

This change:
1. Conditionally omits `experimental.WithDirectConnectivityEnforced()` when `isBucketRapid` is `true`.
2. Skips DirectPath connectivity verification (`verifyDirectPathConnectivity`) for Rapid buckets to avoid unnecessary dummy Stat API call retries, latency, and warning logs.
3. Adds dedicated unit test cases for Rapid vs Non-Rapid bucket gRPC client handle initialization in `internal/storage/storage_handle_test.go`.

### Link to the issue in case of a bug fix.
Fixes b/541764145

### Testing details
1. Manual - Ran verification script `scratch/verify_grpc_headers.sh` confirming header and DirectPath handling for Rapid vs Non-Rapid buckets.
2. Unit tests - Added `TestCreateGRPCClientHandle_RapidBucket` and `TestCreateGRPCClientHandle_NonRapidBucket` in `./internal/storage`. Tests pass cleanly (0.00s execution for Rapid bucket).
3. Integration tests - Executed storage package test suite (`go test -v ./internal/storage`).

| Branch | File Size  |   Read BW    |  Write BW  | RandRead BW  | RandWrite BW |
|--------|------------|--------------|------------|--------------|--------------|
| Master |  0.25MiB   |  546.8MiB/s  | 1.26MiB/s  |  72.64MiB/s  |  1.27MiB/s   |
|   PR   |  0.25MiB   | 543.38MiB/s  | 1.29MiB/s  |  71.39MiB/s  |  1.26MiB/s   |
| Master | 48.828MiB  | 4454.94MiB/s | 72.86MiB/s | 1463.0MiB/s  |  62.66MiB/s  |
|   PR   | 48.828MiB  | 4437.52MiB/s | 75.43MiB/s | 1498.43MiB/s |  75.68MiB/s  |
| Master | 976.562MiB | 4463.69MiB/s | 33.9MiB/s  | 698.35MiB/s  |  39.37MiB/s  |
|   PR   | 976.562MiB | 4493.43MiB/s | 37.92MiB/s | 1085.05MiB/s |  39.9MiB/s   |


### Any backward incompatible change? If so, please explain.
No
