### PR TITLE
build(docker): Support go.mod fallback for Go version detection in package Dockerfile

### DIFF
--- a/tools/package_gcsfuse_docker/Dockerfile
+++ b/tools/package_gcsfuse_docker/Dockerfile
@@ -77,11 +77,35 @@ RUN git clone ${GCSFUSE_REPO} && \
     git checkout ${BRANCH_NAME}
 RUN echo "Building from branch/commit/tag: ${BRANCH_NAME}"
 
-RUN rm -rf /usr/local/go && \
-    GO_VERSION=$(cat gcsfuse/.go-version) && \
-    wget -O go_tar.tar.gz https://go.dev/dl/go${GO_VERSION}.linux-${ARCHITECTURE}.tar.gz -q && \
+# Extract required Go version, determine download URL, and install Go
+RUN set -e; \
+    # Step 1: Extract Go version from .go-version or go.mod \
+    if [ -f gcsfuse/.go-version ]; then \
+        GO_VERSION=$(cat gcsfuse/.go-version); \
+    else \
+        GO_VERSION=$(sed -n 's/^go //p' gcsfuse/go.mod); \
+    fi; \
+    \
+    # Step 2: Determine Go download URL \
+    # Starting with Go 1.21, archives on go.dev/dl require 3-part versions (e.g. 1.21.0 vs 1.20) \
+    case "$GO_VERSION" in \
+        *.*.*) ;; \
+        *.*) \
+            MINOR=$(echo "$GO_VERSION" | cut -d. -f2); \
+            if [ "$MINOR" -ge 21 ] 2>/dev/null; then \
+                GO_VERSION="${GO_VERSION}.0"; \
+            fi \
+            ;; \
+    esac; \
+    GO_URL="https://go.dev/dl/go${GO_VERSION}.linux-${ARCHITECTURE}.tar.gz"; \
+    \
+    # Step 3: Download and install Go \
+    echo "Downloading and installing Go from ${GO_URL}..." && \
+    rm -rf /usr/local/go && \
+    wget -q -O go_tar.tar.gz "${GO_URL}" && \
     tar -C /usr/local -xzf go_tar.tar.gz && \
-    rm go_tar.tar.gz
+    rm -f go_tar.tar.gz
+
 RUN go version
 
 WORKDIR ${GCSFUSE_PATH}


### PR DESCRIPTION
### Description
Fix Go version detection in `tools/package_gcsfuse_docker/Dockerfile` to maintain backward compatibility with older release branches and commits.
#### Root Cause & Fix:
- **Problem**: When packaging older release commits/branches (created prior to the introduction of `.go-version`), running `cat gcsfuse/.go-version` failed with `cat: gcsfuse/.go-version: No such file or directory`.
- **Solution**: Added a fallback in the Dockerfile: if `.go-version` is present, it reads the pinned Go version; otherwise, it extracts the Go version directly from `go.mod`.
### Link to the issue in case of a bug fix.
NA
### Testing details
1. **Manual**:
   - Verified building release commit without `.go-version` (`6bd3b66f1`): Successfully extracted Go version from `go.mod` and built packages for both AMD64 and ARM64.
   - Verified building `master` branch: Successfully used Go version from `.go-version`.
2. **Unit tests**: NA
3. **Integration tests**: NA
### Any backward incompatible change? If so, please explain.
NA