### PR TITLE
feat(native-retries): report mount status and error classification to CSI sidecar

### DIFF
--- a/cmd/legacy_main.go
+++ b/cmd/legacy_main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/monitor"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/mount"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/mountstatus"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/profiler"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
@@ -52,6 +53,7 @@ import (
 	"github.com/jacobsa/fuse"
 	"github.com/kardianos/osext"
 	"github.com/spf13/viper"
+	"google.golang.org/grpc/codes"
 )
 
 const (
@@ -386,6 +388,8 @@ func logGCSFuseMountInformation(mountInfo *mountInfo) {
 func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 	newConfig := mountInfo.config
 
+	mountstatus.InitStatusReporter(newConfig.Foreground)
+
 	var logExporterShutdownFn common.ShutdownFn
 	if newConfig.Foreground {
 		err = logger.InitLogFile(newConfig.Logging, fsName(bucketName), newConfig.MountId)
@@ -516,6 +520,7 @@ func Mount(mountInfo *mountInfo, bucketName, mountPoint string) (err error) {
 			}
 			// Print the success message in the log-file/stdout depending on what the logger is set to.
 			logger.Info(SuccessfulMountMessage)
+			mountstatus.ReportStatus(codes.OK, SuccessfulMountMessage)
 			callDaemonizeSignalOutcome(nil)
 		}
 

--- a/internal/mountstatus/status.go
+++ b/internal/mountstatus/status.go
@@ -1,0 +1,111 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mountstatus
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+)
+
+var statusFile *os.File
+
+// openStatusPipe validates and opens the file descriptor provided via GCSFUSE_STATUS_FD.
+// It ensures the descriptor represents a valid, writable named pipe and sets FD_CLOEXEC.
+func openStatusPipe(statusFDStr string) (*os.File, error) {
+	fd, err := strconv.Atoi(statusFDStr)
+	if err != nil || fd < 0 {
+		return nil, fmt.Errorf("invalid file descriptor %q", statusFDStr)
+	}
+
+	f := os.NewFile(uintptr(fd), "status_pipe")
+	if f == nil {
+		return nil, errors.New("failed to wrap descriptor in os.File")
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat failed: %w", err)
+	}
+
+	if stat.Mode()&os.ModeNamedPipe == 0 {
+		return nil, errors.New("descriptor is not a named pipe")
+	}
+
+	flags, err := unix.FcntlInt(f.Fd(), unix.F_GETFL, 0)
+	if err != nil {
+		return nil, fmt.Errorf("fcntl F_GETFL failed: %w", err)
+	}
+
+	if accMode := flags & unix.O_ACCMODE; accMode != unix.O_WRONLY && accMode != unix.O_RDWR {
+		return nil, errors.New("descriptor is not open for writing")
+	}
+
+	// Set close-on-exec so child processes do not inherit the status pipe.
+	unix.CloseOnExec(fd)
+	return f, nil
+}
+
+// InitStatusReporter configures the status reporting mechanism used to communicate
+// mount progress and outcomes with the CSI sidecar.
+// It only activates if running in foreground mode and GCSFUSE_STATUS_FD is provided.
+func InitStatusReporter(isForeground bool) {
+	if !isForeground || statusFile != nil {
+		return
+	}
+
+	statusFDStr := os.Getenv("GCSFUSE_STATUS_FD")
+	if statusFDStr == "" {
+		return
+	}
+
+	f, err := openStatusPipe(statusFDStr)
+	if err != nil {
+		logger.Warnf("Failed to initialize status reporter from GCSFUSE_STATUS_FD: %v", err)
+		return
+	}
+
+	statusFile = f
+}
+
+// StatusPayload defines the JSON structure sent to the CSI sidecar over the status pipe.
+type StatusPayload struct {
+	Status codes.Code `json:"status"`
+	Error  string     `json:"error"`
+}
+
+// ReportStatus writes the provided gRPC code and error message as a JSON payload
+// to the status file descriptor. It is safe to call even if the pipe is closed
+// or unavailable, as any write failures will simply be logged as warnings.
+func ReportStatus(code codes.Code, errMsg string) {
+	if statusFile == nil {
+		return
+	}
+
+	payload := StatusPayload{
+		Status: code,
+		Error:  errMsg,
+	}
+
+	if err := json.NewEncoder(statusFile).Encode(payload); err != nil {
+		logger.Warnf("Failed to report status to GCSFUSE_STATUS_FD: %v", err)
+	}
+}

--- a/internal/mountstatus/status_test.go
+++ b/internal/mountstatus/status_test.go
@@ -16,11 +16,8 @@ package mountstatus
 
 import (
 	"encoding/json"
-	"fmt"
-	"io"
 	"os"
 	"strconv"
-	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,225 +34,110 @@ func setStatusFileForTesting(f *os.File) func() {
 	}
 }
 
-func TestOpenStatusPipe(t *testing.T) {
-	t.Run("ValidNamedPipe", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		f, err := openStatusPipe(strconv.FormatUint(uint64(w.Fd()), 10))
-		require.NoError(t, err)
-		require.NotNil(t, f)
-		assert.Equal(t, w.Fd(), f.Fd())
-	})
-
-	t.Run("InvalidFDString", func(t *testing.T) {
-		f, err := openStatusPipe("not-an-int")
-		assert.Error(t, err)
-		assert.Nil(t, f)
-	})
-
-	t.Run("NegativeFD", func(t *testing.T) {
-		f, err := openStatusPipe("-5")
-		assert.Error(t, err)
-		assert.Nil(t, f)
-	})
-
-	t.Run("NonPipeFile", func(t *testing.T) {
-		tmpFile, err := os.CreateTemp("", "regular_file")
-		require.NoError(t, err)
-		defer func() { _ = os.Remove(tmpFile.Name()) }()
-		defer func() { _ = tmpFile.Close() }()
-
-		f, err := openStatusPipe(strconv.FormatUint(uint64(tmpFile.Fd()), 10))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "descriptor is not a named pipe")
-		assert.Nil(t, f)
-	})
-
-	t.Run("ReadOnlyPipe", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		f, err := openStatusPipe(strconv.FormatUint(uint64(r.Fd()), 10))
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "descriptor is not open for writing")
-		assert.Nil(t, f)
-	})
-}
-
-func TestInitStatusReporter(t *testing.T) {
-	t.Run("NotForeground", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		t.Setenv("GCSFUSE_STATUS_FD", strconv.FormatUint(uint64(w.Fd()), 10))
-
-		teardown := setStatusFileForTesting(nil)
-		defer teardown()
-
-		InitStatusReporter(false)
-
-		assert.Nil(t, statusFile)
-	})
-
-	t.Run("NoEnvVariable", func(t *testing.T) {
-		t.Setenv("GCSFUSE_STATUS_FD", "")
-
-		teardown := setStatusFileForTesting(nil)
-		defer teardown()
-
-		InitStatusReporter(true)
-
-		assert.Nil(t, statusFile)
-	})
-
-	t.Run("InvalidFDInEnv", func(t *testing.T) {
-		t.Setenv("GCSFUSE_STATUS_FD", "invalid_fd")
-
-		teardown := setStatusFileForTesting(nil)
-		defer teardown()
-
-		InitStatusReporter(true)
-
-		assert.Nil(t, statusFile)
-	})
-
-	t.Run("ValidPipeForeground", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		t.Setenv("GCSFUSE_STATUS_FD", strconv.FormatUint(uint64(w.Fd()), 10))
-
-		teardown := setStatusFileForTesting(nil)
-		defer teardown()
-
-		InitStatusReporter(true)
-
-		require.NotNil(t, statusFile)
-		assert.Equal(t, w.Fd(), statusFile.Fd())
-	})
-
-	t.Run("AlreadyInitialized", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		teardown := setStatusFileForTesting(w)
-		defer teardown()
-
-		InitStatusReporter(true)
-
-		assert.Equal(t, w, statusFile)
-	})
-}
-
-func TestReportStatus(t *testing.T) {
-	t.Run("StatusFileNil", func(t *testing.T) {
-		teardown := setStatusFileForTesting(nil)
-		defer teardown()
-
-		// Should safely return without panic.
-		ReportStatus(codes.OK, "no-op message")
-	})
-
-	t.Run("ReportError", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		teardown := setStatusFileForTesting(w)
-		defer teardown()
-
-		ReportStatus(codes.PermissionDenied, "Waiting for IAM permissions")
-
-		decoder := json.NewDecoder(r)
-		var payload StatusPayload
-		err = decoder.Decode(&payload)
-		require.NoError(t, err)
-
-		assert.Equal(t, codes.PermissionDenied, payload.Status)
-		assert.Equal(t, "Waiting for IAM permissions", payload.Error)
-	})
-
-	t.Run("ReportOK", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		defer func() { _ = r.Close() }()
-		defer func() { _ = w.Close() }()
-
-		teardown := setStatusFileForTesting(w)
-		defer teardown()
-
-		ReportStatus(codes.OK, "File system has been successfully mounted.")
-
-		decoder := json.NewDecoder(r)
-		var payload StatusPayload
-		err = decoder.Decode(&payload)
-		require.NoError(t, err)
-
-		assert.Equal(t, codes.OK, payload.Status)
-		assert.Equal(t, "File system has been successfully mounted.", payload.Error)
-	})
-
-	t.Run("WriteErrorOnClosedPipe", func(t *testing.T) {
-		r, w, err := os.Pipe()
-		require.NoError(t, err)
-		_ = r.Close()
-		_ = w.Close()
-
-		teardown := setStatusFileForTesting(w)
-		defer teardown()
-
-		// Writing to closed pipe should log warning and not panic.
-		ReportStatus(codes.OK, "msg to closed pipe")
-	})
-}
-
-func TestReportStatus_ConcurrentSafety(t *testing.T) {
+func TestOpenStatusPipe_ValidNamedPipe(t *testing.T) {
 	r, w, err := os.Pipe()
 	require.NoError(t, err)
 	defer func() { _ = r.Close() }()
 	defer func() { _ = w.Close() }()
 
+	f, err := openStatusPipe(strconv.Itoa(int(w.Fd())))
+
+	require.NoError(t, err)
+	require.NotNil(t, f)
+	defer func() { _ = f.Close() }()
+	assert.Equal(t, w.Fd(), f.Fd())
+}
+
+func TestOpenStatusPipe_InvalidFDString(t *testing.T) {
+	f, err := openStatusPipe("not-an-int")
+
+	assert.Error(t, err)
+	assert.Nil(t, f)
+}
+
+func TestInitStatusReporter_NotForeground(t *testing.T) {
+	teardown := setStatusFileForTesting(nil)
+	defer teardown()
+
+	InitStatusReporter(false)
+
+	assert.Nil(t, statusFile)
+}
+
+func TestInitStatusReporter_NoEnvVariable(t *testing.T) {
+	t.Setenv("GCSFUSE_STATUS_FD", "")
+	teardown := setStatusFileForTesting(nil)
+	defer teardown()
+
+	InitStatusReporter(true)
+
+	assert.Nil(t, statusFile)
+}
+
+func TestInitStatusReporter_InvalidFDInEnv(t *testing.T) {
+	t.Setenv("GCSFUSE_STATUS_FD", "invalid_fd")
+	teardown := setStatusFileForTesting(nil)
+	defer teardown()
+
+	InitStatusReporter(true)
+
+	assert.Nil(t, statusFile)
+}
+
+func TestInitStatusReporter_ValidPipeForeground(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+	t.Setenv("GCSFUSE_STATUS_FD", strconv.Itoa(int(w.Fd())))
+	teardown := setStatusFileForTesting(nil)
+	defer func() {
+		if statusFile != nil {
+			_ = statusFile.Close()
+		}
+		teardown()
+	}()
+
+	InitStatusReporter(true)
+
+	require.NotNil(t, statusFile)
+	assert.Equal(t, w.Fd(), statusFile.Fd())
+}
+
+func TestInitStatusReporter_AlreadyInitialized(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
 	teardown := setStatusFileForTesting(w)
 	defer teardown()
 
-	const numGoroutines = 20
-	var wg sync.WaitGroup
+	InitStatusReporter(true)
 
-	for i := 0; i < numGoroutines; i++ {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-			ReportStatus(codes.Code(idx%17), fmt.Sprintf("status message %d", idx))
-		}(i)
-	}
+	assert.Equal(t, w, statusFile)
+}
 
