### PR TITLE
perf(cache): optimize stat_cache memory-usage

### DIFF
--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -24,6 +24,9 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 )
 
+// 9223372036 is math.MaxInt64 / 1,000,000,000 (max seconds representable in nanoseconds)
+const maxSeconds int64 = math.MaxInt64 / 1000000000
+
 // A cache mapping from name to most recent known record for the object of that
 // name. External synchronization must be provided.
 type StatCache interface {
@@ -113,7 +116,7 @@ type statCacheBucketView struct {
 type entry struct {
 	m          *gcs.MinObject
 	f          *gcs.Folder
-	expiration time.Time
+	expiration int64
 	// Set to true only for implicit directory entries. This flag will always remain false for negative entries and explicit objects.
 	implicitDir bool
 }
@@ -143,6 +146,25 @@ func (e entry) Size() uint64 {
 	size = uint64(math.Ceil(util.HeapSizeToRssConversionFactor * float64(size)))
 
 	return size
+}
+
+// timeToUnixNano safely converts a time.Time to Unix nanoseconds.
+// It prevents int64 overflow for dates beyond the year 2262, returning
+// math.MaxInt64 instead, which safely mimics "never expire".
+func timeToUnixNano(t time.Time) int64 {
+	if t.IsZero() {
+		return math.MinInt64
+	}
+
+	unixSecs := t.Unix()
+	if unixSecs >= maxSeconds {
+		return math.MaxInt64
+	}
+	if unixSecs <= -maxSeconds {
+		return math.MinInt64
+	}
+
+	return t.UnixNano()
 }
 
 // Should the supplied object for a new positive entry replace the given
@@ -201,7 +223,7 @@ func (sc *statCacheBucketView) Insert(m *gcs.MinObject, expiration time.Time) {
 	// Insert an entry.
 	e := entry{
 		m:          m,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -237,7 +259,7 @@ func (sc *statCacheBucketView) InsertImplicitDir(objectName string, expiration t
 	// Insert an entry.
 	e := entry{
 		implicitDir: true,
-		expiration:  expiration,
+		expiration:  timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -251,7 +273,7 @@ func (sc *statCacheBucketView) AddNegativeEntry(objectName string, expiration ti
 	// Insert a negative entry.
 	e := entry{
 		m:          nil,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -265,7 +287,7 @@ func (sc *statCacheBucketView) AddNegativeEntryForFolder(folderName string, expi
 	// Insert a negative entry.
 	e := entry{
 		f:          nil,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {
@@ -315,7 +337,9 @@ func (sc *statCacheBucketView) sharedCacheLookup(key string, now time.Time) (boo
 	e := value.(entry)
 
 	// Has this entry expired?
-	if e.expiration.Before(now) {
+	nowNano := timeToUnixNano(now)
+
+	if e.expiration < nowNano {
 		sc.Erase(key)
 		return false, nil
 	}
@@ -328,7 +352,7 @@ func (sc *statCacheBucketView) InsertFolder(f *gcs.Folder, expiration time.Time)
 
 	e := entry{
 		f:          f,
-		expiration: expiration,
+		expiration: timeToUnixNano(expiration),
 	}
 
 	if _, err := sc.sharedCache.Insert(name, e); err != nil {

--- a/internal/cache/metadata/stat_cache.go
+++ b/internal/cache/metadata/stat_cache.go
@@ -25,7 +25,7 @@ import (
 )
 
 // 9223372036 is math.MaxInt64 / 1,000,000,000 (max seconds representable in nanoseconds)
-const maxSeconds int64 = math.MaxInt64 / 1000000000
+const maxSeconds int64 = int64(math.MaxInt64 / time.Second)
 
 // A cache mapping from name to most recent known record for the object of that
 // name. External synchronization must be provided.

--- a/internal/cache/metadata/stat_cache_benchmark_test.go
+++ b/internal/cache/metadata/stat_cache_benchmark_test.go
@@ -1,0 +1,89 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metadata_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/lru"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/metadata"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
+)
+
+func generateKeys(count int) []string {
+	keys := make([]string, count)
+	for i := 0; i < count; i++ {
+		keys[i] = fmt.Sprintf("object-%d", i)
+	}
+	return keys
+}
+
+func setupStatCache(capacity uint64) metadata.StatCache {
+	// 1000 items * approx 120 bytes each = ~120,000 bytes capacity
+	lruCache := lru.NewCache(capacity)
+	return metadata.NewStatCacheBucketView(lruCache, "")
+}
+
+func BenchmarkStatCache_Insert(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	objects := make([]*gcs.MinObject, len(keys))
+	for i, key := range keys {
+		objects[i] = &gcs.MinObject{Name: key}
+	}
+
+	i := 0
+	for b.Loop() {
+		m := objects[i%len(objects)]
+		cache.Insert(m, now)
+		i++
+	}
+}
+
+func BenchmarkStatCache_AddNegativeEntry(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	i := 0
+	for b.Loop() {
+		key := keys[i%len(keys)]
+		cache.AddNegativeEntry(key, now)
+		i++
+	}
+}
+
+func BenchmarkStatCache_LookUp(b *testing.B) {
+	keys := generateKeys(10000)
+	cache := setupStatCache(uint64(len(keys) * 500))
+	now := time.Now()
+
+	// Pre-fill the cache with unexpired entries.
+	for _, key := range keys {
+		m := &gcs.MinObject{Name: key}
+		cache.Insert(m, now.Add(time.Hour))
+	}
+
+	i := 0
+	for b.Loop() {
+		key := keys[i%len(keys)]
+		_, _ = cache.LookUp(key, now)
+		i++
+	}
+}

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -168,18 +168,18 @@ func (t *StatCacheTest) Test_KeysPresentButEverythingIsExpired() {
 }
 
 func (t *StatCacheTest) Test_FillUpToCapacity() {
-	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1720 = 5160 bytes
 
 	m0 := &gcs.MinObject{Name: "burrito"}
 	m1 := &gcs.MinObject{Name: "taco"}
 	m2 := &gcs.MinObject{Name: "quesadilla"}
 
-	t.cache.Insert(m0, expiration)                    // size = 1410 bytes
-	t.cache.Insert(m1, expiration)                    // size = 1398 bytes (cumulative = 2808 bytes)
-	t.cache.AddNegativeEntry("enchilada", expiration) // size = 178 bytes (cumulative = 2986 bytes)
-	t.cache.Insert(m2, expiration)                    // size = 1422 bytes (cumulative = 4408 bytes)
-	t.cache.AddNegativeEntry("fajita", expiration)    // size = 172 bytes (cumulative = 4580 bytes)
-	t.cache.AddNegativeEntry("salsa", expiration)     // size = 170 bytes (cumulative = 4750 bytes)
+	t.cache.Insert(m0, expiration)                    // size = 1284 bytes
+	t.cache.Insert(m1, expiration)                    // size = 1278 bytes (cumulative = 2562 bytes)
+	t.cache.AddNegativeEntry("enchilada", expiration) // size = 64 bytes (cumulative = 2626 bytes)
+	t.cache.Insert(m2, expiration)                    // size = 1290 bytes (cumulative = 3916 bytes)
+	t.cache.AddNegativeEntry("fajita", expiration)    // size = 64 bytes (cumulative = 3980 bytes)
+	t.cache.AddNegativeEntry("salsa", expiration)     // size = 64 bytes (cumulative = 4044 bytes)
 
 	// Before expiration
 	justBefore := expiration.Add(-time.Nanosecond)
@@ -209,16 +209,16 @@ func (t *StatCacheTest) Test_FillUpToCapacity() {
 }
 
 func (t *StatCacheTest) Test_ExpiresLeastRecentlyUsed() {
-	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1720 = 5160 bytes
 
 	o0 := &gcs.MinObject{Name: "burrito"}
 	o1 := &gcs.MinObject{Name: "taco"}
 	o2 := &gcs.MinObject{Name: "quesadilla"}
 
-	t.cache.Insert(o0, expiration)                                    // size = 1410 bytes
-	t.cache.Insert(o1, expiration)                                    // Least recent, size = 1398 bytes (cumulative = 2808 bytes)
-	t.cache.AddNegativeEntry("enchilada", expiration)                 // Third most recent, size = 178 bytes (cumulative = 2986 bytes)
-	t.cache.Insert(o2, expiration)                                    // Second most recent, size = 1422 bytes (cumulative = 4408 bytes)
+	t.cache.Insert(o0, expiration)                                    // size = 1284 bytes
+	t.cache.Insert(o1, expiration)                                    // Least recent, size = 1278 bytes (cumulative = 2562 bytes)
+	t.cache.AddNegativeEntry("enchilada", expiration)                 // Third most recent, size = 64 bytes (cumulative = 2626 bytes)
+	t.cache.Insert(o2, expiration)                                    // Second most recent, size = 1290 bytes (cumulative = 3916 bytes)
 	assert.Equal(t.T(), o0, t.cache.LookUpOrNil("burrito", someTime)) // Most recent
 
 	// Insert another.
@@ -382,18 +382,18 @@ func (t *MultiBucketStatCacheTest) Test_CreateEntriesWithSameNameInDifferentBuck
 }
 
 func (t *MultiBucketStatCacheTest) Test_FillUpToCapacity() {
-	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1720 = 5160 bytes
 
 	cache := &t.multiBucketCache
 	fruits := &cache.fruits
 	spices := &cache.spices
 
-	fruits.Insert(apple, expiration)               // size = 1416 bytes
-	fruits.Insert(orange, expiration)              // size = 1420 bytes (cumulative = 2836 bytes)
-	spices.Insert(cardamom, expiration)            // size = 1428 bytes (cumulative = 4264 bytes)
-	fruits.AddNegativeEntry("papaya", expiration)  // size = 186 bytes (cumulative = 4450 bytes)
-	spices.AddNegativeEntry("saffron", expiration) // size = 188 bytes (cumulative = 4638 bytes)
-	spices.AddNegativeEntry("pepper", expiration)  // size = 186 bytes (cumulative = 4824 bytes)
+	fruits.Insert(apple, expiration)               // size = 1280 bytes
+	fruits.Insert(orange, expiration)              // size = 1282 bytes (cumulative = 2562 bytes)
+	spices.Insert(cardamom, expiration)            // size = 1286 bytes (cumulative = 3848 bytes)
+	fruits.AddNegativeEntry("papaya", expiration)  // size = 64 bytes (cumulative = 3912 bytes)
+	spices.AddNegativeEntry("saffron", expiration) // size = 64 bytes (cumulative = 3976 bytes)
+	spices.AddNegativeEntry("pepper", expiration)  // size = 64 bytes (cumulative = 4040 bytes)
 
 	// Before expiration
 	justBefore := expiration.Add(-time.Nanosecond)
@@ -423,15 +423,15 @@ func (t *MultiBucketStatCacheTest) Test_FillUpToCapacity() {
 }
 
 func (t *MultiBucketStatCacheTest) Test_ExpiresLeastRecentlyUsed() {
-	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1640 = 4920 bytes
+	assert.Equal(t.T(), 3, capacity) // maxSize = 3 * 1720 = 5160 bytes
 
 	cache := &t.multiBucketCache
 	fruits := &cache.fruits
 	spices := &cache.spices
 
-	fruits.Insert(apple, expiration)                                  // size = 1416 bytes
-	fruits.Insert(orange, expiration)                                 // Least recent, size = 1420 bytes (cumulative = 2836 bytes)
-	spices.Insert(cardamom, expiration)                               // Second most recent, size = 1428 bytes (cumulative = 4264 bytes)
+	fruits.Insert(apple, expiration)                                  // size = 1280 bytes
+	fruits.Insert(orange, expiration)                                 // Least recent, size = 1282 bytes (cumulative = 2562 bytes)
+	spices.Insert(cardamom, expiration)                               // Second most recent, size = 1286 bytes (cumulative = 3848 bytes)
 	assert.Equal(t.T(), apple, fruits.LookUpOrNil("apple", someTime)) // Most recent
 
 	// Insert another.
@@ -556,8 +556,8 @@ func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize()
 	folderEntry := &gcs.Folder{
 		Name: "3/",
 	}
-	t.statCache.Insert(objectEntry1, expiration) // adds size of 1304
-	t.statCache.Insert(objectEntry2, expiration) // adds size of 1304
+	t.statCache.Insert(objectEntry1, expiration) // adds size of 1272
+	t.statCache.Insert(objectEntry2, expiration) // adds size of 1272
 
 	hit1, entry1 := t.statCache.LookUp("1", someTime)
 	hit2, entry2 := t.statCache.LookUp("2", someTime)
@@ -567,7 +567,7 @@ func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize()
 	assert.True(t.T(), hit2)
 	assert.Equal(t.T(), "2", entry2.Name)
 
-	t.statCache.InsertFolder(folderEntry, expiration) //adds size of 180 and exceeds capacity
+	t.statCache.InsertFolder(folderEntry, expiration) // adds size of 148 and exceeds capacity
 
 	hit1, entry1 = t.statCache.LookUp("1", someTime)
 	hit2, entry2 = t.statCache.LookUp("2", someTime)
@@ -596,12 +596,12 @@ func (t *StatCacheTest) Test_ShouldEvictAllEntriesWithPrefixFolder() {
 	folderEntry3 := &gcs.Folder{
 		Name: "b",
 	}
-	t.statCache.InsertFolder(folderEntry1, expiration) //adds size of 220 and exceeds capacity
-	t.statCache.Insert(objectEntry1, expiration)       // adds size of 1428
-	t.statCache.Insert(objectEntry2, expiration)       // adds size of 1428
-	t.statCache.InsertFolder(folderEntry2, expiration) //adds size of 220 and exceeds capacity
-	t.statCache.InsertFolder(folderEntry3, expiration) //adds size of 220 and exceeds capacity
-	t.statCache.Insert(objectEntry3, expiration)       // adds size of 1428
+	t.statCache.InsertFolder(folderEntry1, expiration) // adds size of 146
+	t.statCache.Insert(objectEntry1, expiration)       // adds size of 1276
+	t.statCache.Insert(objectEntry2, expiration)       // adds size of 1280
+	t.statCache.InsertFolder(folderEntry2, expiration) // adds size of 150
+	t.statCache.InsertFolder(folderEntry3, expiration) // adds size of 146
+	t.statCache.Insert(objectEntry3, expiration)       // adds size of 1272
 
 	t.statCache.EraseEntriesWithGivenPrefix("a")
 
@@ -637,10 +637,10 @@ func (t *StatCacheTest) Test_InsertImplicitDir() {
 }
 
 func (t *StatCacheTest) Test_ImplicitDirSizeEfficiency() {
-	// Standard entry size ~1640 bytes (according to Test_FillUpToCapacity comments).
-	// Implicit entry size should be much smaller (around 100-200 bytes).
+	// Standard entry size ~1280 bytes (according to Test_FillUpToCapacity comments).
+	// Implicit entry size should be much smaller (around 64 bytes).
 	// So we should be able to store many more implicit entries than explicit ones.
-	// capacity is 3 in SetupTest. Max size = 3 * (AvgPos + AvgNeg) ~= 5000 bytes.
+	// capacity is 3 in SetupTest. Max size = 3 * (AvgPos + AvgNeg) = 5160 bytes.
 	// 1. Fill with implicit dirs
 	// Insert 20 implicit dirs. They should all fit if size is small.
 	for i := 0; i < 20; i++ {

--- a/internal/cache/metadata/stat_cache_test.go
+++ b/internal/cache/metadata/stat_cache_test.go
@@ -223,8 +223,10 @@ func (t *StatCacheTest) Test_ExpiresLeastRecentlyUsed() {
 
 	// Insert another.
 	o3 := &gcs.MinObject{Name: "queso"}
-	t.cache.Insert(o3, expiration) // size = 1402 bytes (cumulative = 5810 bytes)
-	// This would evict the least recent entry i.e o1/"taco".
+	t.cache.Insert(o3, expiration)
+
+	// Add a large negative entry to force eviction of taco.
+	t.cache.AddNegativeEntry("very_long_negative_entry_name_to_force_eviction", expiration)
 
 	// See what's left.
 	assert.False(t.T(), t.cache.Hit("taco", someTime))
@@ -434,7 +436,11 @@ func (t *MultiBucketStatCacheTest) Test_ExpiresLeastRecentlyUsed() {
 
 	// Insert another.
 	saffron := &gcs.MinObject{Name: "saffron"}
-	spices.Insert(saffron, expiration) // size = 1424 bytes (cumulative = 5688 bytes)
+	spices.Insert(saffron, expiration)
+
+	saffron2 := &gcs.MinObject{Name: "saffron2"}
+	spices.Insert(saffron2, expiration)
+
 	// This will evict the least recent entry, i.e. orange.
 
 	// See what's left.
@@ -543,7 +549,7 @@ func (t *StatCacheTest) Test_ShouldReturnHitTrueWhenOnlyObjectAlreadyHasEntry() 
 }
 
 func (t *StatCacheTest) Test_ShouldEvictEntryOnFullCapacityIncludingFolderSize() {
-	localCache := lru.NewCache(uint64(2700))
+	localCache := lru.NewCache(uint64(2600))
 	t.statCache = metadata.NewStatCacheBucketView(localCache, "local_bucket")
 	objectEntry1 := &gcs.MinObject{Name: "1"}
 	objectEntry2 := &gcs.MinObject{Name: "2"}


### PR DESCRIPTION
### Description
* Reduce the memory footprint of entries in the metadata-cache
* Add stat-cache benchmarks

### Link to the issue in case of a bug fix.
b/538391384

### Memory Workload Benchmark (1 Million Entries)

| Workload (1M Entries) | Baseline (`master- 0673d1998`) | Optimized Branch | Absolute Memory Saved | Heap Memory Reduction |
|:---|:---:|:---:|:---:|:---:|
| **Flat** | `282.34 MB` | `267.06 MB` | **`-15.28 MB`** | **`-5.41%`** |
| **Nested** | `282.06 MB` | `266.89 MB` | **`-15.17 MB`** | **`-5.38%`** |
| **Deeply Nested** | `282.15 MB` | `266.80 MB` | **`-15.35 MB`** | **`-5.44%`** |

---

### CPU & Allocation Microbenchmarks (`go test -bench -benchmem`)

| Benchmark Operation | Baseline Latency | Optimized Latency | $\Delta$ Latency | Baseline Allocations | Optimized Allocations | $\Delta$ Memory Allocated |
|:---|:---:|:---:|:---:|:---:|:---:|:---:|
| **`LookUp`** | `65.08 ns/op` | `61.50 ns/op` | **`-5.50%`** *(faster)* | `18 B/op (0 allocs)` | `12 B/op (0 allocs)` | **`-33.3%`** *(-6 B/op)* |
| **`Insert`** | `334.00 ns/op` | `334.60 ns/op` | `+0.18%` *(parity)* | `160 B/op (3 allocs)` | `144 B/op (3 allocs)` | **`-10.0%`** *(-16 B/op)* |
| **`AddNegativeEntry`** | `142.10 ns/op` | `141.30 ns/op` | `-0.56%` *(parity)* | `96 B/op (2 allocs)` | `80 B/op (2 allocs)` | **`-16.7%`** *(-16 B/op)* |

---

### Struct Layout & Per-Entry Impact

| Attribute | Baseline (`master`) | Optimized Branch | Difference |
|:---|:---:|:---:|:---:|
| **`entry` Struct Size (`unsafe.Sizeof`)** | `48 bytes` | `32 bytes` | **`-16 bytes` (`-33.3%`)** |
| **`expiration` Field Type** | `time.Time` (24 bytes) | `int64` (8 bytes) | **`-16 bytes`** |
| **Calculated RSS per Entry (`entry.Size()`)** | Base $\approx 1304\text{ B}$ | Base $\approx 1272\text{ B}$ | **`-32 bytes` (with factor $2.0$)** |
| **Direct Heap Memory per 1M Entries** | $\approx 282\text{ MB}$ | $\approx 267\text{ MB}$ | **$\approx -15.3\text{ MB}$** |


### Testing details
1. Manual - Ran `make build` with zero compilation errors and zero lint warnings.
2. Unit tests - Ran `go test -v ./internal/cache/metadata/...` (all unit and memory workload tests passing).
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A