### PR TITLE
feat(native-retries): retry token acquisition and refresh via retrying token provider

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -105,7 +105,7 @@ func createClientOptionForGRPCClient(ctx context.Context, clientConfig *storageu
 		clientOpts = append(clientOpts, option.WithoutAuthentication())
 	} else if clientConfig.EnableGoogleLibAuth {
 		var authOpts []option.ClientOption
-		authOpts, _, err = storageutil.GetClientAuthOptionsAndToken(ctx, clientConfig)
+		authOpts, _, err = storageutil.GetClientAuthOptionsAndTokenSource(ctx, clientConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get client auth options and token: %w", err)
 		}
@@ -280,7 +280,7 @@ func createHTTPClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		clientOpts = append(clientOpts, option.WithoutAuthentication())
 	} else if clientConfig.EnableGoogleLibAuth {
 		var authOpts []option.ClientOption
-		authOpts, tokenSrc, err = storageutil.GetClientAuthOptionsAndToken(ctx, clientConfig)
+		authOpts, tokenSrc, err = storageutil.GetClientAuthOptionsAndTokenSource(ctx, clientConfig)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get client auth options and token: %w", err)
 		}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -30,11 +30,40 @@ import (
 
 // GetClientAuthOptionsAndToken returns client options and a token source using either a token URL or fallback to key file/ADC.
 func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConfig) ([]option.ClientOption, oauth2.TokenSource, error) {
+	retryConfig := NewRetryConfig(config)
+
 	// If Token URL is provided, attempt to fetch token source directly.
 	if config.TokenUrl != "" {
-		tokenSrc, err := auth2.NewTokenSourceFromURL(ctx, config.TokenUrl, config.ReuseTokenFromUrl)
+		var tokenSrc oauth2.TokenSource
+		var err error
+
+		if config.EnableMountRetries {
+			apiCall := func(attemptCtx context.Context) (oauth2.TokenSource, error) {
+				return auth2.NewTokenSourceFromURL(attemptCtx, config.TokenUrl, config.ReuseTokenFromUrl)
+			}
+			tokenSrc, err = ExecuteWithCustomShouldRetryAtLogLevel(
+				ctx,
+				retryConfig,
+				"NewTokenSourceFromURL",
+				"token-source",
+				uuid.NewString(),
+				apiCall,
+				ShouldRetryOnMount,
+				logger.LevelInfo,
+			)
+		} else {
+			tokenSrc, err = auth2.NewTokenSourceFromURL(ctx, config.TokenUrl, config.ReuseTokenFromUrl)
+		}
+
 		if err != nil {
 			return nil, nil, fmt.Errorf("while fetching token source: %w", err)
+		}
+
+		if config.EnableMountRetries {
+			tokenSrc = &retryingTokenSource{
+				base:        tokenSrc,
+				retryConfig: retryConfig,
+			}
 		}
 
 		clientOpts := []option.ClientOption{option.WithTokenSource(tokenSrc)}
@@ -42,12 +71,40 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 	}
 
 	// Fallback: Use key file credentials.
-	cred, err := auth2.GetCredentials(config.KeyFile)
+	var cred *auth.Credentials
+	var err error
+
+	if config.EnableMountRetries {
+		apiCall := func(_ context.Context) (*auth.Credentials, error) {
+			return auth2.GetCredentials(config.KeyFile)
+		}
+		cred, err = ExecuteWithCustomShouldRetryAtLogLevel(
+			ctx,
+			retryConfig,
+			"GetCredentials",
+			"credentials",
+			uuid.NewString(),
+			apiCall,
+			ShouldRetryOnMount,
+			logger.LevelInfo,
+		)
+	} else {
+		cred, err = auth2.GetCredentials(config.KeyFile)
+	}
+
 	if err != nil {
 		return nil, nil, fmt.Errorf("while fetching credentials: %w", err)
 	}
 
-	tokenSrc := oauth2adapt.TokenSourceFromTokenProvider(cred.TokenProvider)
+	tokenProvider := cred.TokenProvider
+	if config.EnableMountRetries {
+		tokenProvider = &retryingTokenProvider{
+			base:        cred.TokenProvider,
+			retryConfig: retryConfig,
+		}
+	}
+
+	tokenSrc := oauth2adapt.TokenSourceFromTokenProvider(tokenProvider)
 
 	var domain string
 
@@ -58,14 +115,16 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 		logger.Infof("Bypassing UniverseDomain metadata server lookup on standard commercial GCP setup")
 		domain = auth2.UniverseDomainDefault
 	} else {
-		retryConfig := NewRetryConfig(config)
-
 		apiCall := func(attemptCtx context.Context) (string, error) {
 			d, err := cred.UniverseDomain(attemptCtx)
 			return d, err
 		}
 
-		domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, logger.LevelInfo)
+		if config.EnableMountRetries {
+			domain, err = ExecuteWithCustomShouldRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, ShouldRetryOnMount, logger.LevelInfo)
+		} else {
+			domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, logger.LevelInfo)
+		}
 		if err != nil {
 			logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)
 			// Setting default universe domain to googleapis.com in case we are unable to fetch the domain.
