### PR TITLE
fix(cfg): enable finalize-on-close for aiml-checkpointing profile

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -78,6 +78,12 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			Value: bool(true),
 		},
 	},
+	Profiles: []shared.ProfileOptimization{
+		{
+			Name:  "aiml-checkpointing",
+			Value: bool(true),
+		},
+	},
 }, "file-system.fuse-max-request-size-kb": {
 	BucketTypeOptimization: []shared.BucketTypeOptimization{
 		{

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -284,8 +284,10 @@ func TestApplyOptimizations(t *testing.T) {
 			expectedValue   any
 		}{
 			{
-				name:   "user_set",
-				config: Config{},
+				name: "user_set",
+				config: Config{
+					Profile: "aiml-checkpointing",
+				},
 				userSetFlags: map[string]any{
 					"write.finalize-file-for-rapid": true,
 					"machine-type":                  "a2-megagpu-16g",
@@ -305,6 +307,14 @@ func TestApplyOptimizations(t *testing.T) {
 				expectedValue:   false,
 			},
 			{
+				name:            "profile_aiml-checkpointing",
+				config:          Config{Profile: "aiml-checkpointing"},
+				userSetFlags:    map[string]any{},
+				input:           nil,
+				expectOptimized: true,
+				expectedValue:   true,
+			},
+			{
 				name:            "bucket_type_zonal",
 				config:          Config{Profile: ""},
 				userSetFlags:    map[string]any{},
@@ -317,6 +327,14 @@ func TestApplyOptimizations(t *testing.T) {
 				config:          Config{Profile: ""},
 				userSetFlags:    map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   true,
+			},
+			{
+				name:            "profile_overrides_bucket_type",
+				config:          Config{Profile: "aiml-checkpointing"},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypeZonal},
 				expectOptimized: true,
 				expectedValue:   true,
 			},

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1368,6 +1368,9 @@ params:
           value: false
         - bucket-type: "pirlo"
           value: true
+      profiles:
+        - name: "aiml-checkpointing"
+          value: true
 
   - config-path: "write.global-max-blocks"
     flag-name: "write-global-max-blocks"

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -412,6 +412,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteBlockSizeMB:      32,
 			expectedWriteGlobalMaxBlocks:  1600,
 			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileForRapid:  true,
 		},
 		{
 			name:                          "Test_optimization_fallback_to_default_config_with_un-overridden_profile_on_low-end_machine",
@@ -422,6 +423,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteBlockSizeMB:      32,
 			expectedWriteGlobalMaxBlocks:  4,
 			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileForRapid:  true,
 		},
 		{
 			name:                          "Test_optimization_overriden_by_user_config_with_profile_set_on_high-end_machine",
@@ -432,6 +434,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteBlockSizeMB:      32,
 			expectedWriteGlobalMaxBlocks:  200,
 			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileForRapid:  true,
 		},
 		{
 			name:                          "Test_optimizationoverriden_by_user_config_with_profile_set_on_low-end_machine",
@@ -442,6 +445,7 @@ func TestArgsParsing_WriteConfigFlags(t *testing.T) {
 			expectedWriteBlockSizeMB:      32,
 			expectedWriteGlobalMaxBlocks:  16,
 			expectedWriteMaxBlocksPerFile: 1,
+			expectedFinalizeFileForRapid:  true,
 		},
 		{
 			name:                          "Test enable-rapid-writes and finalize-file-for-rapid flags.",


### PR DESCRIPTION
### Description
This PR enables `finalize-on-close` by default for the `aiml-checkpointing` profile to prevent checkpoint loading failures caused by stale metadata.

**Background:**
As discovered in b/540250863 during checkpoint benchmarking, when a directory rename occurs, GCSFuse invalidates cached entries under the old folder prefix. A subsequent `ListObjects` call on the new directory re-populates the cache. 

However, because zonal buckets use the appendable API where objects are not finalized on write by default, `ListObjects` can return a stale, intermediate object size for these unfinalized objects. Since the `aiml-checkpointing` profile sets an infinite metadata cache TTL (`metadata-cache.ttl-secs = -1`), this stale size is cached permanently in RAM, which ultimately causes `OUT_OF_RANGE` errors during checkpoint loading. 

Enabling finalize on close explicitly finalizes the object, avoiding the asynchronous metadata propagation delay for unfinalized appendable objects.

### Link to the issue in case of a bug fix.
b/544523257

### Testing details
1. Manual - NA
2. Unit tests - Added test cases for `aiml-checkpointing` profile in `cfg/config_test.go`
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
