### PR TITLE
fix(caching): only cache negative entries from authoritative listings

### DIFF
--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -115,6 +115,15 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 	}
 }
 
+// isAuthoritativeListing returns true if the listing represents a complete,
+// un-windowed, and non-paginated view of the entire requested prefix.
+func isAuthoritativeListing(req *gcs.ListObjectsRequest, listing *gcs.Listing) bool {
+	if req == nil || listing == nil {
+		return false
+	}
+	return req.StartOffset == "" && req.ContinuationToken == "" && listing.ContinuationToken == ""
+}
+
 // LOCKS_EXCLUDED(b.mu)
 // insertListing caches all objects and sub-directories discovered during a GCS listing.
 // It explicitly handles the "implicit directory" edge case where a directory exists
@@ -155,17 +164,13 @@ func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing
 	// If enableEmptyManagedFolders is true, do not negatively cache empty directories,
 	// otherwise existing positive entries for valid empty managed folders get overwritten.
 	//
-	// An empty listing proves the directory doesn't exist only when it is
-	// authoritative for the whole prefix: a windowed listing (StartOffset or
-	// ContinuationToken set on the request) covers a slice of the namespace, and
-	// an empty page that carries a continuation token is an incomplete listing.
-	// Caching a negative entry from such a listing would overwrite a valid
-	// positive entry and serve ENOENT for the entire subtree until the negative
-	// TTL expires.
+	// Only an authoritative listing proves the directory doesn't exist: caching
+	// a negative entry from a windowed or paginated listing would overwrite a
+	// valid positive entry and serve ENOENT for the entire subtree until the
+	// negative TTL expires.
 	isNegativeCacheEnabled := b.negativeCacheTTL > 0 && !b.enableEmptyManagedFolders
 	isEmptyNonRootDir := !dirHasContents && dirName != ""
-	isAuthoritativeListing := req.StartOffset == "" && req.ContinuationToken == "" && listing.ContinuationToken == ""
-	if isNegativeCacheEnabled && isEmptyNonRootDir && isAuthoritativeListing {
+	if isNegativeCacheEnabled && isEmptyNonRootDir && isAuthoritativeListing(req, listing) {
 		b.cache.AddNegativeEntry(dirName, b.clock.Now().Add(b.negativeCacheTTL))
 	}
 

--- a/internal/storage/caching/fast_stat_bucket.go
+++ b/internal/storage/caching/fast_stat_bucket.go
@@ -119,7 +119,7 @@ func (b *fastStatBucket) insertMultiple(objs []*gcs.Object) {
 // insertListing caches all objects and sub-directories discovered during a GCS listing.
 // It explicitly handles the "implicit directory" edge case where a directory exists
 // only as a prefix to other objects.
-func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing, dirName string) {
+func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing, req *gcs.ListObjectsRequest) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
@@ -129,6 +129,7 @@ func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing
 		return
 	}
 
+	dirName := req.Prefix
 	expiration := b.clock.Now().Add(b.primaryCacheTTL)
 
 	// 1. Parent Directory Inference (Implicit Check)