@@ -79,7 +138,7 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 	// to bypass a known issue (b/442805436) in the current authentication library.
 	// TODO: Remove this workaround once issue b/442805436 is resolved in the library.
 	newCreds := auth.NewCredentials(&auth.CredentialsOptions{
-		TokenProvider:          cred.TokenProvider,
+		TokenProvider:          tokenProvider,
 		UniverseDomainProvider: auth.CredentialsPropertyFunc(func(_ context.Context) (string, error) { return domain, nil }),
 	})
 	clientOpts := []option.ClientOption{option.WithUniverseDomain(domain), option.WithAuthCredentials(newCreds)}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -61,6 +61,7 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 
 		if config.EnableMountRetries {
 			tokenSrc = &retryingTokenSource{
+				ctx:         ctx,
 				base:        tokenSrc,
 				retryConfig: retryConfig,
 			}

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -40,7 +40,6 @@ func GetClientAuthOptionsAndTokenSource(ctx context.Context, config *StorageClie
 
 		if config.EnableMountRetries {
 			tokenSrc = &retryingTokenSource{
-				ctx:         ctx,
 				base:        tokenSrc,
 				retryConfig: retryConfig,
 			}
@@ -81,9 +80,9 @@ func GetClientAuthOptionsAndTokenSource(ctx context.Context, config *StorageClie
 		}
 
 		if config.EnableMountRetries {
-			domain, err = ExecuteWithCustomShouldRetry(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, ShouldRetryOnMount)
+			domain, err = ExecuteWithCustomShouldRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, ShouldRetryOnMount, logger.LevelInfo)
 		} else {
-			domain, err = ExecuteWithRetry(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall)
+			domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, logger.LevelInfo)
 		}
 		if err != nil {
 			logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)

--- a/internal/storage/storageutil/auth_client_option.go
+++ b/internal/storage/storageutil/auth_client_option.go
@@ -28,33 +28,12 @@ import (
 	"google.golang.org/api/option"
 )
 
-// GetClientAuthOptionsAndToken returns client options and a token source using either a token URL or fallback to key file/ADC.
-func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConfig) ([]option.ClientOption, oauth2.TokenSource, error) {
+// GetClientAuthOptionsAndTokenSource returns client options and a token source using either a token URL or fallback to key file/ADC.
+func GetClientAuthOptionsAndTokenSource(ctx context.Context, config *StorageClientConfig) ([]option.ClientOption, oauth2.TokenSource, error) {
 	retryConfig := NewRetryConfig(config)
-
 	// If Token URL is provided, attempt to fetch token source directly.
 	if config.TokenUrl != "" {
-		var tokenSrc oauth2.TokenSource
-		var err error
-
-		if config.EnableMountRetries {
-			apiCall := func(attemptCtx context.Context) (oauth2.TokenSource, error) {
-				return auth2.NewTokenSourceFromURL(attemptCtx, config.TokenUrl, config.ReuseTokenFromUrl)
-			}
-			tokenSrc, err = ExecuteWithCustomShouldRetryAtLogLevel(
-				ctx,
-				retryConfig,
-				"NewTokenSourceFromURL",
-				"token-source",
-				uuid.NewString(),
-				apiCall,
-				ShouldRetryOnMount,
-				logger.LevelInfo,
-			)
-		} else {
-			tokenSrc, err = auth2.NewTokenSourceFromURL(ctx, config.TokenUrl, config.ReuseTokenFromUrl)
-		}
-
+		tokenSrc, err := auth2.NewTokenSourceFromURL(ctx, config.TokenUrl, config.ReuseTokenFromUrl)
 		if err != nil {
 			return nil, nil, fmt.Errorf("while fetching token source: %w", err)
 		}
@@ -72,27 +51,7 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 	}
 
 	// Fallback: Use key file credentials.
-	var cred *auth.Credentials
-	var err error
-
-	if config.EnableMountRetries {
-		apiCall := func(_ context.Context) (*auth.Credentials, error) {
-			return auth2.GetCredentials(config.KeyFile)
-		}
-		cred, err = ExecuteWithCustomShouldRetryAtLogLevel(
-			ctx,
-			retryConfig,
-			"GetCredentials",
-			"credentials",
-			uuid.NewString(),
-			apiCall,
-			ShouldRetryOnMount,
-			logger.LevelInfo,
-		)
-	} else {
-		cred, err = auth2.GetCredentials(config.KeyFile)
-	}
-
+	cred, err := auth2.GetCredentials(config.KeyFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("while fetching credentials: %w", err)
 	}
@@ -122,9 +81,9 @@ func GetClientAuthOptionsAndToken(ctx context.Context, config *StorageClientConf
 		}
 
 		if config.EnableMountRetries {
-			domain, err = ExecuteWithCustomShouldRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, ShouldRetryOnMount, logger.LevelInfo)
+			domain, err = ExecuteWithCustomShouldRetry(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, ShouldRetryOnMount)
 		} else {
-			domain, err = ExecuteWithRetryAtLogLevel(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall, logger.LevelInfo)
+			domain, err = ExecuteWithRetry(ctx, retryConfig, "cred.UniverseDomain", "credentials", uuid.NewString(), apiCall)
 		}
 		if err != nil {
 			logger.Errorf("failed to get UniverseDomain: %v, setting default universe domain", err)

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -58,10 +58,42 @@ func Test_GetClientAuthOptionsAndTokenSource_TokenUrlError(t *testing.T) {
 	assert.Empty(t, clientOpts)
 }
 
+func Test_GetClientAuthOptionsAndTokenSource_TokenUrlWithMountRetries(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprintln(w, `{"access_token":"dummy-token","token_type":"Bearer"}`)
+	}))
+	defer server.Close()
+	config := &StorageClientConfig{
+		TokenUrl:           server.URL,
+		EnableMountRetries: true,
+	}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.IsType(t, &retryingTokenSource{}, tokenSrc)
+	assert.Len(t, clientOpts, 1)
+}
+
 func Test_GetClientAuthOptionsAndTokenSource_FallbackToKeyFileSuccess(t *testing.T) {
 	config := &StorageClientConfig{
 		TokenUrl: "", // triggers fallback
 		KeyFile:  "testdata/key.json",
+	}
+
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, tokenSrc)
+	assert.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
+}
+
+func Test_GetClientAuthOptionsAndTokenSource_FallbackToKeyFileWithMountRetries(t *testing.T) {
+	config := &StorageClientConfig{
+		KeyFile:            "testdata/key.json",
+		EnableMountRetries: true,
 	}
 
 	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)

