### PR TITLE
chore(scripts): Fix and simplify package creation Dockerfile and CD packaging script

### DIFF
--- a/tools/cd_scripts/package_gcsfuse.sh
+++ b/tools/cd_scripts/package_gcsfuse.sh
@@ -30,7 +30,8 @@ set -e
 function fetch_meta_data_value() {
   metadata_key=$1
   # Fetch metadata value directly from the local metadata server
-  value=$(curl -sfS -H "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$metadata_key")
+  value=$(curl -sfS -H "Metadata-Flavor: Google" \
+    "http://metadata.google.internal/computeMetadata/v1/instance/attributes/$metadata_key")
   echo "$value"
 }
 
@@ -53,7 +54,11 @@ echo COMMIT_HASH="$COMMIT_HASH"
 
 sudo apt-get update
 echo Install docker
-sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
+sudo apt install -y \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  software-properties-common
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
 sudo add-apt-repository "deb [arch=${architecture}] https://download.docker.com/linux/ubuntu focal stable"
 apt-cache policy docker-ce
@@ -64,11 +69,19 @@ sudo apt-get install git -y
 sudo apt-get install qemu-user-static binfmt-support
 git clone https://github.com/GoogleCloudPlatform/gcsfuse.git
 cd gcsfuse/tools/package_gcsfuse_docker/
-git checkout "$COMMIT_HASH"
 echo "Building docker for ${architecture} ..."
-sudo docker buildx build --load . -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" --build-arg ARCHITECTURE=${architecture} --build-arg BRANCH_NAME="$COMMIT_HASH" &> docker_${architecture}.log
+# Use Dockerfile from master and pass GCSFUSE_VERSION (release version) and BRANCH_NAME (target commit) to build the package.
+sudo docker buildx build --load . \
+  -t gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" \
+  --build-arg GCSFUSE_VERSION="$RELEASE_VERSION" \
+  --build-arg ARCHITECTURE=${architecture} \
+  --build-arg BRANCH_NAME="$COMMIT_HASH" &> docker_${architecture}.log
+
 gcloud storage cp docker_${architecture}.log gs://"$UPLOAD_BUCKET"/v"$RELEASE_VERSION"/
-sudo docker run  -v $HOME/gcsfuse/release:/release gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" cp -r /packages/. /release/v"$RELEASE_VERSION"
+sudo docker run \
+  -v $HOME/gcsfuse/release:/release \
+  gcsfuse-release-${architecture}:"$RELEASE_VERSION_TAG" \
+  cp -r /packages/. /release/v"$RELEASE_VERSION"
 
 echo "Upload files in the bucket ..."
 gcloud storage cp --recursive $HOME/gcsfuse/release/v"$RELEASE_VERSION" gs://"$UPLOAD_BUCKET"/

--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -42,19 +42,36 @@
 #   - /packages/gcsfuse_{VERSION}_{ARCH}.deb
 #   - /packages/gcsfuse-{VERSION}-1.x86_64.rpm (or aarch64 for arm64)
 
-FROM golang:1.24.5 as builder
+ARG GO_VERSION=1.24.5
+
+FROM golang:${GO_VERSION}-bookworm AS builder
+
+# Build arguments
+ARG ARCHITECTURE="amd64"
+# GCSFUSE_VERSION: The release version string (e.g. "2.5.4") embedded in package filenames, control files, changelogs, and RPM specs.
+ARG GCSFUSE_VERSION
+ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
+# BRANCH_NAME: The Git commit hash, branch, or tag used to build gcsfuse. Defaults to "v${GCSFUSE_VERSION}".
+ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
+ARG GCSFUSE_PATH="/go/gcsfuse"
+ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_${ARCHITECTURE}"
+ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
+ARG GCSFUSE_PKG="/packages"
+
+# Environment variables
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GO111MODULE=auto
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 RUN apt-get update -qq && apt-get install -y ruby ruby-dev rubygems build-essential && gem install --no-document bundler -v "2.4.12"
 RUN apt-get install -y rpm wget
