### PR TITLE
fix(storage): honor --enable-rapid-writes flag during object overwrites for pirlo buckets

### DIFF
--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -200,9 +200,14 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 
 	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
 	// created with the RAPID storage class in the zonal cache rather than
-	// defaulting to the bucket's default storage class
+	// defaulting to the bucket's default storage class.
+	// If rapid writes are disabled, we explicitly clear the storage class to prevent
+	// inheriting the RAPID storage class from an overwritten object and write it to
+	// the bucket's default storage class.
 	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
 		req.StorageClass = storageClassRapid
+	} else if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesDisabled {
+		req.StorageClass = ""
 	}
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
@@ -250,8 +255,13 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
 	// created with the RAPID storage class in the zonal cache rather than
 	// defaulting to the bucket's default storage class.
+	// If rapid writes are disabled, we explicitly clear the storage class to prevent
+	// inheriting the RAPID storage class from an overwritten object and write it to
+	// the bucket's default storage class.
 	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
 		req.StorageClass = storageClassRapid
+	} else if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesDisabled {
+		req.StorageClass = ""
 	}
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -193,7 +193,7 @@ func (bh *bucketHandle) getObjectHandleWithPreconditionsSet(req *gcs.CreateObjec
 	return obj
 }
 
-func (bh *bucketHandle) overrideStorageClassForPirlo(req *gcs.CreateObjectRequest) {
+func (bh *bucketHandle) getStorageClassForCreateObject(defaultStorageClass string) string {
 	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
 	// created with the RAPID storage class in the zonal cache rather than
 	// defaulting to the bucket's default storage class.
@@ -202,9 +202,11 @@ func (bh *bucketHandle) overrideStorageClassForPirlo(req *gcs.CreateObjectReques
 	// the bucket's default storage class.
 	switch bh.BucketType().Pirlo {
 	case gcs.PirloStateRapidWritesEnabled:
-		req.StorageClass = storageClassRapid
+		return storageClassRapid
 	case gcs.PirloStateRapidWritesDisabled:
-		req.StorageClass = ""
+		return ""
+	default:
+		return defaultStorageClass
 	}
 }
 
@@ -213,7 +215,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 		err = gcs.GetGCSError(err)
 	}()
 
-	bh.overrideStorageClassForPirlo(req)
+	req.StorageClass = bh.getStorageClassForCreateObject(req.StorageClass)
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 
@@ -257,7 +259,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 }
 
 func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
-	bh.overrideStorageClassForPirlo(req)
+	req.StorageClass = bh.getStorageClassForCreateObject(req.StorageClass)
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -204,9 +204,10 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	// If rapid writes are disabled, we explicitly clear the storage class to prevent
 	// inheriting the RAPID storage class from an overwritten object and write it to
 	// the bucket's default storage class.
-	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
+	switch bh.BucketType().Pirlo {
+	case gcs.PirloStateRapidWritesEnabled:
 		req.StorageClass = storageClassRapid
-	} else if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesDisabled {
+	case gcs.PirloStateRapidWritesDisabled:
 		req.StorageClass = ""
 	}
 
@@ -258,9 +259,10 @@ func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.Cr
 	// If rapid writes are disabled, we explicitly clear the storage class to prevent
 	// inheriting the RAPID storage class from an overwritten object and write it to
 	// the bucket's default storage class.