--- a/internal/storage/storageutil/auth_client_option_test.go
+++ b/internal/storage/storageutil/auth_client_option_test.go
@@ -29,7 +29,7 @@ import (
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func Test_GetClientAuthOptionsAndToken_TokenUrlSuccess(t *testing.T) {
+func Test_GetClientAuthOptionsAndTokenSource_TokenUrlSuccess(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprintln(w, `{"access_token":"dummy-token","token_type":"Bearer"}`)
@@ -41,41 +41,41 @@ func Test_GetClientAuthOptionsAndToken_TokenUrlSuccess(t *testing.T) {
 		KeyFile:           "testdata/key.json",
 	}
 
-	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tokenSrc)
 	assert.Len(t, clientOpts, 1) // Only tokenSource option attached
 }
 
-func Test_GetClientAuthOptionsAndToken_TokenUrlError(t *testing.T) {
+func Test_GetClientAuthOptionsAndTokenSource_TokenUrlError(t *testing.T) {
 	config := &StorageClientConfig{TokenUrl: ":"}
 
-	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
 
 	assert.Error(t, err)
 	assert.Nil(t, tokenSrc)
 	assert.Empty(t, clientOpts)
 }
 
-func Test_GetClientAuthOptionsAndToken_FallbackToKeyFileSuccess(t *testing.T) {
+func Test_GetClientAuthOptionsAndTokenSource_FallbackToKeyFileSuccess(t *testing.T) {
 	config := &StorageClientConfig{
 		TokenUrl: "", // triggers fallback
 		KeyFile:  "testdata/key.json",
 	}
 
-	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, tokenSrc)
 	assert.Len(t, clientOpts, 2) // UniverseDomain + AuthCredentials
 }
 
-func Test_GetClientAuthOptionsAndToken_FallbackToKeyFileError(t *testing.T) {
+func Test_GetClientAuthOptionsAndTokenSource_FallbackToKeyFileError(t *testing.T) {
 	config := &StorageClientConfig{TokenUrl: "", KeyFile: "fake-key"}
 	var clientOpts []option.ClientOption
 
-	clientOpts, tokenSrc, err := GetClientAuthOptionsAndToken(context.TODO(), config)
+	clientOpts, tokenSrc, err := GetClientAuthOptionsAndTokenSource(context.TODO(), config)
 
 	assert.Error(t, err)
 	assert.Nil(t, tokenSrc)

--- a/internal/storage/storageutil/token_retry.go
+++ b/internal/storage/storageutil/token_retry.go
@@ -19,7 +19,6 @@ import (
 
 	"cloud.google.com/go/auth"
 	"github.com/google/uuid"
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"golang.org/x/oauth2"
 )
 
@@ -34,7 +33,7 @@ func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 		return r.base.Token(attemptCtx)
 	}
 
-	return ExecuteWithCustomShouldRetryAtLogLevel(
+	return ExecuteWithCustomShouldRetry(
 		ctx,
 		r.retryConfig,
 		"TokenProvider.Token",
@@ -42,7 +41,6 @@ func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 		uuid.NewString(),
 		apiCall,
 		ShouldRetryOnMount,
-		logger.LevelInfo,
 	)
 }
 
@@ -63,7 +61,7 @@ func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
 		ctx = context.Background()
 	}
 
-	return ExecuteWithCustomShouldRetryAtLogLevel(
+	return ExecuteWithCustomShouldRetry(
 		ctx,
 		r.retryConfig,
 		"Token",
@@ -71,6 +69,5 @@ func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
 		uuid.NewString(),
 		apiCall,
 		ShouldRetryOnMount,
-		logger.LevelInfo,
 	)
 }

--- a/internal/storage/storageutil/token_retry.go
+++ b/internal/storage/storageutil/token_retry.go
@@ -48,6 +48,7 @@ func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 
 // retryingTokenSource wraps an oauth2.TokenSource to retry transient MDS/OAuth errors.
 type retryingTokenSource struct {
+	ctx         context.Context
 	base        oauth2.TokenSource
 	retryConfig *RetryConfig
 }
@@ -57,8 +58,13 @@ func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
 		return r.base.Token()
 	}
 
+	ctx := r.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
 	return ExecuteWithCustomShouldRetryAtLogLevel(
-		context.Background(),
+		ctx,
 		r.retryConfig,
 		"Token",
 		"token-refresh",

--- a/internal/storage/storageutil/token_retry.go
+++ b/internal/storage/storageutil/token_retry.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,7 +41,7 @@ func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 		"token-refresh",
 		uuid.NewString(),
 		apiCall,
-		isTransientMDSError,
+		ShouldRetryOnMount,
 		logger.LevelInfo,
 	)
 }
