### PR TITLE
fix(bufferedwrites): prevent memory leak & race in UploadHandler.Destroy

### DIFF
--- a/internal/bufferedwrites/buffered_write_handler.go
+++ b/internal/bufferedwrites/buffered_write_handler.go
@@ -300,6 +300,10 @@ func (wh *bufferedWriteHandlerImpl) WriteFileInfo() WriteFileInfo {
 }
 
 func (wh *bufferedWriteHandlerImpl) Destroy() error {
+	if wh.current != nil {
+		wh.blockPool.Release(wh.current)
+		wh.current = nil
+	}
 	wh.uploadHandler.Destroy()
 	return wh.blockPool.ClearFreeBlockChannel(true)
 }

--- a/internal/bufferedwrites/buffered_write_handler_test.go
+++ b/internal/bufferedwrites/buffered_write_handler_test.go
@@ -622,8 +622,49 @@ func (testSuite *BufferedWriteTest) TestDestroyShouldClearFreeBlockChannel() {
 
 	require.Nil(testSuite.T(), err)
 	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
+	assert.Nil(testSuite.T(), bwhImpl.current)
 	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
 	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	// Check if all semaphore permits are released correctly.
+	assert.True(testSuite.T(), testSuite.globalSemaphore.TryAcquire(10))
+}
+
+func (testSuite *BufferedWriteTest) TestDestroyWithPartialBlockInCurrent() {
+	// Write a partial block (less than blockSize) so it stays in wh.current and is not uploaded.
+	partialData := strings.Repeat("B", blockSize/2)
+	err := testSuite.bwh.Write(context.Background(), []byte(partialData), 0)
+	require.Nil(testSuite.T(), err)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
+	require.NotNil(testSuite.T(), bwhImpl.current)
+	assert.Equal(testSuite.T(), int64(blockSize/2), bwhImpl.current.Size())
+
+	err = testSuite.bwh.Destroy()
+
+	require.Nil(testSuite.T(), err)
+	assert.Nil(testSuite.T(), bwhImpl.current)
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	// Verify that all 10 permits (including the one used by wh.current) are released.
+	assert.True(testSuite.T(), testSuite.globalSemaphore.TryAcquire(10))
+}
+
+func (testSuite *BufferedWriteTest) TestDestroyWithMultiBlocksAndPartialBlockInCurrent() {
+	// Write 2.5 blocks of data: 2 full blocks sent to uploadCh, 0.5 block stays in wh.current.
+	data := strings.Repeat("C", int(blockSize*2.5))
+	err := testSuite.bwh.Write(context.Background(), []byte(data), 0)
+	require.Nil(testSuite.T(), err)
+	bwhImpl := testSuite.bwh.(*bufferedWriteHandlerImpl)
+	require.NotNil(testSuite.T(), bwhImpl.current)
+	assert.Equal(testSuite.T(), int64(blockSize/2), bwhImpl.current.Size())
+
+	err = testSuite.bwh.Destroy()
+
+	require.Nil(testSuite.T(), err)
+	assert.Nil(testSuite.T(), bwhImpl.current)
+	assert.Equal(testSuite.T(), 0, bwhImpl.uploadHandler.blockPool.TotalFreeBlocks())
+	assert.Equal(testSuite.T(), 0, len(bwhImpl.uploadHandler.uploadCh))
+	// Verify that all 10 permits are released back to global semaphore.
+	assert.True(testSuite.T(), testSuite.globalSemaphore.TryAcquire(10))
 }
 
 func (testSuite *BufferedWriteTest) TestUnlinkBeforeWrite() {

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -98,6 +98,7 @@ func (uh *UploadHandler) Upload(ctx context.Context, block block.Block) error {
 
 	err := uh.ensureWriter(ctx)
 	if err != nil {
+		uh.wg.Done()
 		return fmt.Errorf("uh.ensureWriter() failed: %v", err)
 	}
 	// Start the uploader goroutine but only once.

--- a/internal/bufferedwrites/upload_handler.go
+++ b/internal/bufferedwrites/upload_handler.go
@@ -269,20 +269,28 @@ func (uh *UploadHandler) AwaitBlocksUpload() {
 }
 
 func (uh *UploadHandler) Destroy() {
-	// Move all pending blocks to freeBlockCh and close the channel if not done.
+	// Cancel the context to abort any ongoing GCS upload.
+	if uh.cancelFunc != nil {
+		uh.cancelFunc()
+	}
+
+	// Drain all pending blocks from uploadCh and return them to the block pool,
+	// then close uploadCh and wait for the uploader goroutine to finish.
 	for {
 		select {
 		case currBlock, ok := <-uh.uploadCh:
-			// Not ok means channel closed. Return.
+			// If ok is false, the channel was already closed (e.g. by Finalize).
 			if !ok {
 				return
 			}
 			uh.blockPool.Release(currBlock)
-			// Marking as wg.Done to ensure any waiters are unblocked.
+			// Mark as wg.Done for each drained block to ensure wg.Wait() can unblock.
 			uh.wg.Done()
 		default:
-			// This will get executed when there are no blocks pending in uploadCh and its not closed.
+			// Executed when there are no more blocks pending in uploadCh and it is not closed.
 			close(uh.uploadCh)
+			// Wait for the uploader goroutine to finish processing its current in-flight block.
+			uh.wg.Wait()
 			return
 		}
 	}

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -610,3 +610,38 @@ func (t *UploadHandlerTest) createBlocks(count int) []block.Block {
 
 	return blocks
 }
+
+func (t *UploadHandlerTest) TestDestroyWithUploaderGoroutineInProgress() {
+	writer := &storagemock.Writer{}
+	writeBlockChan := make(chan struct{})
+	writeStartedChan := make(chan struct{})
+	writer.On("Write", mock.Anything).Run(func(args mock.Arguments) {
+		close(writeStartedChan)
+		<-writeBlockChan // Block the writer to simulate a slow upload
+	}).Return(4, nil)
+	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
+	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(writer, nil)
+	blocks := t.createBlocks(1)
+	b := blocks[0]
+	_, err := b.Write([]byte("taco"))
+	require.NoError(t.T(), err)
+	err = t.uh.Upload(context.Background(), b)
+	require.NoError(t.T(), err)
+	<-writeStartedChan // Wait for the uploader goroutine to pull the block and call Write()
+
+	destroyDone := make(chan struct{})
+	go func() {
+		t.uh.Destroy()
+		close(destroyDone)
+	}()
+	select {
+	case <-destroyDone:
+		assert.Fail(t.T(), "Destroy should have blocked waiting for uploader to finish")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(writeBlockChan) // Unblock the writer
+	<-destroyDone         // Wait for Destroy to complete
+
+	assert.Equal(t.T(), 1, t.uh.blockPool.TotalFreeBlocks())
+	assertAllBlocksProcessed(t.T(), t.uh)
+}

--- a/internal/bufferedwrites/upload_handler_test.go
+++ b/internal/bufferedwrites/upload_handler_test.go
@@ -240,12 +240,12 @@ func (t *UploadHandlerTest) TestMultipleBlockUpload() {
 }
 
 func (t *UploadHandlerTest) TestUploadWhenCreateObjectWriterFails() {
-	// Create a block.
-	b, err := t.blockPool.Get()
-	require.NoError(t.T(), err)
 	// CreateObjectChunkWriter -- should be called once.
 	t.mockBucket.On("BucketType").Return(gcs.BucketType{})
 	t.mockBucket.On("CreateObjectChunkWriter", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("taco"))
+	// Create a block.
+	b, err := t.blockPool.Get()
+	require.NoError(t.T(), err)
 
 	// Upload the block.
 	err = t.uh.Upload(context.Background(), b)
@@ -253,6 +253,7 @@ func (t *UploadHandlerTest) TestUploadWhenCreateObjectWriterFails() {
 	require.Error(t.T(), err)
 	assert.ErrorContains(t.T(), err, "createObjectWriter")
 	assert.ErrorContains(t.T(), err, "taco")
+	assertAllBlocksProcessed(t.T(), t.uh)
 }
 
 func (t *UploadHandlerTest) TestFinalizeWithWriterAlreadyPresent() {


### PR DESCRIPTION
## Description
When a file handle is destroyed (e.g., after a failed upload or unlink), `UploadHandler.Destroy` did not cancel the ongoing GCS upload context or wait for the background `uploader` goroutine to finish processing its current chunk.

This caused the `uploader` goroutine to return its in-flight block back to the block pool *after* `ClearFreeBlockChannel` had already executed and finished teardown. In production, this resulted in severe consequences:
1. **Memory Leaks:** The late-arriving block was abandoned in the pool, meaning `Deallocate()` was never called and the underlying `mmap` memory was never freed.
2. **Global Write Degredation:** The global semaphore permit (`globalMaxBlocksSem`) tied to the abandoned block was never released. Over time, these leaked permits would exhaust the semaphore capacity, causing all new writes across the GCSFuse mount to use staged writes.

This PR fixes the teardown sequence and synchronization:
- Cancels the GCS upload context inside `Destroy()` to quickly abort the in-flight upload.
- Adds `uh.wg.Wait()` after draining `uploadCh` to ensure the `uploader` goroutine fully completes and releases its block before teardown continues.
- Introduces `TestDestroyWithUploaderGoroutineInProgress` to assert strict synchronization between `Destroy` and the `uploader`.

## How Has This Been Tested?
- Ran `go test -v -count=100 -run TestBufferedWriteTestSuite/TestDestroyShouldClearFreeBlockChannel ./internal/bufferedwrites/...` and verified it passes 100% of the time.
- Implemented and verified the new `TestDestroyWithUploaderGoroutineInProgress` unit test to directly trigger and assert this race condition.
- Confirmed that the new test fails without the fix and succeeds with it.


### Link to the issue in case of a bug fix.
b/546299575

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
NA