-	wg.Wait()
-	_ = w.Close()
+func TestReportStatus_NilStatusFile(t *testing.T) {
+	teardown := setStatusFileForTesting(nil)
+	defer teardown()
+
+	ReportStatus(codes.OK, "no-op message")
+}
+
+func TestReportStatus_ReportPayload(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+	teardown := setStatusFileForTesting(w)
+	defer teardown()
+
+	ReportStatus(codes.PermissionDenied, "Waiting for IAM permissions")
 
 	decoder := json.NewDecoder(r)
-	count := 0
-	for {
-		var payload StatusPayload
-		if err := decoder.Decode(&payload); err != nil {
-			if err == io.EOF {
-				break
-			}
-			t.Fatalf("JSON decode error on line %d: %v", count+1, err)
-		}
-		count++
-	}
-
-	assert.Equal(t, numGoroutines, count)
+	var payload StatusPayload
+	err = decoder.Decode(&payload)
+	require.NoError(t, err)
+	assert.Equal(t, codes.PermissionDenied, payload.Status)
+	assert.Equal(t, "Waiting for IAM permissions", payload.Error)
 }

--- a/internal/mountstatus/status_test.go
+++ b/internal/mountstatus/status_test.go
@@ -1,0 +1,261 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mountstatus
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+)
+
+func setStatusFileForTesting(f *os.File) func() {
+	old := statusFile
+	statusFile = f
+
+	return func() {
+		statusFile = old
+	}
+}
+
+func TestOpenStatusPipe(t *testing.T) {
+	t.Run("ValidNamedPipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		f, err := openStatusPipe(strconv.FormatUint(uint64(w.Fd()), 10))
+		require.NoError(t, err)
+		require.NotNil(t, f)
+		assert.Equal(t, w.Fd(), f.Fd())
+	})
+
+	t.Run("InvalidFDString", func(t *testing.T) {
+		f, err := openStatusPipe("not-an-int")
+		assert.Error(t, err)
+		assert.Nil(t, f)
+	})
+
+	t.Run("NegativeFD", func(t *testing.T) {
+		f, err := openStatusPipe("-5")
+		assert.Error(t, err)
+		assert.Nil(t, f)
+	})
+
+	t.Run("NonPipeFile", func(t *testing.T) {
+		tmpFile, err := os.CreateTemp("", "regular_file")
+		require.NoError(t, err)
+		defer func() { _ = os.Remove(tmpFile.Name()) }()
+		defer func() { _ = tmpFile.Close() }()
+
+		f, err := openStatusPipe(strconv.FormatUint(uint64(tmpFile.Fd()), 10))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "descriptor is not a named pipe")
+		assert.Nil(t, f)
+	})
+
+	t.Run("ReadOnlyPipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		f, err := openStatusPipe(strconv.FormatUint(uint64(r.Fd()), 10))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "descriptor is not open for writing")
+		assert.Nil(t, f)
+	})
+}
+
+func TestInitStatusReporter(t *testing.T) {
+	t.Run("NotForeground", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		t.Setenv("GCSFUSE_STATUS_FD", strconv.FormatUint(uint64(w.Fd()), 10))
+
+		teardown := setStatusFileForTesting(nil)
+		defer teardown()
+
+		InitStatusReporter(false)
+
+		assert.Nil(t, statusFile)
+	})
+
+	t.Run("NoEnvVariable", func(t *testing.T) {
+		t.Setenv("GCSFUSE_STATUS_FD", "")
+
+		teardown := setStatusFileForTesting(nil)
+		defer teardown()
+
+		InitStatusReporter(true)
+
+		assert.Nil(t, statusFile)
+	})
+
+	t.Run("InvalidFDInEnv", func(t *testing.T) {
+		t.Setenv("GCSFUSE_STATUS_FD", "invalid_fd")
+
+		teardown := setStatusFileForTesting(nil)
+		defer teardown()
+
+		InitStatusReporter(true)
+
+		assert.Nil(t, statusFile)
+	})
+
+	t.Run("ValidPipeForeground", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		t.Setenv("GCSFUSE_STATUS_FD", strconv.FormatUint(uint64(w.Fd()), 10))
+
+		teardown := setStatusFileForTesting(nil)
+		defer teardown()
+
+		InitStatusReporter(true)
+
+		require.NotNil(t, statusFile)
+		assert.Equal(t, w.Fd(), statusFile.Fd())
+	})
+
+	t.Run("AlreadyInitialized", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		teardown := setStatusFileForTesting(w)
+		defer teardown()
+
+		InitStatusReporter(true)
+
+		assert.Equal(t, w, statusFile)
+	})
+}
+
+func TestReportStatus(t *testing.T) {
+	t.Run("StatusFileNil", func(t *testing.T) {
+		teardown := setStatusFileForTesting(nil)
+		defer teardown()
+
+		// Should safely return without panic.
+		ReportStatus(codes.OK, "no-op message")
+	})
+
+	t.Run("ReportError", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		teardown := setStatusFileForTesting(w)
+		defer teardown()
+
+		ReportStatus(codes.PermissionDenied, "Waiting for IAM permissions")
+
+		decoder := json.NewDecoder(r)
+		var payload StatusPayload
+		err = decoder.Decode(&payload)
+		require.NoError(t, err)
+
+		assert.Equal(t, codes.PermissionDenied, payload.Status)
+		assert.Equal(t, "Waiting for IAM permissions", payload.Error)
+	})
+
+	t.Run("ReportOK", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		defer func() { _ = r.Close() }()
+		defer func() { _ = w.Close() }()
+
+		teardown := setStatusFileForTesting(w)
+		defer teardown()
+
+		ReportStatus(codes.OK, "File system has been successfully mounted.")
+
+		decoder := json.NewDecoder(r)
+		var payload StatusPayload
+		err = decoder.Decode(&payload)
+		require.NoError(t, err)
+
+		assert.Equal(t, codes.OK, payload.Status)
+		assert.Equal(t, "File system has been successfully mounted.", payload.Error)
+	})
+
+	t.Run("WriteErrorOnClosedPipe", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		_ = r.Close()
+		_ = w.Close()
+
+		teardown := setStatusFileForTesting(w)
+		defer teardown()
+
+		// Writing to closed pipe should log warning and not panic.
+		ReportStatus(codes.OK, "msg to closed pipe")
+	})
+}
+
+func TestReportStatus_ConcurrentSafety(t *testing.T) {
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	defer func() { _ = r.Close() }()
+	defer func() { _ = w.Close() }()
+
+	teardown := setStatusFileForTesting(w)
+	defer teardown()
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			ReportStatus(codes.Code(idx%17), fmt.Sprintf("status message %d", idx))
+		}(i)
+	}
+
+	wg.Wait()
+	_ = w.Close()
+
+	decoder := json.NewDecoder(r)
+	count := 0
+	for {
+		var payload StatusPayload
+		if err := decoder.Decode(&payload); err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("JSON decode error on line %d: %v", count+1, err)
+		}
+		count++
+	}
+
+	assert.Equal(t, numGoroutines, count)
+}