@@ -70,7 +70,7 @@ func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
 		"token-refresh",
 		uuid.NewString(),
 		apiCall,
-		isTransientMDSError,
+		ShouldRetryOnMount,
 		logger.LevelInfo,
 	)
 }

--- a/internal/storage/storageutil/token_retry.go
+++ b/internal/storage/storageutil/token_retry.go
@@ -1,0 +1,70 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storageutil
+
+import (
+	"context"
+
+	"cloud.google.com/go/auth"
+	"github.com/google/uuid"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+	"golang.org/x/oauth2"
+)
+
+// retryingTokenProvider wraps an auth.TokenProvider to retry transient MDS/OAuth errors.
+type retryingTokenProvider struct {
+	base        auth.TokenProvider
+	retryConfig *RetryConfig
+}
+
+func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) {
+	apiCall := func(attemptCtx context.Context) (*auth.Token, error) {
+		return r.base.Token(attemptCtx)
+	}
+
+	return ExecuteWithCustomShouldRetryAtLogLevel(
+		ctx,
+		r.retryConfig,
+		"TokenProvider.Token",
+		"token-refresh",
+		uuid.NewString(),
+		apiCall,
+		isTransientMDSError,
+		logger.LevelInfo,
+	)
+}
+
+// retryingTokenSource wraps an oauth2.TokenSource to retry transient MDS/OAuth errors.
+type retryingTokenSource struct {
+	base        oauth2.TokenSource
+	retryConfig *RetryConfig
+}
+
+func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
+	apiCall := func(_ context.Context) (*oauth2.Token, error) {
+		return r.base.Token()
+	}
+
+	return ExecuteWithCustomShouldRetryAtLogLevel(
+		context.Background(),
+		r.retryConfig,
+		"Token",
+		"token-refresh",
+		uuid.NewString(),
+		apiCall,
+		isTransientMDSError,
+		logger.LevelInfo,
+	)
+}

--- a/internal/storage/storageutil/token_retry.go
+++ b/internal/storage/storageutil/token_retry.go
@@ -46,7 +46,6 @@ func (r *retryingTokenProvider) Token(ctx context.Context) (*auth.Token, error) 
 
 // retryingTokenSource wraps an oauth2.TokenSource to retry transient MDS/OAuth errors.
 type retryingTokenSource struct {
-	ctx         context.Context
 	base        oauth2.TokenSource
 	retryConfig *RetryConfig
 }
@@ -56,15 +55,10 @@ func (r *retryingTokenSource) Token() (*oauth2.Token, error) {
 		return r.base.Token()
 	}
 
