### PR TITLE
fix(storage): enforce single attempt retryer on DirectPath verification handle

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -241,6 +241,9 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 		bucketHandle = bucketHandle.UserProject(billingProject)
 	}
 
+	// Disable Go SDK retries for this call to let ExecuteWithRetry handle it.
+	bucketHandle = bucketHandle.Retryer(storage.WithMaxAttempts(1))
+
 	dpClientConfig := &storageutil.StorageClientConfig{
 		MaxRetrySleep:    directPathDetectionMaxBackoff,
 		RetryMultiplier:  clientConfig.RetryMultiplier,
@@ -251,9 +254,6 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	apiCall := func(attemptCtx context.Context) (*storage.ObjectAttrs, error) {
 		return bucketHandle.Object(testObject).Attrs(attemptCtx)
 	}
-
-	// Disable Go SDK retries for this call to let ExecuteWithRetry handle it.
-	sc.SetRetry(storage.WithMaxAttempts(1))
 
 	_, statErr := storageutil.ExecuteWithRetryAtLogLevel(ctx, retryConfig, "Attrs", testObject, uuid.NewString(), apiCall, logger.LevelInfo)
 

--- a/tools/integration_tests/mount_timeout/mount_timeout_test.go
+++ b/tools/integration_tests/mount_timeout/mount_timeout_test.go
@@ -53,20 +53,21 @@ var (
 
 const (
 	// Constants specific to non-ZB E2E runs.
-	testEnvGCEUSCentral                    string        = "gce-us-central"
-	testEnvGCENonUSCentral                 string        = "gce-non-us-central"
-	testEnvNonGCE                          string        = "non-gce"
-	multiRegionUSBucket                    string        = "mount_timeout_test_bucket_us"
-	multiRegionAsiaBucket                  string        = "mount_timeout_test_bucket_asia"
-	dualRegionUSBucket                     string        = "mount_timeout_test_bucket_nam4"
-	dualRegionAsiaBucket                   string        = "mount_timeout_test_bucket_asia1"
-	singleRegionUSCentralBucket            string        = "mount_timeout_test_bucket_us-central1"
-	singleRegionAsiaEastBucket             string        = "mount_timeout_test_bucket_asia-east1"
-	singleRegionAsiaEastExpectedMountTime  time.Duration = 5500 * time.Millisecond
+	testEnvGCEUSCentral         string = "gce-us-central"
+	testEnvGCENonUSCentral      string = "gce-non-us-central"
+	testEnvNonGCE               string = "non-gce"
+	multiRegionUSBucket         string = "mount_timeout_test_bucket_us"
+	multiRegionAsiaBucket       string = "mount_timeout_test_bucket_asia"
+	dualRegionUSBucket          string = "mount_timeout_test_bucket_nam4"
+	dualRegionAsiaBucket        string = "mount_timeout_test_bucket_asia1"
+	singleRegionUSCentralBucket string = "mount_timeout_test_bucket_us-central1"
+	singleRegionAsiaEastBucket  string = "mount_timeout_test_bucket_asia-east1"
+	// TODO: Remove temporary 10s timeout for cross-region mounts after cl/958817829 is rolled out to production.
+	singleRegionAsiaEastExpectedMountTime  time.Duration = 10000 * time.Millisecond
 	multiRegionUSExpectedMountTime         time.Duration = 4500 * time.Millisecond
-	multiRegionAsiaExpectedMountTime       time.Duration = 7500 * time.Millisecond
+	multiRegionAsiaExpectedMountTime       time.Duration = 10000 * time.Millisecond
 	dualRegionUSExpectedMountTime          time.Duration = 4500 * time.Millisecond
-	dualRegionAsiaExpectedMountTime        time.Duration = 6250 * time.Millisecond
+	dualRegionAsiaExpectedMountTime        time.Duration = 10000 * time.Millisecond
 	singleRegionUSCentralExpectedMountTime time.Duration = 2500 * time.Millisecond
 	// Constants specific to ZB E2E runs.
 	testEnvZoneGCEUSCentral1A       string        = "gce-zone-us-central1-a"
@@ -77,7 +78,7 @@ const (
 	zonalSameZoneExpectedMountTime  time.Duration = 2500 * time.Millisecond
 	zonalCrossZoneExpectedMountTime time.Duration = 5000 * time.Millisecond
 	// Commont constants.
-	relaxedExpectedMountTime time.Duration = 8000 * time.Millisecond
+	relaxedExpectedMountTime time.Duration = 10000 * time.Millisecond
 	logfilePathPrefix        string        = "/tmp/gcsfuse_mount_timeout_"
 )
 


### PR DESCRIPTION
### Description
Disable Go SDK internal retries for the `BucketHandle` used during `verifyDirectPathConnectivity` by setting `Retryer(storage.WithMaxAttempts(1))` directly on `bucketHandle`.

Previously, `sc.SetRetry(storage.WithMaxAttempts(1))` was called after `sc.Bucket(bucketName)` had already cloned the client retry config, causing `bucketHandle` to ignore `SetRetry` and execute 15-second internal SDK retries per attempt when the backend returned `UNAVAILABLE` for cross-location DirectPath requests.

Additionally, temporarily increased expected cross-region mount timeouts to 10 seconds in `mount_timeout_test.go` with a TODO to revert after cl/958817829 rolls out to production.

### Link to the issue in case of a bug fix.
https://b.corp.google.com/issues/542608390

### Testing details
1. Manual - Verified fast fallback (~7s total) using Go reproducer script.
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No.