### PR TITLE
feat(grpc): bypass DirectPath connectivity check for rapid buckets

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -209,7 +209,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 
 	// Set the production level retry config.
 	defer func() {
-		logger.Infof("Applying production retry config after DirectPath verification.")
+		logger.Infof("Applying production retry config.")
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -187,7 +187,7 @@ func setRetryConfig(ctx context.Context, sc *storage.Client, clientConfig *stora
 }
 
 // Followed https://pkg.go.dev/cloud.google.com/go/storage#hdr-Experimental_gRPC_API to create the gRPC client.
-func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isbucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
+func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.StorageClientConfig, isBucketRapid bool, enableBidiConfig bool, bucketName string, billingProject string) (*storage.Client, error) {
 	if err := os.Setenv("GOOGLE_CLOUD_ENABLE_DIRECT_PATH_XDS", "true"); err != nil {
 		return nil, fmt.Errorf("error setting direct path env var: %w", err)
 	}
@@ -199,8 +199,10 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	// For non-rapid buckets, add DirectPath enforcement - operations performed via the client will fail if DirectPath is not available.
+	if !isBucketRapid {
+		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	}
 
 	sc, err := storage.NewGRPCClient(ctx, clientOpts...)
 	if err != nil {
@@ -208,14 +210,14 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}
 
 	// For regional buckets, perform the direct path verification.
-	if !isbucketRapid {
+	if !isBucketRapid {
 		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
 			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
 			return nil, verifyErr
 		}
 		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
-
+	setRetryConfig(ctx, sc, clientConfig)
 	return sc, nil
 }
 
@@ -252,6 +254,10 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
+		// The client is unusable, close it to prevent connection leaks.
+		if err := sc.Close(); err != nil {
+			logger.Errorf("Failed to close unusable gRPC client: %v", err)
+		}
 		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
 	}
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -207,12 +207,6 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 
-	// Set the production level retry config.
-	defer func() {
-		logger.Infof("Applying production retry config.")
-		setRetryConfig(ctx, sc, clientConfig)
-	}()
-
 	// For regional buckets, perform the direct path verification.
 	if !isbucketRapid {
 		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -214,12 +214,11 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 	}()
 
 	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
-	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
-		if !isbucketRapid {
+	if !isbucketRapid {
+		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
+			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
 			return nil, verifyErr
 		}
-	} else {
 		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
 

--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -213,7 +213,7 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		setRetryConfig(ctx, sc, clientConfig)
 	}()
 
-	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
+	// For regional buckets, perform the direct path verification.
 	if !isbucketRapid {
 		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
 			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1216,8 +1216,13 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_WithPref
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid() {
 	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, true, false, "my-bucket", "")
+	defer func() {
+		if client != nil {
+			_ = client.Close()
+		}
+	}()
 
-	// If the bucket is rapid, the method for directpath check is not called, so err should be nil
+	// If the bucket is rapid, the method for directpath check is not called, so err should be nil.
 	assert.Nil(testSuite.T(), err)
 	assert.NotNil(testSuite.T(), client)
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1213,3 +1213,20 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_WithPref
 		testSuite.T().Fatal("Timeout waiting for request")
 	}
 }
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid() {
+	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, true, false, "my-bucket", "")
+
+	// If the bucket is rapid, the method for directpath check is not called, so err should be nil
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), client)
+}
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_DirectPathVerificationForStandard() {
+	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, false, false, "my-bucket", "")
+
+	// If the bucket is non rapid, the method for directpath check is called, which fails in unit test environment.
+	assert.NotNil(testSuite.T(), err)
+	assert.ErrorContains(testSuite.T(), err, "DirectPath verification failed")
+	assert.Nil(testSuite.T(), client)
+}

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1215,6 +1215,10 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_WithPref
 }
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid() {
+	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
+	// This prevents storage.NewGRPCClient from failing in CI environments (like GitHub Actions)
+	// where Google credentials are not available.
+	testSuite.clientConfig.AnonymousAccess = true
 	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, true, false, "my-bucket", "")
 	defer func() {
 		if client != nil {

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1223,6 +1223,12 @@ func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVer
 }
 
 func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_DirectPathVerificationForStandard() {
+	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
+	// This ensures the DirectPath verification strictly fails with PermissionDenied
+	// (instead of potentially authenticating and getting a NotFound error which is ignored).
+	// This guarantees test determinism across all execution environments.
+	testSuite.clientConfig.AnonymousAccess = true
+
 	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, false, false, "my-bucket", "")
 
 	// If the bucket is non rapid, the method for directpath check is called, which fails in unit test environment.


### PR DESCRIPTION
### Description
This PR modifies the `createGRPCClientHandle` logic to bypass the `verifyDirectPathConnectivity` dummy-stat check for Rapid (and Pirlo) buckets. 
Since Rapid buckets primarily rely on gRPC for high throughput and bidirectional streaming, skipping this verification eliminates unnecessary initialization latency and potential connection failures on startup. DirectPath verification failures remain strictly fatal for standard regional buckets.

**Test Determinism**: Explicitly set `AnonymousAccess = true` in the standard test to strip environment credentials (e.g., GCE Application Default Credentials). This ensures the dummy `Attrs` call strictly fails with a `PermissionDenied` rather than authenticating and returning a `NotFound` (which the check ignores), guaranteeing deterministic failures across all CI environments.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - yes.
2. Unit tests - Added.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No. 