-	ctx := r.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
 	return ExecuteWithCustomShouldRetry(
-		ctx,
+		context.Background(),
 		r.retryConfig,
-		"Token",
+		"TokenSource.Token",
 		"token-refresh",
 		uuid.NewString(),
 		apiCall,

--- a/internal/storage/storageutil/token_retry_test.go
+++ b/internal/storage/storageutil/token_retry_test.go
@@ -218,3 +218,23 @@ func TestRetryingTokenSource_ExhaustedAttempts_Fails(t *testing.T) {
 	assert.Nil(t, token)
 	assert.Equal(t, 3, mock.calls)
 }
+
+func TestRetryingTokenSource_CancelledContext_FastFail(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // Cancel immediately
+
+	mock := &mockTokenSource{
+		tokens: []*oauth2.Token{{AccessToken: "valid-token"}},
+	}
+	ts := &retryingTokenSource{
+		ctx:         ctx,
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := ts.Token()
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.True(t, errors.Is(err, context.Canceled))
+}

--- a/internal/storage/storageutil/token_retry_test.go
+++ b/internal/storage/storageutil/token_retry_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,166 +75,155 @@ func fastRetryConfig() *RetryConfig {
 	}
 }
 
-func TestRetryingTokenProvider_SuccessOnFirstAttempt(t *testing.T) {
-	mock := &mockTokenProvider{
-		tokens: []*auth.Token{{Value: "valid-token"}},
-	}
-	provider := &retryingTokenProvider{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := provider.Token(context.Background())
-
-	assert.NoError(t, err)
-	assert.NotNil(t, token)
-	assert.Equal(t, "valid-token", token.Value)
-	assert.Equal(t, 1, mock.calls)
-}
-
-func TestRetryingTokenProvider_RetryOnTransientMDSError_Success(t *testing.T) {
+func TestRetryingTokenProvider(t *testing.T) {
 	transientErr := &oauth2.RetrieveError{
 		Response: &http.Response{StatusCode: http.StatusServiceUnavailable},
 	}
-	mock := &mockTokenProvider{
-		errs:   []error{transientErr, transientErr, nil},
-		tokens: []*auth.Token{nil, nil, {Value: "recovered-token"}},
-	}
-	provider := &retryingTokenProvider{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := provider.Token(context.Background())
-
-	assert.NoError(t, err)
-	assert.NotNil(t, token)
-	assert.Equal(t, "recovered-token", token.Value)
-	assert.Equal(t, 3, mock.calls)
-}
-
-func TestRetryingTokenProvider_NonTransientError_NoRetry(t *testing.T) {
+	metadata500 := &metadata.Error{Code: 500}
 	permanentErr := errors.New("permanent auth failure")
-	mock := &mockTokenProvider{
-		errs: []error{permanentErr},
-	}
-	provider := &retryingTokenProvider{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
+
+	testCases := []struct {
+		name          string
+		mockTokens    []*auth.Token
+		mockErrors    []error
+		expectError   bool
+		expectedToken string
+		expectedCalls int
+	}{
+		{
+			name:          "SuccessOnFirstAttempt",
+			mockTokens:    []*auth.Token{{Value: "valid-token"}},
+			expectedToken: "valid-token",
+			expectedCalls: 1,
+		},
+		{
+			name:          "RecoveryAfterTransientMDSErrors",
+			mockErrors:    []error{transientErr, transientErr, nil},
+			mockTokens:    []*auth.Token{nil, nil, {Value: "recovered-token"}},
+			expectedToken: "recovered-token",
+			expectedCalls: 3,
+		},
+		{
+			name:          "FastFailOnNonTransientError",
+			mockErrors:    []error{permanentErr},
+			expectError:   true,
+			expectedCalls: 1,
+		},
+		{
+			name:          "ExhaustedRetryAttempts",
+			mockErrors:    []error{metadata500, metadata500, metadata500, metadata500},
+			expectError:   true,
+			expectedCalls: 3,
+		},
 	}
 
-	token, err := provider.Token(context.Background())
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockTokenProvider{
+				tokens: tc.mockTokens,
+				errs:   tc.mockErrors,
+			}
+			provider := &retryingTokenProvider{
+				base:        mock,
+				retryConfig: fastRetryConfig(),
+			}
 
-	assert.Error(t, err)
-	assert.Nil(t, token)
-	assert.Equal(t, 1, mock.calls)
+			token, err := provider.Token(context.Background())
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, token)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, token)
+				assert.Equal(t, tc.expectedToken, token.Value)
+			}
+			assert.Equal(t, tc.expectedCalls, mock.calls)
+		})
+	}
 }
 
