### PR TITLE
fix: Setting expires field explicitly based on expiresIn

### DIFF
--- a/internal/auth/token_source.go
+++ b/internal/auth/token_source.go
@@ -22,6 +22,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"time"
 
 	"golang.org/x/oauth2"
 )
@@ -116,6 +117,10 @@ func (ts proxyTokenSource) Token() (token *oauth2.Token, err error) {
 	if err != nil {
 		err = fmt.Errorf("proxyTokenSource cannot decode body: %w", err)
 		return nil, err
+	}
+
+	if token.ExpiresIn != 0 && token.Expiry.IsZero() {
+		token.Expiry = time.Now().Add(time.Duration(token.ExpiresIn) * time.Second)
 	}
 
 	return token, nil

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -231,7 +231,6 @@ func TestProxyTokenSource_ExpiresInPopulatesExpiry_Success(t *testing.T) {
 
 	assert.Equal(t, "token-123", token.AccessToken)
 	assert.Equal(t, "Bearer", token.TokenType)
-	assert.Equal(t, int64(3600), token.ExpiresIn)
 	assert.False(t, token.Expiry.IsZero(), "token.Expiry must be populated from expires_in")
 	assert.True(t, token.Expiry.After(before.Add(3595*time.Second)))
 	assert.True(t, token.Expiry.Before(after.Add(3605*time.Second)))

--- a/internal/auth/token_source_test.go
+++ b/internal/auth/token_source_test.go
@@ -22,7 +22,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,8 +41,74 @@ func tokenHandler(accessToken string) http.HandlerFunc {
 	}
 }
 
+// Helper: startFakeTCPTokenServer creates an HTTP test server returning a standard token.
 func startFakeTCPTokenServer(accessToken string) *httptest.Server {
 	return httptest.NewServer(tokenHandler(accessToken))
+}
+
+// Helper: startFakeJSONTokenServer creates an HTTP test server returning raw JSON.
+func startFakeJSONTokenServer(responseJSON string) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(responseJSON))
+	}))
+}
+
+// Helper: fetchTokenFromJSON starts a mock server with raw JSON, creates a TokenSource, and fetches the token.
+func fetchTokenFromJSON(t *testing.T, responseJSON string) *oauth2.Token {
+	server := startFakeJSONTokenServer(responseJSON)
+	defer server.Close()
+
+	ts, err := NewTokenSourceFromURL(context.Background(), server.URL, false)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	token, err := ts.Token()
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	return token
+}
+
+// Helper: createTempUnixSocket creates a temporary Unix domain socket and registers automatic cleanup with t.Cleanup.
+func createTempUnixSocket(t *testing.T) (string, net.Listener) {
+	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
+	require.NoError(t, err)
+	socketPath := tmpFile.Name()
+	require.NoError(t, tmpFile.Close())
+	require.NoError(t, os.Remove(socketPath))
+
+	listener, err := net.Listen("unix", socketPath)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		_ = listener.Close()
+		_ = os.Remove(socketPath)
+	})
+
+	return socketPath, listener
+}
+
+// Helper: startUDSServer runs an HTTP server over a Unix domain socket listener with automatic cleanup.
+func startUDSServer(t *testing.T, listener net.Listener, handler http.Handler) *http.Server {
+	server := &http.Server{Handler: handler}
+	go func() {
+		_ = server.Serve(listener)
+	}()
+	t.Cleanup(func() {
+		_ = server.Close()
+	})
+	return server
+}
+
+// Helper: startFakeUDSTokenServer runs a UDS server asserting path, query, and host expectations.
+func startFakeUDSTokenServer(t *testing.T, listener net.Listener, expectedEscapedPath, expectedQuery, accessToken string) *http.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, expectedEscapedPath, r.URL.EscapedPath())
+		assert.Equal(t, expectedQuery, r.URL.RawQuery)
+		assert.Equal(t, "unix", r.Host)
+		tokenHandler(accessToken)(w, r)
+	})
+	return startUDSServer(t, listener, handler)
 }
 
 func Test_NewTokenSourceFromURL_Success(t *testing.T) {
@@ -98,40 +166,13 @@ func TestProxyTokenSource_TokenFetch_InvalidJSON(t *testing.T) {
 	assert.Nil(t, token)
 }
 
-func startFakeUDSTokenServer(t *testing.T, listener net.Listener, expectedEscapedPath, expectedQuery, accessToken string) *http.Server {
-	server := &http.Server{
-		Handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			assert.Equal(t, expectedEscapedPath, r.URL.EscapedPath())
-			assert.Equal(t, expectedQuery, r.URL.RawQuery)
-			assert.Equal(t, "unix", r.Host)
-			tokenHandler(accessToken)(w, r)
-		}),
-	}
-	go func() {
-		_ = server.Serve(listener)
-	}()
-	return server
-}
-
 func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_Success(t *testing.T) {
-	// Create a temp file for the socket.
-	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
-	require.NoError(t, err)
-	socketPath := tmpFile.Name()
-	require.NoError(t, tmpFile.Close())
-	require.NoError(t, os.Remove(socketPath)) // remove it so net.Listen can create it
-	defer func() { _ = os.Remove(socketPath) }()
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer func() { _ = listener.Close() }()
-
+	socketPath, listener := createTempUnixSocket(t)
 	expectedEscapedPath := "/computeMetadata/v1/instance/service-accounts/default/token"
 	expectedQuery := "foo=bar&baz=qux"
 	accessToken := "uds-access-token"
 
-	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
-	defer func() { _ = server.Close() }()
+	startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
 
 	// unix:///path/to/socket#/http_path?query
 	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedEscapedPath, expectedQuery)
