### PR TITLE
test(storage_client): use gRPC storage client for Pirlo

### DIFF
--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -113,21 +113,19 @@ func CreateStorageClient(ctx context.Context) (client *storage.Client, err error
 			return nil, fmt.Errorf("unable to fetch token-source for TPC: %w", err)
 		}
 		client, err = storage.NewClient(ctx, option.WithEndpoint("storage.apis-tpczero.goog:443"), option.WithTokenSource(ts))
-	} else {
-		if setup.IsZonalBucketRun() {
-			var opts []option.ClientOption
-			opts = append(opts, experimental.WithGRPCBidiReads())
-			if kf := setup.KeyFile(); kf != "" {
-				ts, err := getTokenSrc(kf)
-				if err != nil {
-					return nil, err
-				}
-				opts = append(opts, option.WithTokenSource(ts))
+	} else if setup.IsZonalBucketRun() || setup.IsPirloBucketRun() {
+		var opts []option.ClientOption
+		opts = append(opts, experimental.WithGRPCBidiReads())
+		if kf := setup.KeyFile(); kf != "" {
+			ts, err := getTokenSrc(kf)
+			if err != nil {
+				return nil, err
 			}
-			client, err = storage.NewGRPCClient(ctx, opts...)
-		} else {
-			client, err = CreateHttp1StorageClient(ctx)
+			opts = append(opts, option.WithTokenSource(ts))
 		}
+		client, err = storage.NewGRPCClient(ctx, opts...)
+	} else {
+		client, err = CreateHttp1StorageClient(ctx)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("storage.NewClient: %w", err)


### PR DESCRIPTION
### Description
Updates `CreateStorageClient` in the integration test utilities to instantiate a gRPC storage client for Pirlo bucket runs. Since Pirlo exclusively uses gRPC, this change ensures that our test functionality matches this behavior by correctly utilizing gRPC for Pirlo.

### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### Any backward incompatible change? If so, please explain.
No.