@@ -153,9 +154,18 @@ func (b *fastStatBucket) insertListing(ctx context.Context, listing *gcs.Listing
 	// Negative Cache (Only if it's a directory and there are NO contents)
 	// If enableEmptyManagedFolders is true, do not negatively cache empty directories,
 	// otherwise existing positive entries for valid empty managed folders get overwritten.
+	//
+	// An empty listing proves the directory doesn't exist only when it is
+	// authoritative for the whole prefix: a windowed listing (StartOffset or
+	// ContinuationToken set on the request) covers a slice of the namespace, and
+	// an empty page that carries a continuation token is an incomplete listing.
+	// Caching a negative entry from such a listing would overwrite a valid
+	// positive entry and serve ENOENT for the entire subtree until the negative
+	// TTL expires.
 	isNegativeCacheEnabled := b.negativeCacheTTL > 0 && !b.enableEmptyManagedFolders
 	isEmptyNonRootDir := !dirHasContents && dirName != ""
-	if isNegativeCacheEnabled && isEmptyNonRootDir {
+	isAuthoritativeListing := req.StartOffset == "" && req.ContinuationToken == "" && listing.ContinuationToken == ""
+	if isNegativeCacheEnabled && isEmptyNonRootDir && isAuthoritativeListing {
 		b.cache.AddNegativeEntry(dirName, b.clock.Now().Add(b.negativeCacheTTL))
 	}
 
@@ -474,7 +484,7 @@ func (b *fastStatBucket) ListObjects(
 	}
 
 	if b.isTypeCacheDeprecated {
-		b.insertListing(ctx, listing, req.Prefix)
+		b.insertListing(ctx, listing, req)
 	} else {
 		// note anything we found.
 		b.insertMultipleMinObjects(ctx, listing.MinObjects)

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -1062,6 +1062,33 @@ func (t *ListObjectsTest_InsertListing) EmptyPageWithResponseContinuationTokenDo
 	t.callAndVerifyWithRequest(context.TODO(), false, listing, req, nil, nil, false)
 }
 
+// A non-empty windowed listing (StartOffset set) must insert the returned
+// objects and still infer the parent implicit directory.
+func (t *ListObjectsTest_InsertListing) NonEmptyListingWithStartOffsetInsertsPositiveEntries() {
+	listing := &gcs.Listing{
+		MinObjects: []*gcs.MinObject{
+			{Name: "dir/c", Size: 10},
+		},
+	}
+	req := &gcs.ListObjectsRequest{
+		Prefix:      "dir/",
+		StartOffset: "dir/b",
+	}
+	expectedInserts := []*gcs.MinObject{
+		{Name: "dir/c", Size: 10},
+	}
+	expectedImplicitDirs := []string{"dir/"}
+	t.callAndVerifyWithRequest(
+		context.TODO(),
+		false, // isHNS
+		listing,
+		req,
+		expectedInserts,
+		expectedImplicitDirs,
+		false, // expectNegativeEntry
+	)
+}
+
 func (t *ListObjectsTest_InsertListing) EmptyListing() {
 	listing := &gcs.Listing{}
 	expectedInserts := []*gcs.MinObject{}

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -1078,6 +1078,7 @@ func (t *ListObjectsTest_InsertListing) NonEmptyListingWithStartOffsetInsertsPos
 		{Name: "dir/c", Size: 10},
 	}
 	expectedImplicitDirs := []string{"dir/"}
+
 	t.callAndVerifyWithRequest(
 		context.TODO(),
 		false, // isHNS

--- a/internal/storage/caching/fast_stat_bucket_test.go
+++ b/internal/storage/caching/fast_stat_bucket_test.go
@@ -1007,6 +1007,11 @@ func (t *ListObjectsTest_InsertListing) SetUp(ti *TestInfo) {
 }
 
 func (t *ListObjectsTest_InsertListing) callAndVerify(ctx context.Context, isHNS bool, listing *gcs.Listing, prefix string, expectedInserts []*gcs.MinObject, expectedImplicitDirs []string) {
+	expectNegativeEntry := len(listing.MinObjects) == 0 && len(listing.CollapsedRuns) == 0 && prefix != "" && listing.ContinuationToken == ""
+	t.callAndVerifyWithRequest(ctx, isHNS, listing, &gcs.ListObjectsRequest{Prefix: prefix}, expectedInserts, expectedImplicitDirs, expectNegativeEntry)
+}
+
+func (t *ListObjectsTest_InsertListing) callAndVerifyWithRequest(ctx context.Context, isHNS bool, listing *gcs.Listing, req *gcs.ListObjectsRequest, expectedInserts []*gcs.MinObject, expectedImplicitDirs []string, expectNegativeEntry bool) {
 	// Wrapped
 	ExpectCall(t.wrapped, "BucketType")().
 		WillOnce(Return(gcs.BucketType{Hierarchical: isHNS}))
@@ -1019,15 +1024,42 @@ func (t *ListObjectsTest_InsertListing) callAndVerify(ctx context.Context, isHNS
 	for _, dir := range expectedImplicitDirs {
 		ExpectCall(t.cache, "InsertImplicitDir")(dir, Any())
 	}
-	if len(listing.MinObjects) == 0 && len(listing.CollapsedRuns) == 0 && prefix != "" {
-		ExpectCall(t.cache, "AddNegativeEntry")(prefix, Any())
+	if expectNegativeEntry {
+		ExpectCall(t.cache, "AddNegativeEntry")(req.Prefix, Any())
 	}
 
 	// Call
-	gotListing, err := t.bucket.ListObjects(ctx, &gcs.ListObjectsRequest{Prefix: prefix})
+	gotListing, err := t.bucket.ListObjects(ctx, req)
 
 	AssertEq(nil, err)
 	AssertEq(listing, gotListing)
+}
+
+// An empty windowed listing (StartOffset set) covers only a slice of the
+// namespace and must not produce a negative entry for the directory.
+func (t *ListObjectsTest_InsertListing) EmptyListingWithStartOffsetDoesNotCacheNegativeEntry() {
+	listing := &gcs.Listing{}
+	req := &gcs.ListObjectsRequest{Prefix: "dir/", StartOffset: "dir/zzz"}
+
+	t.callAndVerifyWithRequest(context.TODO(), false, listing, req, nil, nil, false)
+}
+
+// An empty continuation page proves nothing about the prefix as a whole and
+// must not produce a negative entry for the directory.
+func (t *ListObjectsTest_InsertListing) EmptyListingWithRequestContinuationTokenDoesNotCacheNegativeEntry() {
+	listing := &gcs.Listing{}
+	req := &gcs.ListObjectsRequest{Prefix: "dir/", ContinuationToken: "token-from-previous-page"}
+
+	t.callAndVerifyWithRequest(context.TODO(), false, listing, req, nil, nil, false)
+}
+
+// An empty page that carries a continuation token is an incomplete listing and
+// must not produce a negative entry for the directory.
+func (t *ListObjectsTest_InsertListing) EmptyPageWithResponseContinuationTokenDoesNotCacheNegativeEntry() {
+	listing := &gcs.Listing{ContinuationToken: "next-page"}
+	req := &gcs.ListObjectsRequest{Prefix: "dir/"}
+
+	t.callAndVerifyWithRequest(context.TODO(), false, listing, req, nil, nil, false)
 }
 
 func (t *ListObjectsTest_InsertListing) EmptyListing() {

--- a/internal/storage/caching/integration_test.go
+++ b/internal/storage/caching/integration_test.go
@@ -80,6 +80,47 @@ func statObject(ctx context.Context, bucket gcs.Bucket, name string) (*gcs.Objec
 	return storageutil.ConvertMinObjectToObject(m), nil
 }
 
+func TestIntegration_WindowedListingDoesNotPoisonExistingDirectory(t *testing.T) {
+	deps := setupIntegrationTest(t)
+	const dirName = "dir/"
+
+	_, err := storageutil.CreateObject(deps.ctx, deps.wrapped, dirName+"a", []byte("x"))
+	require.NoError(t, err)
+
+	// Populate a positive cache entry for the existing implicit directory.
+	listing, err := deps.bucket.ListObjects(deps.ctx, &gcs.ListObjectsRequest{
+		Prefix:    dirName,
+		Delimiter: "/",
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, listing.MinObjects)
+
+	statReq := &gcs.StatObjectRequest{
+		Name:               dirName,
+		FetchOnlyFromCache: true,
+	}
+	dir, _, err := deps.bucket.StatObject(deps.ctx, statReq)
+	require.NoError(t, err)
+	require.NotNil(t, dir)
+
+	// Model a metadata-prefetch listing whose window begins after the final
+	// child. The empty result describes only this window, not the whole prefix.
+	listing, err = deps.bucket.ListObjects(deps.ctx, &gcs.ListObjectsRequest{
+		Prefix:      dirName,
+		Delimiter:   "/",
+		StartOffset: dirName + "zzz",
+	})
+	require.NoError(t, err)
+	require.Empty(t, listing.MinObjects)
+	require.Empty(t, listing.CollapsedRuns)
+	require.Empty(t, listing.ContinuationToken)
+
+	// The implicit directory still exists and should remain positively cached.
+	dir, _, err = deps.bucket.StatObject(deps.ctx, statReq)
+	assert.NoError(t, err)
+	assert.NotNil(t, dir)
+}
+
 func TestIntegration_CreateInsertsIntoCache(t *testing.T) {
 	deps := setupIntegrationTest(t)
 	const name = "taco"


### PR DESCRIPTION
### Description

Prevent empty windowed or paginated object listings from creating a negative stat-cache entry for an entire implicit-directory prefix.

`fastStatBucket.insertListing` previously treated every empty listing as evidence that the requested directory did not exist. That is not authoritative when the request uses `StartOffset` or a continuation token, or when the response contains a continuation token. In those cases, the listing represents only part of the namespace, and inserting a negative entry can overwrite a valid positive directory entry and cause transient `ENOENT` responses.

This change:

- passes the originating `ListObjectsRequest` to `insertListing`;
- limits listing-derived negative entries to unwindowed, complete listings;
- preserves negative caching for authoritative empty listings; and
- adds request-level coverage for start offsets and continuation tokens, plus a regression test using the real LRU/stat-cache implementation.

### Link to the issue in case of a bug fix.

Fixes #5018

### Testing details

1. Manual - Verified the deterministic regression fails on the unpatched implementation with `gcs.NotFoundError: negative cache entry for dir/` and passes with this change. `make build` also passes.
2. Unit tests - Passed in `golang:1.26.5` Docker:
   - `go test ./internal/storage/caching -count=1`
   - `CGO_ENABLED=0 go test ./internal/storage/... -count=1`
   - `go test -race ./internal/storage/caching -count=1`
   - `go vet ./internal/storage/caching`
   - `CGO_ENABLED=0 go build ./...`
3. Integration tests - Added `TestIntegration_WindowedListingDoesNotPoisonExistingDirectory`, which exercises `fastStatBucket` with the real LRU/stat cache and fake GCS backend. A live FUSE/GCS end-to-end test was not run.

### Any backward incompatible change? If so, please explain.

N/A. The changed method is internal, and no exported API, configuration, or existing authoritative-listing behavior changes.