-ARG ARCHITECTURE="amd64"
+
 RUN if [ "${ARCHITECTURE}" != "amd64" ] && [ "${ARCHITECTURE}" != "arm64" ]; then \
     echo "Architecture should be amd64 or arm64"; \
     exit 1; \
     fi
 
-ARG GCSFUSE_VERSION
-ARG GCSFUSE_REPO="https://github.com/googlecloudplatform/gcsfuse/"
-ARG BRANCH_NAME="v${GCSFUSE_VERSION}"
 RUN git clone ${GCSFUSE_REPO} && \
     cd gcsfuse && \
     git checkout ${BRANCH_NAME}
@@ -65,24 +82,13 @@ RUN rm -rf /usr/local/go && \
     wget -O go_tar.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${ARCHITECTURE}.tar.gz -q && \
     tar -C /usr/local -xzf go_tar.tar.gz && \
     rm go_tar.tar.gz
-RUN PATH=$PATH:/usr/local/go/bin
 RUN go version
 
-ENV CGO_ENABLED=0
-ENV GOOS=linux
-ENV GO111MODULE=auto
-
-ARG GCSFUSE_PATH=${GOPATH}/gcsfuse
 WORKDIR ${GCSFUSE_PATH}
-
-ARG DEBEMAIL="gcs-fuse-maintainers@google.com"
-ARG DEBFULLNAME="GCSFuse Team"
 
 # Install fpm package using bundle
 RUN bundle install --gemfile=${GCSFUSE_PATH}/tools/gem_dependency/Gemfile
 
-ARG GCSFUSE_BIN="/gcsfuse_${GCSFUSE_VERSION}_${ARCHITECTURE}"
-ARG GCSFUSE_DOC="${GCSFUSE_BIN}/usr/share/doc/gcsfuse"
 WORKDIR ${GCSFUSE_PATH}/tools/build_gcsfuse
 RUN go install
 RUN mkdir -p ${GCSFUSE_BIN}
@@ -108,7 +114,6 @@ RUN gzip -9 -n ${GCSFUSE_DOC}/changelog
 RUN strip --strip-unneeded ${GCSFUSE_BIN}/usr/bin/gcsfuse && \
     strip --strip-unneeded ${GCSFUSE_BIN}/sbin/mount.gcsfuse
 
-ARG GCSFUSE_PKG="/packages"
 RUN mkdir -p ${GCSFUSE_PKG}
 WORKDIR ${GCSFUSE_PKG}
 # Build the package
@@ -125,5 +130,5 @@ RUN fpm \
     --rpm-digest sha256 \
     --license Apache-2.0 \
     --vendor "" \
-    --url "https://$GCSFUSE_REPO" \
+    --url "$GCSFUSE_REPO" \
     --description "A user-space file system for Google Cloud Storage."


### PR DESCRIPTION
### Description
### Summary of Changes

1. **Pin Debian Bookworm Base Image**: Pinned base image to `golang:${GO_VERSION}-bookworm` in `tools/package_gcsfuse_docker/Dockerfile` to ensure compatibility with `fpm` / `rpmbuild` (avoiding breaking changes introduced in RPM 4.20+ on Debian Trixie).
2. **Fix Duplicate Scheme in RPM URL**: Removed duplicate `https://` prefix in `fpm --url "$GCSFUSE_REPO"`.
3. **Consolidate Build ARGs and ENVs**: Grouped all `ARG` and `ENV` declarations at the top of the packaging Dockerfile, ensuring `$PATH` persists across layers.
4. **Decouple Host Dockerfile from Release Commit**: Updated `tools/cd_scripts/package_gcsfuse.sh` to use the packaging Dockerfile from `master` while compiling code for the target commit passed via `--build-arg BRANCH_NAME="$COMMIT_HASH"`.

### Testing
- Verified local and remote `docker buildx build` for AMD64 and ARM64.
- Verified `.deb` installation on Ubuntu 22.04 and `.rpm` installation on AlmaLinux 9.
- Validated package metadata (`rpm -qip`) and binary execution (`gcsfuse --version`).

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
