### PR TITLE
refactor(locker & lru): Refactor `locker` and `lru` to isolate invariant checking and eliminate global state

### DIFF
--- a/internal/cache/lru/lru.go
+++ b/internal/cache/lru/lru.go
@@ -89,6 +89,18 @@ func NewCache(maxSize uint64) *Cache {
 	return c
 }
 
+// NewCacheWithOptions returns a Cache instance initialized with the
+// supplied maxSize and lock options.
+func NewCacheWithOptions(maxSize uint64, opts locker.Options) *Cache {
+	c := &Cache{
+		maxSize: maxSize,
+		index:   make(map[string]*list.Element),
+	}
+
+	c.mu = locker.NewRWWithOptions("LRUCache", c.checkInvariants, opts)
+	return c
+}
+
 // checkInvariants panic if any internal invariants have been violated.
 func (c *Cache) checkInvariants() {
 	// INVARIANT: maxSize > 0

--- a/internal/cache/lru/lru_test.go
+++ b/internal/cache/lru/lru_test.go
@@ -39,13 +39,17 @@ func (td testData) Size() uint64 {
 }
 
 func setupCacheTest(t *testing.T) *lru.Cache {
-	locker.EnableInvariantsCheck()
-	return lru.NewCache(MaxSize)
+	t.Helper()
+	testOpts := locker.Options{
+		EnableInvariantsCheck: true,
+	}
+	return lru.NewCacheWithOptions(MaxSize, testOpts)
 }
 
 // insertAndAssert inserts the given key,value in the cache and assert based on
 // the expected eviction and error.
 func insertAndAssert(t *testing.T, cache *lru.Cache, key string, val lru.ValueType, evictedValues []int64, expectedError error) {
+	t.Helper()
 	ret, err := cache.Insert(key, val)
 
 	require.ErrorIs(t, err, expectedError)

--- a/internal/fs/fs_test.go
+++ b/internal/fs/fs_test.go
@@ -49,10 +49,13 @@ import (
 )
 
 const (
-	filePerms            os.FileMode = 0740
-	dirPerms                         = 0754
-	RenameDirLimit                   = 5
-	SequentialReadSizeMb             = 200
+	filePerms os.FileMode = 0740
+	dirPerms  os.FileMode = 0754
+)
+
+const (
+	RenameDirLimit       = 5
+	SequentialReadSizeMb = 200
 )
 
 func TestFS(t *testing.T) { RunTests(t) }

--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -23,35 +23,45 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 )
 
+// TODO: Migrate all usages of these global variables to explicitly instantiate and pass locker.Options.
 var gEnableInvariantsCheck bool
 var gEnableDebugMessages bool
 
-// Enable the check for invariants in the locks. Must be set before creating
+// EnableInvariantsCheck enables the check for invariants in the locks. Must be set before creating
 // any lockers.
+// TODO: Deprecate and delete this function once all components migrate to using locker.Options.
 func EnableInvariantsCheck() {
 	gEnableInvariantsCheck = true
 }
 
-// Enable the debug messages to diagnose dead locks. Must be set before creating
+// EnableDebugMessages enables the debug messages to diagnose dead locks. Must be set before creating
 // any lockers.
+// TODO: Deprecate and delete this function once all components migrate to using locker.Options.
 func EnableDebugMessages() {
 	gEnableDebugMessages = true
 }
 
 type Locker sync.Locker
 
-// Returns a locker with potential capability for debugging.
-func New(name string, check func()) Locker {
+// Options contains configuration for creating lockers.
+// By using options, callers can avoid relying on the package-level global variables.
+type Options struct {
+	EnableInvariantsCheck bool
+	EnableDebugMessages   bool
+}
+
+// NewWithOptions returns a locker with potential capability for debugging based on options.
+func NewWithOptions(name string, check func(), opts Options) Locker {
 	var l Locker = &sync.Mutex{}
 
-	if gEnableInvariantsCheck {
+	if opts.EnableInvariantsCheck {
 		l = &checker{
 			locker: l,
 			check:  check,
 		}
 	}
 
-	if gEnableDebugMessages {
+	if opts.EnableDebugMessages {
 		l = &debugger{
 			locker: l,
 			name:   name,
@@ -59,6 +69,15 @@ func New(name string, check func()) Locker {
 	}
 
 	return l
+}
+
+// New returns a locker with potential capability for debugging.
+// TODO: Deprecate and delete this function once all components migrate to using locker.Options.
+func New(name string, check func()) Locker {
+	return NewWithOptions(name, check, Options{
+		EnableInvariantsCheck: gEnableInvariantsCheck,
+		EnableDebugMessages:   gEnableDebugMessages,
+	})
 }
 
 type checker struct {

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -29,21 +29,18 @@ type RWLocker interface {
 	RUnlock()
 }
 
-// NewRW returns a RW locker with potential capability for debugging.
-//
-// Note: The deadlock detection is done only for writer lock and not for reader
-// lock.
-func NewRW(name string, check func()) RWLocker {
+// NewRWWithOptions returns an RW locker with potential capability for debugging based on options.
+func NewRWWithOptions(name string, check func(), opts Options) RWLocker {
 	var l RWLocker = &sync.RWMutex{}
 
-	if gEnableInvariantsCheck {
+	if opts.EnableInvariantsCheck {
 		l = &rwChecker{
 			locker: l,
 			check:  check,
 		}
 	}
 
-	if gEnableDebugMessages {
+	if opts.EnableDebugMessages {
 		l = &rwDebugger{
 			locker: l,
 			name:   name,
@@ -51,6 +48,18 @@ func NewRW(name string, check func()) RWLocker {
 	}
 
 	return l
+}
+
+// NewRW returns a RW locker with potential capability for debugging.
+//
+// Note: The deadlock detection is done only for writer lock and not for reader
+// lock.
+// TODO: Deprecate and delete this function once all components migrate to using locker.Options.
+func NewRW(name string, check func()) RWLocker {
+	return NewRWWithOptions(name, check, Options{
+		EnableInvariantsCheck: gEnableInvariantsCheck,
+		EnableDebugMessages:   gEnableDebugMessages,
+	})
 }
 
 type rwChecker struct {


### PR DESCRIPTION
### Description
This PR addresses a severe O(N²) performance bottleneck in our tests caused by global lock state, and paves the way for explicitly configuring `locker` instances across the codebase.
Previously, `gEnableInvariantsCheck` in `locker.go` was a global variable. When a unit test enabled it, the O(N) `checkInvariants` loop was forcefully enabled for *all* concurrent tests sharing the process, causing large stress tests (like `lru_memory_test.go`) to hit massive slowdowns and flake/timeout in CI. 
This change introduces an explicit `locker.Options` configuration struct to replace the global state. Components can now explicitly configure and scope their lock behaviors (invariants checking and debug messaging) per instance.

### Key Changes
* **`internal/locker` Refactoring**: 
  * Introduced `locker.Options` and `NewWithOptions` / `NewRWWithOptions` to allow for explicit, localized lock configuration.
  * Marked existing global variables (`gEnableInvariantsCheck`, `gEnableDebugMessages`) and legacy constructors (`New`, `NewRW`) with `TODO`s for future migration and deprecation.
* **`internal/cache/lru` Migration**:
  * Added `NewCacheWithOptions` to allow constructing an LRU cache with specific lock configurations.
  * Migrated `lru_test.go` to explicitly pass `locker.Options{EnableInvariantsCheck: true}` instead of mutating global state. This successfully isolates the expensive invariant checks to just these tests!
* **`internal/fs` Lint Fix**: 
  * Grouped typed constants in `fs_test.go` to resolve a minor lint error.

### Why this matters
By passing down `locker.Options` instead of mutating package-level variables, tests will no longer accidentally sabotage the performance of other concurrent tests. It also sets up the architecture to be more idiomatic, testable, and dependency-injected moving forward.

### Link to the issue in case of a bug fix.
[b/545172419](https://b.corp.google.com/issues/545172419)

### Testing details
This fixes the flake detector that was timing out from many days -

<img width="1476" height="93" alt="image" src="https://github.com/user-attachments/assets/a0683085-eadf-45e9-8a89-c6cc8f915ece" />

1. Manual - NA
2. Unit tests - Passed `go test ./internal/cache/lru/... ./internal/locker/...`
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA (Legacy constructors and global functions are preserved for backward compatibility during migration)
