### PR TITLE
test(rapid_writes): explicitly set appendable API and finalizeOnClose=false in CreateUnfinalizedObject

### DIFF
--- a/tools/integration_tests/util/client/gcs_helper.go
+++ b/tools/integration_tests/util/client/gcs_helper.go
@@ -182,7 +182,7 @@ func GetCRCFromGCS(objectPath string, ctx context.Context, storageClient *storag
 // and performs a flush with Zonal Bucket Flush API for content to be available for read
 // and returns the writer.
 func CreateUnfinalizedObject(ctx context.Context, t *testing.T, client *storage.Client, object, content string) *storage.Writer {
-	writer, err := NewWriterWithPreconditionsSet(ctx, client, object, storage.Conditions{})
+	writer, err := NewWriterWithPreconditionsSet(ctx, client, object, storage.Conditions{}, WithAppendableAPI(true), WithFinalizeOnClose(false))
 	require.NoError(t, err)
 
 	bytesWritten, err := writer.Write([]byte(content))

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -515,7 +515,7 @@ func DeleteBucket(ctx context.Context, client *storage.Client, bucketName string
 	return nil
 }
 
-func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, object string, precondition storage.Conditions) (*storage.Writer, error) {
+func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, object string, precondition storage.Conditions, opts ...WriterOption) (*storage.Writer, error) {
 	bucket, object := setup.GetBucketAndObjectBasedOnTypeOfMount(object)
 
 	o := getBucketHandle(client, bucket).Object(object)
@@ -524,7 +524,7 @@ func NewWriterWithPreconditionsSet(ctx context.Context, client *storage.Client, 
 	}
 
 	// Upload an object with storage.Writer.
-	wc := NewWriterWithOptions(ctx, o)
+	wc := NewWriterWithOptions(ctx, o, opts...)
 	return wc, nil
 }
 


### PR DESCRIPTION
### Description
Earlier, the `CreateUnfinalizedObject` test helper relied on default flag values to create unfinalized objects. With Pirlo, we need to explicitly configure it to use the appendable API and set finalize on close to false. 

This PR modifies the `NewWriterWithPreconditionsSet` helper to accept variadic `opts ...WriterOption` and updates `CreateUnfinalizedObject` to explicitly pass `WithAppendableAPI(true)` and `WithFinalizeOnClose(false)`.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated.

### Any backward incompatible change? If so, please explain.
No.