--- a/internal/storage/storageutil/custom_retry.go
+++ b/internal/storage/storageutil/custom_retry.go
@@ -23,6 +23,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"cloud.google.com/go/storage"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/logger"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/mountstatus"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"golang.org/x/oauth2"
 	"google.golang.org/api/googleapi"
@@ -175,5 +176,14 @@ func ShouldRetryWithMonitoringAndRetryContext(
 // ShouldRetryOnMount checks if the error is retryable during mount initialization.
 // In addition to standard transient errors, it retries HTTP 403/404 and gRPC PermissionDenied/NotFound errors.
 func ShouldRetryOnMount(err error) bool {
-	return determineRetryAction(err) != noRetry
+	action := determineRetryAction(err)
+
+	switch action {
+	case retry403, retryPermissionDenied:
+		mountstatus.ReportStatus(codes.PermissionDenied, err.Error())
+	case retry404BucketDoesNotExist, retryNotFoundBucketDoesNotExist:
+		mountstatus.ReportStatus(codes.NotFound, err.Error())
+	}
+
+	return action != noRetry
 }


### PR DESCRIPTION
### Description
- Implement mount status reporting subsystem in `internal/mountstatus` to communicate mount status to CSI sidecar over a named pipe specified via `GCSFUSE_STATUS_FD`.
- Report mount success (`codes.OK`) and mount failure classifications (`codes.PermissionDenied`, `codes.NotFound`).

### Link to the issue in case of a bug fix.
b/545400301

### Testing details
1. Manual - Verified build and diff against master.
2. Unit tests - Ran storageutil unit tests.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No