-func TestRetryingTokenProvider_ExhaustedAttempts_Fails(t *testing.T) {
-	transientErr := &metadata.Error{Code: 500}
-	mock := &mockTokenProvider{
-		errs: []error{transientErr, transientErr, transientErr, transientErr},
-	}
-	provider := &retryingTokenProvider{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := provider.Token(context.Background())
-
-	assert.Error(t, err)
-	assert.Nil(t, token)
-	assert.Equal(t, 3, mock.calls)
-}
-
-func TestRetryingTokenSource_SuccessOnFirstAttempt(t *testing.T) {
-	mock := &mockTokenSource{
-		tokens: []*oauth2.Token{{AccessToken: "valid-token"}},
-	}
-	ts := &retryingTokenSource{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := ts.Token()
-
-	assert.NoError(t, err)
-	assert.NotNil(t, token)
-	assert.Equal(t, "valid-token", token.AccessToken)
-	assert.Equal(t, 1, mock.calls)
-}
-
-func TestRetryingTokenSource_RetryOnTransientMDSError_Success(t *testing.T) {
-	transientErr := &metadata.Error{Code: 503}
-	mock := &mockTokenSource{
-		errs:   []error{transientErr, nil},
-		tokens: []*oauth2.Token{nil, {AccessToken: "recovered-token"}},
-	}
-	ts := &retryingTokenSource{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := ts.Token()
-
-	assert.NoError(t, err)
-	assert.NotNil(t, token)
-	assert.Equal(t, "recovered-token", token.AccessToken)
-	assert.Equal(t, 2, mock.calls)
-}
-
-func TestRetryingTokenSource_NonTransientError_NoRetry(t *testing.T) {
-	permanentErr := errors.New("permanent auth failure")
-	mock := &mockTokenSource{
-		errs: []error{permanentErr},
-	}
-	ts := &retryingTokenSource{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
-
-	token, err := ts.Token()
-
-	assert.Error(t, err)
-	assert.Nil(t, token)
-	assert.Equal(t, 1, mock.calls)
-}
-
-func TestRetryingTokenSource_ExhaustedAttempts_Fails(t *testing.T) {
+func TestRetryingTokenSource(t *testing.T) {
 	transientErr := &oauth2.RetrieveError{
 		Response: &http.Response{StatusCode: http.StatusTooManyRequests},
 	}
-	mock := &mockTokenSource{
-		errs: []error{transientErr, transientErr, transientErr, transientErr},
-	}
-	ts := &retryingTokenSource{
-		base:        mock,
-		retryConfig: fastRetryConfig(),
-	}
+	metadata503 := &metadata.Error{Code: 503}
+	permanentErr := errors.New("permanent auth failure")
 
-	token, err := ts.Token()
-
-	assert.Error(t, err)
-	assert.Nil(t, token)
-	assert.Equal(t, 3, mock.calls)
-}
-
-func TestRetryingTokenSource_CancelledContext_FastFail(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
+	cancelledCtx, cancel := context.WithCancel(context.Background())
 	cancel() // Cancel immediately
 
-	mock := &mockTokenSource{
-		tokens: []*oauth2.Token{{AccessToken: "valid-token"}},
-	}
-	ts := &retryingTokenSource{
-		ctx:         ctx,
-		base:        mock,
-		retryConfig: fastRetryConfig(),
+	testCases := []struct {
+		name          string
+		ctx           context.Context
+		mockTokens    []*oauth2.Token
+		mockErrors    []error
+		expectError   bool
+		checkCancel   bool
+		expectedToken string
+		expectedCalls int
+	}{
+		{
+			name:          "SuccessOnFirstAttempt",
+			mockTokens:    []*oauth2.Token{{AccessToken: "valid-token"}},
+			expectedToken: "valid-token",
+			expectedCalls: 1,
+		},
+		{
+			name:          "RecoveryAfterTransientMDSError",
+			mockErrors:    []error{metadata503, nil},
+			mockTokens:    []*oauth2.Token{nil, {AccessToken: "recovered-token"}},
+			expectedToken: "recovered-token",
+			expectedCalls: 2,
+		},
+		{
+			name:          "FastFailOnNonTransientError",
+			mockErrors:    []error{permanentErr},
+			expectError:   true,
+			expectedCalls: 1,
+		},
+		{
+			name:          "ExhaustedRetryAttempts",
+			mockErrors:    []error{transientErr, transientErr, transientErr, transientErr},
+			expectError:   true,
+			expectedCalls: 3,
+		},
+		{
+			name:          "FastFailOnCancelledContext",
+			ctx:           cancelledCtx,
+			mockTokens:    []*oauth2.Token{{AccessToken: "valid-token"}},
+			expectError:   true,
+			checkCancel:   true,
+			expectedCalls: 0,
+		},
 	}
 
-	token, err := ts.Token()
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mock := &mockTokenSource{
+				tokens: tc.mockTokens,
+				errs:   tc.mockErrors,
+			}
+			ts := &retryingTokenSource{
+				ctx:         tc.ctx,
+				base:        mock,
+				retryConfig: fastRetryConfig(),
+			}
 
-	assert.Error(t, err)
-	assert.Nil(t, token)
-	assert.True(t, errors.Is(err, context.Canceled))
+			token, err := ts.Token()
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, token)
+				if tc.checkCancel {
+					assert.True(t, errors.Is(err, context.Canceled))
+				}
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, token)
+				assert.Equal(t, tc.expectedToken, token.AccessToken)
+			}
+			assert.Equal(t, tc.expectedCalls, mock.calls)
+		})
+	}
 }