@@ -145,24 +186,13 @@ func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_Success(t *testing.T) {
 }
 
 func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_EscapedChars_Success(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
-	require.NoError(t, err)
-	socketPath := tmpFile.Name()
-	require.NoError(t, tmpFile.Close())
-	require.NoError(t, os.Remove(socketPath))
-	defer func() { _ = os.Remove(socketPath) }()
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer func() { _ = listener.Close() }()
-
+	socketPath, listener := createTempUnixSocket(t)
 	// Path contains escaped slash (%2F) and query contains escaped space (%20)
 	expectedEscapedPath := "/computeMetadata%2Fv1%2Finstance%2Fservice-accounts%2Fdefault%2Ftoken"
 	expectedQuery := "foo=bar%20baz"
 	accessToken := "uds-access-token-escaped"
 
-	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
-	defer func() { _ = server.Close() }()
+	startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
 
 	tokenURL := fmt.Sprintf("unix://%s#%s?%s", socketPath, expectedEscapedPath, expectedQuery)
 	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
@@ -175,23 +205,12 @@ func Test_NewTokenSourceFromURL_UnixSocket_WithFragment_EscapedChars_Success(t *
 }
 
 func Test_NewTokenSourceFromURL_UnixSocket_BackwardCompatibility_Success(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "gcsfuse-uds-test-*.sock")
-	require.NoError(t, err)
-	socketPath := tmpFile.Name()
-	require.NoError(t, tmpFile.Close())
-	require.NoError(t, os.Remove(socketPath))
-	defer func() { _ = os.Remove(socketPath) }()
-
-	listener, err := net.Listen("unix", socketPath)
-	require.NoError(t, err)
-	defer func() { _ = listener.Close() }()
-
+	socketPath, listener := createTempUnixSocket(t)
 	expectedEscapedPath := "/"
 	expectedQuery := "foo=bar"
 	accessToken := "uds-access-token-compat"
 
-	server := startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
-	defer func() { _ = server.Close() }()
+	startFakeUDSTokenServer(t, listener, expectedEscapedPath, expectedQuery, accessToken)
 
 	// unix:///path/to/socket?query (old way, but with query)
 	tokenURL := fmt.Sprintf("unix://%s?%s", socketPath, expectedQuery)
@@ -202,4 +221,93 @@ func Test_NewTokenSourceFromURL_UnixSocket_BackwardCompatibility_Success(t *test
 	token, err := ts.Token()
 	assert.NoError(t, err)
 	assert.Equal(t, accessToken, token.AccessToken)
+}
+
+func TestProxyTokenSource_ExpiresInPopulatesExpiry_Success(t *testing.T) {
+	before := time.Now()
+	// Standard RFC 6749 response (expires_in only, no Go-specific expiry field)
+	token := fetchTokenFromJSON(t, `{"access_token":"token-123","token_type":"Bearer","expires_in":3600}`)
+	after := time.Now()
+
+	assert.Equal(t, "token-123", token.AccessToken)
+	assert.Equal(t, "Bearer", token.TokenType)
+	assert.Equal(t, int64(3600), token.ExpiresIn)
+	assert.False(t, token.Expiry.IsZero(), "token.Expiry must be populated from expires_in")
+	assert.True(t, token.Expiry.After(before.Add(3595*time.Second)))
+	assert.True(t, token.Expiry.Before(after.Add(3605*time.Second)))
+	assert.True(t, token.Valid())
+}
+
+func TestProxyTokenSource_ExplicitExpiryPreserved_Success(t *testing.T) {
+	// Response with both explicit expiry timestamp and expires_in
+	token := fetchTokenFromJSON(t, `{"access_token":"token-456","token_type":"Bearer","expires_in":3600,"expiry":"2035-01-01T00:00:00Z"}`)
+
+	expectedExpiry, _ := time.Parse(time.RFC3339, "2035-01-01T00:00:00Z")
+	assert.Equal(t, expectedExpiry, token.Expiry, "explicit expiry field must not be overwritten")
+}
+
+func TestProxyTokenSource_ZeroExpiresIn_ExpiryRemainsZero(t *testing.T) {
+	token := fetchTokenFromJSON(t, `{"access_token":"token-no-expiry","token_type":"Bearer"}`)
+
+	assert.True(t, token.Expiry.IsZero(), "token.Expiry should remain zero when expires_in is 0")
+}
+
+func TestProxyTokenSource_TokenRefresh_WithReuseTokenSource(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&requestCount, 1)
+		w.Header().Set("Content-Type", "application/json")
+		// oauth2.ReuseTokenSource has a 10-second safety window (expiryDelta = 10s).
+		// Setting expires_in = 12 allows the token to remain valid for 2 seconds.
+		resp := fmt.Sprintf(`{"access_token":"token-%d","token_type":"Bearer","expires_in":12}`, count)
+		_, _ = w.Write([]byte(resp))
+	}))
+	defer server.Close()
+
+	// reuseTokenFromUrl = true enables oauth2.ReuseTokenSource
+	ts, err := NewTokenSourceFromURL(context.Background(), server.URL, true)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	// 1. Initial fetch
+	token1, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-1", token1.AccessToken)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount))
+
+	// 2. Fetch immediately -> Should return cached token (no new HTTP request)
+	tokenCached, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-1", tokenCached.AccessToken)
+	assert.Equal(t, int32(1), atomic.LoadInt32(&requestCount), "HTTP server should not be called while token is valid")
+
+	// 3. Wait past the 2-second validity window (12s - 10s delta = 2s)
+	time.Sleep(2500 * time.Millisecond)
+
+	// 4. Fetch after expiry -> ReuseTokenSource should detect expiry and fetch fresh token
+	token2, err := ts.Token()
+	require.NoError(t, err)
+	assert.Equal(t, "token-2", token2.AccessToken)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&requestCount), "HTTP server must be called when token expires")
+}
+
+func Test_NewTokenSourceFromURL_UnixSocket_ExpiresInPopulatesExpiry(t *testing.T) {
+	socketPath, listener := createTempUnixSocket(t)
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"uds-token-rfc","token_type":"Bearer","expires_in":1800}`))
+	})
+	startUDSServer(t, listener, handler)
+
+	tokenURL := fmt.Sprintf("unix://%s#/computeMetadata/v1/instance/service-accounts/default/token", socketPath)
+	ts, err := NewTokenSourceFromURL(context.Background(), tokenURL, false)
+	require.NoError(t, err)
+	require.NotNil(t, ts)
+
+	token, err := ts.Token()
+	assert.NoError(t, err)
+	require.NotNil(t, token)
+	assert.Equal(t, "uds-token-rfc", token.AccessToken)
+	assert.False(t, token.Expiry.IsZero())
+	assert.True(t, time.Until(token.Expiry) > 1700*time.Second)
 }


### PR DESCRIPTION
go auth2 library populates expiry field based on expiresIn. Since GCSFuse is doing custom unmarshalling we need to explicitly populate it to handle scenarios where the token only has expiresIn field set.
https://github.com/golang/oauth2/blob/master/internal/token.go#L79
bug fix: https://buganizer.corp.google.com/u/1/issues/543949965

### Testing details
1. Manual - Done
2. Unit tests - Added
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