-	if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesEnabled {
+	switch bh.BucketType().Pirlo {
+	case gcs.PirloStateRapidWritesEnabled:
 		req.StorageClass = storageClassRapid
-	} else if bh.BucketType().Pirlo == gcs.PirloStateRapidWritesDisabled {
+	case gcs.PirloStateRapidWritesDisabled:
 		req.StorageClass = ""
 	}
 

--- a/internal/storage/bucket_handle.go
+++ b/internal/storage/bucket_handle.go
@@ -193,11 +193,7 @@ func (bh *bucketHandle) getObjectHandleWithPreconditionsSet(req *gcs.CreateObjec
 	return obj
 }
 
-func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
-	defer func() {
-		err = gcs.GetGCSError(err)
-	}()
-
+func (bh *bucketHandle) overrideStorageClassForPirlo(req *gcs.CreateObjectRequest) {
 	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
 	// created with the RAPID storage class in the zonal cache rather than
 	// defaulting to the bucket's default storage class.
@@ -210,6 +206,14 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 	case gcs.PirloStateRapidWritesDisabled:
 		req.StorageClass = ""
 	}
+}
+
+func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectRequest) (o *gcs.Object, err error) {
+	defer func() {
+		err = gcs.GetGCSError(err)
+	}()
+
+	bh.overrideStorageClassForPirlo(req)
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 
@@ -253,18 +257,7 @@ func (bh *bucketHandle) CreateObject(ctx context.Context, req *gcs.CreateObjectR
 }
 
 func (bh *bucketHandle) CreateObjectChunkWriter(ctx context.Context, req *gcs.CreateObjectRequest, chunkSize int, callBack func(bytesUploadedSoFar int64)) (gcs.Writer, error) {
-	// When rapid writes are enabled on an RCU bucket, objects should be explicitly
-	// created with the RAPID storage class in the zonal cache rather than
-	// defaulting to the bucket's default storage class.
-	// If rapid writes are disabled, we explicitly clear the storage class to prevent
-	// inheriting the RAPID storage class from an overwritten object and write it to
-	// the bucket's default storage class.
-	switch bh.BucketType().Pirlo {
-	case gcs.PirloStateRapidWritesEnabled:
-		req.StorageClass = storageClassRapid
-	case gcs.PirloStateRapidWritesDisabled:
-		req.StorageClass = ""
-	}
+	bh.overrideStorageClassForPirlo(req)
 
 	obj := bh.getObjectHandleWithPreconditionsSet(req)
 

--- a/internal/storage/bucket_handle_test.go
+++ b/internal/storage/bucket_handle_test.go
@@ -688,6 +688,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
 	bucketScenarios := []struct {
 		name                        string
 		bucketType                  gcs.BucketType
+		initialStorageClass         string
 		expectedWriterStorageClass  string
 		expectedCreatedStorageClass string
 		canTestCreateObject         bool
@@ -695,25 +696,37 @@ func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
 		{
 			name:                        "StandardBucket",
 			bucketType:                  gcs.BucketType{Pirlo: gcs.PirloStateNone},
+			initialStorageClass:         "",
 			expectedWriterStorageClass:  "",
 			expectedCreatedStorageClass: "STANDARD",
 			canTestCreateObject:         true,
 		},
 		{
+			name:                        "StandardBucket_InheritsStorageClass",
+			bucketType:                  gcs.BucketType{Pirlo: gcs.PirloStateNone},
+			initialStorageClass:         "COLDLINE",
+			expectedWriterStorageClass:  "COLDLINE",
+			expectedCreatedStorageClass: "COLDLINE",
+			canTestCreateObject:         true,
+		},
+		{
 			name:                       "ZonalBucket",
 			bucketType:                 gcs.BucketType{Zonal: true},
+			initialStorageClass:        "",
 			expectedWriterStorageClass: "",    // Zonal buckets do not use the RAPID storage class.
 			canTestCreateObject:        false, // Fails on HTTP append.
 		},
 		{
 			name:                       "PirloBucket_RapidEnabled",
 			bucketType:                 gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesEnabled},
+			initialStorageClass:        "STANDARD", // Simulate inheriting from standard source
 			expectedWriterStorageClass: storageClassRapid,
 			canTestCreateObject:        false, // Fails on HTTP append.
 		},
 		{
 			name:                        "PirloBucket_RapidDisabled",
 			bucketType:                  gcs.BucketType{Pirlo: gcs.PirloStateRapidWritesDisabled},
+			initialStorageClass:         storageClassRapid, // Simulate inheriting from rapid source
 			expectedWriterStorageClass:  "",
 			expectedCreatedStorageClass: "STANDARD",
 			canTestCreateObject:         true,
@@ -725,7 +738,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
 			createBucketHandle(testSuite, &controlpb.StorageLayout{})
 			testSuite.bucketHandle.bucketType = &scenario.bucketType
 			testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{}
-			req := &gcs.CreateObjectRequest{Name: "test_object_2"}
+			req := &gcs.CreateObjectRequest{Name: "test_object_2", StorageClass: scenario.initialStorageClass}
 
 			w, err := testSuite.bucketHandle.CreateObjectChunkWriter(context.Background(), req, 1024, nil)
 
@@ -740,7 +753,7 @@ func (testSuite *BucketHandleTest) TestBucketHandle_StorageClassOverrides() {
 				createBucketHandle(testSuite, &controlpb.StorageLayout{})
 				testSuite.bucketHandle.bucketType = &scenario.bucketType
 				testSuite.bucketHandle.writeConfig = &cfg.WriteConfig{}
-				req := &gcs.CreateObjectRequest{Name: "test_object_1", Contents: strings.NewReader("data")}
+				req := &gcs.CreateObjectRequest{Name: "test_object_1", Contents: strings.NewReader("data"), StorageClass: scenario.initialStorageClass}
 
 				o, err := testSuite.bucketHandle.CreateObject(context.Background(), req)
 


### PR DESCRIPTION
### Description
When overwriting an existing object, GCSFuse currently copies the original object's storage class into the new request. If an object with the `RAPID` storage class in a pirlo bucket is overwritten while the GCSFuse mount flag `--enable-rapid-writes` is set to `false`, the request fails with an `InvalidArgument` error. This occurs because the combination of using the Resumable upload API (which is used when rapid writes are disabled) and explicitly passing the `RAPID` storage class is rejected by GCS.

This PR fixes the issue by explicitly clearing the storage class (`req.StorageClass = ""`) for pirlo buckets when rapid writes are disabled. This ensures GCSFuse strictly honors the mount flag rather than inheriting the original object's `RAPID` storage class, allowing the overwritten pirlo bucket object to correctly fall back to the bucket's default storage class instead.

### Link to the issue in case of a bug fix.
b/543390252

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No.