--- a/internal/storage/storageutil/token_retry_test.go
+++ b/internal/storage/storageutil/token_retry_test.go
@@ -82,22 +82,29 @@ func TestRetryingTokenProvider(t *testing.T) {
 	metadata500 := &metadata.Error{Code: 500}
 	permanentErr := errors.New("permanent auth failure")
 
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
 	testCases := []struct {
 		name          string
+		ctx           context.Context
 		mockTokens    []*auth.Token
 		mockErrors    []error
 		expectError   bool
+		checkCancel   bool
 		expectedToken string
 		expectedCalls int
 	}{
 		{
 			name:          "SuccessOnFirstAttempt",
+			ctx:           context.Background(),
 			mockTokens:    []*auth.Token{{Value: "valid-token"}},
 			expectedToken: "valid-token",
 			expectedCalls: 1,
 		},
 		{
 			name:          "RecoveryAfterTransientMDSErrors",
+			ctx:           context.Background(),
 			mockErrors:    []error{transientErr, transientErr, nil},
 			mockTokens:    []*auth.Token{nil, nil, {Value: "recovered-token"}},
 			expectedToken: "recovered-token",
@@ -105,15 +112,25 @@ func TestRetryingTokenProvider(t *testing.T) {
 		},
 		{
 			name:          "FastFailOnNonTransientError",
+			ctx:           context.Background(),
 			mockErrors:    []error{permanentErr},
 			expectError:   true,
 			expectedCalls: 1,
 		},
 		{
 			name:          "ExhaustedRetryAttempts",
+			ctx:           context.Background(),
 			mockErrors:    []error{metadata500, metadata500, metadata500, metadata500},
 			expectError:   true,
 			expectedCalls: 3,
+		},
+		{
+			name:          "FastFailOnCancelledContext",
+			ctx:           cancelledCtx,
+			mockTokens:    []*auth.Token{{Value: "valid-token"}},
+			expectError:   true,
+			checkCancel:   true,
+			expectedCalls: 0,
 		},
 	}
 
@@ -128,11 +145,14 @@ func TestRetryingTokenProvider(t *testing.T) {
 				retryConfig: fastRetryConfig(),
 			}
 
-			token, err := provider.Token(context.Background())
+			token, err := provider.Token(tc.ctx)
 
 			if tc.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, token)
+				if tc.checkCancel {
+					assert.True(t, errors.Is(err, context.Canceled))
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, token)
@@ -150,16 +170,11 @@ func TestRetryingTokenSource(t *testing.T) {
 	metadata503 := &metadata.Error{Code: 503}
 	permanentErr := errors.New("permanent auth failure")
 
-	cancelledCtx, cancel := context.WithCancel(context.Background())
-	cancel() // Cancel immediately
-
 	testCases := []struct {
 		name          string
-		ctx           context.Context
 		mockTokens    []*oauth2.Token
 		mockErrors    []error
 		expectError   bool
-		checkCancel   bool
 		expectedToken string
 		expectedCalls int
 	}{
@@ -188,14 +203,6 @@ func TestRetryingTokenSource(t *testing.T) {
 			expectError:   true,
 			expectedCalls: 3,
 		},
-		{
-			name:          "FastFailOnCancelledContext",
-			ctx:           cancelledCtx,
-			mockTokens:    []*oauth2.Token{{AccessToken: "valid-token"}},
-			expectError:   true,
-			checkCancel:   true,
-			expectedCalls: 0,
-		},
 	}
 
 	for _, tc := range testCases {
@@ -205,7 +212,6 @@ func TestRetryingTokenSource(t *testing.T) {
 				errs:   tc.mockErrors,
 			}
 			ts := &retryingTokenSource{
-				ctx:         tc.ctx,
 				base:        mock,
 				retryConfig: fastRetryConfig(),
 			}
@@ -215,9 +221,6 @@ func TestRetryingTokenSource(t *testing.T) {
 			if tc.expectError {
 				assert.Error(t, err)
 				assert.Nil(t, token)
-				if tc.checkCancel {
-					assert.True(t, errors.Is(err, context.Canceled))
-				}
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, token)

--- a/internal/storage/storageutil/token_retry_test.go
+++ b/internal/storage/storageutil/token_retry_test.go
@@ -1,0 +1,220 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package storageutil
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"cloud.google.com/go/auth"
+	"cloud.google.com/go/compute/metadata"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/oauth2"
+)
+
+type mockTokenProvider struct {
+	tokens []*auth.Token
+	errs   []error
+	calls  int
+}
+
+func (m *mockTokenProvider) Token(ctx context.Context) (*auth.Token, error) {
+	idx := m.calls
+	m.calls++
+	if idx < len(m.errs) && m.errs[idx] != nil {
+		return nil, m.errs[idx]
+	}
+	if idx < len(m.tokens) && m.tokens[idx] != nil {
+		return m.tokens[idx], nil
+	}
+	return &auth.Token{Value: "default-token"}, nil
+}
+
+type mockTokenSource struct {
+	tokens []*oauth2.Token
+	errs   []error
+	calls  int
+}
+
+func (m *mockTokenSource) Token() (*oauth2.Token, error) {
+	idx := m.calls
+	m.calls++
+	if idx < len(m.errs) && m.errs[idx] != nil {
+		return nil, m.errs[idx]
+	}
+	if idx < len(m.tokens) && m.tokens[idx] != nil {
+		return m.tokens[idx], nil
+	}
+	return &oauth2.Token{AccessToken: "default-token"}, nil
+}
+
+func fastRetryConfig() *RetryConfig {
+	return &RetryConfig{
+		MaxAttempts:   3,
+		RetryDeadline: 1 * time.Second,
+		BackoffConfig: exponentialBackoffConfig{
+			initial:    1 * time.Millisecond,
+			max:        5 * time.Millisecond,
+			multiplier: 1.5,
+		},
+	}
+}
+
+func TestRetryingTokenProvider_SuccessOnFirstAttempt(t *testing.T) {
+	mock := &mockTokenProvider{
+		tokens: []*auth.Token{{Value: "valid-token"}},
+	}
+	provider := &retryingTokenProvider{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := provider.Token(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "valid-token", token.Value)
+	assert.Equal(t, 1, mock.calls)
+}
+
+func TestRetryingTokenProvider_RetryOnTransientMDSError_Success(t *testing.T) {
+	transientErr := &oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusServiceUnavailable},
+	}
+	mock := &mockTokenProvider{
+		errs:   []error{transientErr, transientErr, nil},
+		tokens: []*auth.Token{nil, nil, {Value: "recovered-token"}},
+	}
+	provider := &retryingTokenProvider{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := provider.Token(context.Background())
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "recovered-token", token.Value)
+	assert.Equal(t, 3, mock.calls)
+}
+
+func TestRetryingTokenProvider_NonTransientError_NoRetry(t *testing.T) {
+	permanentErr := errors.New("permanent auth failure")
+	mock := &mockTokenProvider{
+		errs: []error{permanentErr},
+	}
+	provider := &retryingTokenProvider{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := provider.Token(context.Background())
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.Equal(t, 1, mock.calls)
+}
+
+func TestRetryingTokenProvider_ExhaustedAttempts_Fails(t *testing.T) {
+	transientErr := &metadata.Error{Code: 500}
+	mock := &mockTokenProvider{
+		errs: []error{transientErr, transientErr, transientErr, transientErr},
+	}
+	provider := &retryingTokenProvider{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := provider.Token(context.Background())
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.Equal(t, 3, mock.calls)
+}
+
+func TestRetryingTokenSource_SuccessOnFirstAttempt(t *testing.T) {
+	mock := &mockTokenSource{
+		tokens: []*oauth2.Token{{AccessToken: "valid-token"}},
+	}
+	ts := &retryingTokenSource{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := ts.Token()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "valid-token", token.AccessToken)
+	assert.Equal(t, 1, mock.calls)
+}
+
+func TestRetryingTokenSource_RetryOnTransientMDSError_Success(t *testing.T) {
+	transientErr := &metadata.Error{Code: 503}
+	mock := &mockTokenSource{
+		errs:   []error{transientErr, nil},
+		tokens: []*oauth2.Token{nil, {AccessToken: "recovered-token"}},
+	}
+	ts := &retryingTokenSource{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := ts.Token()
+
+	assert.NoError(t, err)
+	assert.NotNil(t, token)
+	assert.Equal(t, "recovered-token", token.AccessToken)
+	assert.Equal(t, 2, mock.calls)
+}
+
+func TestRetryingTokenSource_NonTransientError_NoRetry(t *testing.T) {
+	permanentErr := errors.New("permanent auth failure")
+	mock := &mockTokenSource{
+		errs: []error{permanentErr},
+	}
+	ts := &retryingTokenSource{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := ts.Token()
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.Equal(t, 1, mock.calls)
+}
+
+func TestRetryingTokenSource_ExhaustedAttempts_Fails(t *testing.T) {
+	transientErr := &oauth2.RetrieveError{
+		Response: &http.Response{StatusCode: http.StatusTooManyRequests},
+	}
+	mock := &mockTokenSource{
+		errs: []error{transientErr, transientErr, transientErr, transientErr},
+	}
+	ts := &retryingTokenSource{
+		base:        mock,
+		retryConfig: fastRetryConfig(),
+	}
+
+	token, err := ts.Token()
+
+	assert.Error(t, err)
+	assert.Nil(t, token)
+	assert.Equal(t, 3, mock.calls)
+}


### PR DESCRIPTION
### Description
- Added `retryingTokenProvider` (`auth.TokenProvider`) and `retryingTokenSource` (`oauth2.TokenSource`) in `internal/storage/storageutil/token_retry.go` to retry transient Metadata Server (MDS) and OAuth2 errors (`isTransientMDSError`) using `ExecuteWithCustomShouldRetryAtLogLevel`.
- Updated `GetClientAuthOptionsAndToken` in `internal/storage/storageutil/auth_client_option.go` to wrap credentials and token sources with the retry decorators when `EnableMountRetries` is enabled.
- Retries both initial token source creation (`auth2.NewTokenSourceFromURL` and `auth2.GetCredentials`) during mount as well as subsequent `Token()` / `ProvideToken()` calls during runtime token refresh.
- Added comprehensive unit tests in `internal/storage/storageutil/token_retry_test.go`.

### Link to the issue in case of a bug fix.
b/538080458

### Testing details
1. Manual - NA
2. Unit tests - Added unit tests in `token_retry_test.go` verifying first-attempt success, retry on transient errors, fast failure on non-transient errors, and exhausted retry attempts.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No