### PR TITLE
test(integration): add dedicated NPI test suite to e2e test runner

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/e2e_tests/build.sh
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Script to run e2e tests for regional or zonal buckets if env variable RUN_TESTS_WITH_ZONAL_BUCKET is set to 'true'.
+# Script to run e2e tests for regional, zonal, or NPI buckets if env variable RUN_TESTS_WITH_ZONAL_BUCKET or RUN_TESTS_FOR_NPI is set to 'true'.
 # Exit on error, treat unset variables as errors, and propagate pipeline errors.
 set -euo pipefail
 
 if [[ $# -gt 0 ]]; then
-    echo "This script requires no argument. Pass env variable RUN_TESTS_WITH_ZONAL_BUCKET set to 'true' to run this script for zonal buckets." 
+    echo "This script requires no argument. Pass env variable RUN_TESTS_WITH_ZONAL_BUCKET or RUN_TESTS_FOR_NPI set to 'true' to run this script for zonal or NPI buckets." 
     exit 1
 fi
 
@@ -46,14 +46,19 @@ fi
 echo "Checking out commit ${commitId}."
 git checkout $commitId
 
-if [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then
+if [[ "${RUN_TESTS_FOR_NPI-}" == "true" ]]; then
+    echo "Running NPI e2e tests on installed package...."
+    bash ./tools/integration_tests/improved_run_e2e_tests.sh --test-installed-package --npi
+elif [[ "${RUN_TESTS_WITH_ZONAL_BUCKET-}" == "true" ]]; then
     echo "Running zonal e2e tests on installed package...."
     bash ./tools/integration_tests/improved_run_e2e_tests.sh --test-installed-package --zonal
 else
     if [[ -n "${RUN_TESTS_WITH_ZONAL_BUCKET-}" ]]; then
         echo "Warning: RUN_TESTS_WITH_ZONAL_BUCKET is set to '${RUN_TESTS_WITH_ZONAL_BUCKET}', which is not 'true'. Running regional tests."
+    elif [[ -n "${RUN_TESTS_FOR_NPI-}" ]]; then
+        echo "Warning: RUN_TESTS_FOR_NPI is set to '${RUN_TESTS_FOR_NPI}', which is not 'true'. Running regional tests."
     else
-        echo "RUN_TESTS_WITH_ZONAL_BUCKET is not set. Running regional tests by default."
+        echo "RUN_TESTS_WITH_ZONAL_BUCKET and RUN_TESTS_FOR_NPI are not set. Running regional tests by default."
     fi
     echo "Running regional e2e tests on installed package...."
     bash ./tools/integration_tests/improved_run_e2e_tests.sh --test-installed-package

--- a/tools/integration_tests/improved_run_e2e_tests.sh
+++ b/tools/integration_tests/improved_run_e2e_tests.sh
@@ -28,6 +28,7 @@ usage() {
   echo "    --presubmit                                  Run tests with presubmit flag. (Default: false)"
   echo "    --zonal                                      Run tests with zonal bucket in --bucket-location region."
   echo "                                                 The placement for Zonal buckets by deafault is Zone A of --bucket-location. (Default: false)"
+  echo "    --npi                                        Run dedicated NPI (Network Protocol Integration / Pirlo) test suite. (Default: false)"
   echo "    --no-build-binary-in-script                  To disable building gcsfuse binary in script. (Default: false)"
   echo "    --package-level-parallelism   <parallelism>  To adjust the number of packages to execute in parallel. (Default: 10)"
   echo "    --track-resource-usage                       To track resource(cpu/mem/disk) usage during e2e run. (Default: false)"
@@ -131,6 +132,7 @@ INSTALL_PACKAGE_FROM_PATH=""
 RUN_TEST_ON_TPC_ENDPOINT=false
 RUN_TESTS_WITH_PRESUBMIT_FLAG=false
 RUN_TESTS_WITH_ZONAL_BUCKET=false
+RUN_TESTS_FOR_NPI=false
 BUILD_BINARY_IN_SCRIPT=true
 TRACK_RESOURCE_USAGE=false
 PACKAGE_LEVEL_PARALLELISM=10 # Controls how many test packages are run in parallel for hns, flat or zonal buckets.
@@ -140,7 +142,7 @@ FLAKE_ATTEMPTS=1
 
 # Define options for getopt
 # A long option name followed by a colon indicates it requires an argument.
-LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
+LONG=bucket-location:,project-id:,test-installed-package,install-package-from-path:,skip-non-essential-tests,no-build-binary-in-script,test-on-tpc-endpoint,presubmit,zonal,npi,package-level-parallelism:,track-resource-usage,output-dir:,help,run-package:,skip-emulator,flake-attempts:
 
 # Parse the options using getopt
 # --options "" specifies that there are no short options.
@@ -194,6 +196,10 @@ while (( $# >= 1 )); do
             ;;
         --zonal)
             RUN_TESTS_WITH_ZONAL_BUCKET=true
+            shift
+            ;;
+        --npi)
+            RUN_TESTS_FOR_NPI=true
             shift
             ;;
         --track-resource-usage)
@@ -388,11 +394,38 @@ TEST_PACKAGES_FOR_RB=("${TEST_PACKAGES_COMMON[@]}" "inactive_stream_timeout" "cl
 TEST_PACKAGES_FOR_ZB=("${TEST_PACKAGES_COMMON[@]}" "rapid_operations" "unfinalized_object")
 # Test packages for TPC buckets.
 TEST_PACKAGES_FOR_TPC=("operations")
+# Test packages for NPI (Network Protocol Integration / Pirlo) tests.
+# Sorted list descending run times.
+TEST_PACKAGES_FOR_NPI=(
+  "operations"
+  "read_large_files"
+  "concurrent_operations"
+  "read_cache"
+  "list_large_dir"
+  "write_large_files"
+  "implicit_dir"
+  "interrupt"
+  "local_file"
+  "readonly"
+  "rename_dir_limit"
+  "kernel_list_cache"
+  "streaming_writes"
+  "explicit_dir"
+  "gzip"
+  "unsupported_path"
+  "negative_stat_cache"
+  "stale_handle"
+  "readdirplus"
+  "dentry_cache"
+  "buffered_read"
+  "symlink_handling"
+)
 
 # Parse and apply --run-package filters if provided
 if [[ -n "$RUN_PACKAGE_REGEX" ]]; then
   filter_array TEST_PACKAGES_FOR_RB "$RUN_PACKAGE_REGEX"
   filter_array TEST_PACKAGES_FOR_ZB "$RUN_PACKAGE_REGEX"
+  filter_array TEST_PACKAGES_FOR_NPI "$RUN_PACKAGE_REGEX"
 fi
 
 # acquire_lock: Acquires exclusive lock or exits script on failure.
@@ -754,6 +787,9 @@ test_package() {
   if ${RUN_TEST_ON_TPC_ENDPOINT}; then
     go_test_cmd_parts+=("--testOnTPCEndPoint")
   fi
+  if ${RUN_TESTS_FOR_NPI}; then
+    go_test_cmd_parts+=("--pirlo")
+  fi
   if [[ -n "$BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR" ]]; then 
     go_test_cmd_parts+=("--gcsfuse_prebuilt_dir=${BUILT_BY_SCRIPT_GCSFUSE_BUILD_DIR}")
   fi
@@ -1046,7 +1082,10 @@ main() {
 
   local pids=()
   local overall_exit_code=0
-  if ${RUN_TESTS_WITH_ZONAL_BUCKET}; then
+  if ${RUN_TESTS_FOR_NPI}; then
+    run_test_group "NPI" "$HNS" "${TEST_PACKAGES_FOR_NPI[@]}" & pids+=($!)
+    run_test_group "NPI" "$FLAT" "${TEST_PACKAGES_FOR_NPI[@]}" & pids+=($!)
+  elif ${RUN_TESTS_WITH_ZONAL_BUCKET}; then
     run_test_group "ZONAL" "$ZONAL" "${TEST_PACKAGES_FOR_ZB[@]}" & pids+=($!)
   elif ${RUN_TEST_ON_TPC_ENDPOINT}; then
     # Override PROJECT_ID and BUCKET_LOCATION for TPC tests


### PR DESCRIPTION
### Description
This PR introduces a dedicated integration test configuration for NPI related tests: **CLI Runner Integration (`--npi`)**
Added `--npi` option to `improved_run_e2e_tests.sh` to trigger NPI test groups across Flat and HNS regional buckets.

### Link to the issue in case of a bug fix.
b/530771587

### Testing details
1. Manual - Verified code layout, formatting, linting, and build via `make build`. Validated shell scripts syntax with `bash -n`.
2. Unit tests - N/A
3. Integration tests - Ran the tests manually

### Any backward incompatible change? If so, please explain.
N/A
