### PR TITLE
test(write_test): log empty MediaLink attribute as a known gRPC limitation

### DIFF
--- a/tools/integration_tests/operations/write_test.go
+++ b/tools/integration_tests/operations/write_test.go
@@ -120,8 +120,9 @@ func (w *writeOperationsTest) validateObjectAttributes(attr1, attr2 *storage.Obj
 		w.T().Error("Expected CRC32 attributes to be non 0")
 	}
 	if attr1.MediaLink == "" || attr2.MediaLink == "" {
-		if setup.IsZonalBucketRun() || (setup.IsPirloBucketRun() && w.isRapidWritesEnabled) {
-			w.T().Logf("media link is empty, but it is a known limitation in RAPID/zonal buckets.")
+		// TODO: Align test storage client protocol with the mount protocol. Note that when using gRPC to verify attributes for regional buckets, MediaLink will be empty.
+		if setup.IsZonalBucketRun() || setup.IsPirloBucketRun() {
+			w.T().Logf("media link is empty, but it is a known limitation in gRPC.")
 		} else {
 			w.T().Errorf("Expected media link to be non empty")
 		}


### PR DESCRIPTION
### Description
The `MediaLink` field is intentionally excluded from the GCS gRPC API specification because it is an HTTP-specific functionality. Previously, the integration test incorrectly attributed the missing `MediaLink` attribute to RAPID/zonal buckets. This PR updates the logic in `write_test.go` to correctly identify the empty `MediaLink` as a known gRPC limitation, simplifying the condition for Pirlo buckets and updating the log message accordingly.


### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - NA.

### Any backward incompatible change? If so, please explain.
None.
