### PR TITLE
fix(locker): resolve data race by removing holder struct field

### DIFF
--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -98,7 +98,6 @@ func (c *checker) Unlock() {
 type debugger struct {
 	locker Locker
 	name   string
-	holder string
 	timer  *time.Timer
 }
 
@@ -107,15 +106,14 @@ func (d *debugger) Lock() {
 
 	buf := make([]byte, 2048)
 	runtime.Stack(buf, false /* all */)
-	d.holder = string(buf)
+	holder := string(buf)
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
-		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
+		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, holder)
 	})
 }
 
 func (d *debugger) Unlock() {
-	d.holder = ""
 	d.timer.Stop()
 	d.timer = nil
 

--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -114,8 +114,10 @@ func (d *debugger) Lock() {
 }
 
 func (d *debugger) Unlock() {
-	d.timer.Stop()
-	d.timer = nil
+	if d.timer != nil {
+		d.timer.Stop()
+		d.timer = nil
+	}
 
 	d.locker.Unlock()
 }

--- a/internal/locker/locker.go
+++ b/internal/locker/locker.go
@@ -105,8 +105,9 @@ func (d *debugger) Lock() {
 	d.locker.Lock()
 
 	buf := make([]byte, 2048)
-	runtime.Stack(buf, false /* all */)
-	holder := string(buf)
+	n := runtime.Stack(buf, false /* all */)
+	// Use only the bytes written to the buffer to avoid uninitialized values in the string.
+	holder := string(buf[:n])
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
 		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, holder)

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -100,8 +100,9 @@ func (d *rwDebugger) Lock() {
 	d.locker.Lock()
 
 	buf := make([]byte, 2048)
-	runtime.Stack(buf, false /* all */)
-	holder := string(buf)
+	n := runtime.Stack(buf, false /* all */)
+	// Use only the bytes written to the buffer to avoid uninitialized values in the string.
+	holder := string(buf[:n])
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
 		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, holder)

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -109,8 +109,10 @@ func (d *rwDebugger) Lock() {
 }
 
 func (d *rwDebugger) Unlock() {
-	d.timer.Stop()
-	d.timer = nil
+	if d.timer != nil {
+		d.timer.Stop()
+		d.timer = nil
+	}
 
 	d.locker.Unlock()
 }

--- a/internal/locker/rw_locker.go
+++ b/internal/locker/rw_locker.go
@@ -93,7 +93,6 @@ func (c *rwChecker) RUnlock() {
 type rwDebugger struct {
 	locker RWLocker
 	name   string
-	holder string
 	timer  *time.Timer
 }
 
@@ -102,15 +101,14 @@ func (d *rwDebugger) Lock() {
 
 	buf := make([]byte, 2048)
 	runtime.Stack(buf, false /* all */)
-	d.holder = string(buf)
+	holder := string(buf)
 
 	d.timer = time.AfterFunc(5*time.Second, func() {
-		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, d.holder)
+		logger.Tracef("debug_mutex: Potential dead lock detected for a lock %q held by: %v\n", d.name, holder)
 	})
 }
 
 func (d *rwDebugger) Unlock() {
-	d.holder = ""
 	d.timer.Stop()
 	d.timer = nil
 


### PR DESCRIPTION
### Description
This PR fixes a data race condition in the deadlock detection logic of the `locker` and `rw_locker` packages.

**Root Cause:**
When a lock was held for exactly 5 seconds, the `time.AfterFunc` background timer would fire to log a deadlock warning. This background goroutine read the `holder` string from the `debugger` struct at the exact same time the main goroutine cleared it (`d.holder = ""`) inside the `Unlock()` method. This concurrent read and write to the same memory address without synchronization resulted in a data race.

**Fix:**
* Removed the `holder` struct field from the `debugger` and `rwDebugger` types since it wasn't needed.
* In `Lock()`, captured the stack trace into a local, immutable `holder` variable and passed it into the closure for the background timer, ensuring thread-safe access.
* Added a `nil` check for the timer cleanup in `Unlock()` to prevent nil pointer panics and preserve the standard library's `"sync: unlock of unlocked mutex"` panic message when unlocking an uninitialized locker.


### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.