### PR TITLE
feat(Improvements): Migrate downloader package from legacy jacobsa dependency to testify.

### DIFF
--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -17,7 +17,6 @@ package downloader
 import (
 	"context"
 	"os"
-	"path"
 	"sync"
 	"testing"
 	"time"
@@ -32,17 +31,16 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
-	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/operations"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
-var cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
-
-func TestDownloader(t *testing.T) { RunTests(t) }
-
 type downloaderTest struct {
+	t                      *testing.T
+	assert                 *assert.Assertions
+	require                *require.Assertions
 	defaultFileCacheConfig *cfg.FileCacheConfig
 	job                    *Job
 	bucket                 gcs.Bucket
@@ -51,13 +49,23 @@ type downloaderTest struct {
 	fakeStorage            storage.FakeStorage
 	fileSpec               data.FileSpec
 	jm                     *JobManager
+	cacheDir               string
 }
 
-func init() { RegisterTestSuite(&downloaderTest{}) }
+func newDownloaderTest(t *testing.T) *downloaderTest {
+	dt := &downloaderTest{
+		t:       t,
+		assert:  assert.New(t),
+		require: require.New(t),
+	}
+	dt.defaultFileCacheConfig = &cfg.FileCacheConfig{EnableCrc: true, ExperimentalParallelDownloadsDefaultOn: true}
+	dt.setupHelper()
+	return dt
+}
 
 func (dt *downloaderTest) setupHelper() {
 	locker.EnableInvariantsCheck()
-	operations.RemoveDir(cacheDir)
+	dt.cacheDir = dt.t.TempDir()
 
 	// Create bucket in fake storage.
 	var err error
@@ -68,18 +76,13 @@ func (dt *downloaderTest) setupHelper() {
 		Return(&controlpb.StorageLayout{}, nil)
 	ctx := context.Background()
 	dt.bucket, err = storageHandle.BucketHandle(ctx, storage.TestBucketName, "")
-	ExpectEq(nil, err)
+	dt.require.NoError(err)
 
 	dt.initJobTest(DefaultObjectName, []byte("taco"), DefaultSequentialReadSizeMb, CacheMaxSize, func() {})
-	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, cacheDir, DefaultSequentialReadSizeMb, dt.defaultFileCacheConfig, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), 1)
+	dt.jm = NewJobManager(dt.cache, util.DefaultFilePerm, util.DefaultDirPerm, dt.cacheDir, DefaultSequentialReadSizeMb, dt.defaultFileCacheConfig, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), 1)
 }
 
-func (dt *downloaderTest) SetUp(*TestInfo) {
-	dt.defaultFileCacheConfig = &cfg.FileCacheConfig{EnableCrc: true, ExperimentalParallelDownloadsDefaultOn: true}
-	dt.setupHelper()
-}
-
-func (dt *downloaderTest) TearDown() {
+func (dt *downloaderTest) tearDown() {
 	if dt.job != nil {
 		dt.job.Invalidate()
 	}
@@ -87,12 +90,9 @@ func (dt *downloaderTest) TearDown() {
 		dt.jm.Destroy()
 	}
 	dt.fakeStorage.ShutDown()
-	operations.RemoveDir(cacheDir)
 }
 
 func (dt *downloaderTest) waitForCrcCheckToBeCompleted() {
-	// Last notification is sent after the entire file is downloaded and before the CRC check is done.
-	// Hence, explicitly waiting till the CRC check is done.
 	for {
 		dt.job.mu.Lock()
 		if dt.job.status.Name == Completed || dt.job.status.Name == Failed || dt.job.status.Name == Invalid {
@@ -107,36 +107,42 @@ func (dt *downloaderTest) waitForCrcCheckToBeCompleted() {
 func (dt *downloaderTest) verifyJob(job *Job, object *gcs.MinObject, bucket gcs.Bucket, sequentialReadSizeMb int32) {
 	job.mu.Lock()
 	defer job.mu.Unlock()
-	ExpectEq(object.Generation, job.object.Generation)
-	ExpectEq(object.Name, job.object.Name)
-	ExpectEq(bucket.Name(), job.bucket.Name())
+	dt.assert.Equal(object.Generation, job.object.Generation)
+	dt.assert.Equal(object.Name, job.object.Name)
+	dt.assert.Equal(bucket.Name(), job.bucket.Name())
 	downloadPath, err := util.GetDownloadPath(dt.jm.cacheDir, util.GetObjectPath(bucket.Name(), object.Name))
-	ExpectEq(nil, err)
-	ExpectEq(downloadPath, job.fileSpec.Path)
-	ExpectEq(sequentialReadSizeMb, job.sequentialReadSizeMb)
-	ExpectNe(nil, job.removeJobCallback)
+	dt.require.NoError(err)
+	dt.assert.Equal(downloadPath, job.fileSpec.Path)
+	dt.assert.Equal(sequentialReadSizeMb, job.sequentialReadSizeMb)
+	dt.assert.NotNil(job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_CreateJobIfNotExists_NotExisting() {
+func Test_CreateJobIfNotExists_NotExisting(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
 	_, ok := dt.jm.jobs[objectPath]
-	AssertFalse(ok)
+	dt.assert.False(ok)
 	dt.jm.mu.Unlock()
 
 	// Call CreateJobIfNotExists for job which doesn't exist.
 	job, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	dt.jm.mu.Lock()
 	defer dt.jm.mu.Unlock()
 	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	actualJob, ok := dt.jm.jobs[objectPath]
-	AssertTrue(ok)
-	AssertEq(job, actualJob)
+	dt.assert.True(ok)
+	dt.assert.Equal(job, actualJob)
 }
 
-func (dt *downloaderTest) Test_CreateJobIfNotExists_Existing() {
+func Test_CreateJobIfNotExists_Existing(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	// First create and store new job
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
@@ -145,50 +151,59 @@ func (dt *downloaderTest) Test_CreateJobIfNotExists_Existing() {
 
 	// Call CreateJobIfNotExists for existing job.
 	job, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
-	AssertEq(dt.job, job)
+	dt.assert.Equal(dt.job, job)
 	dt.jm.mu.Lock()
 	defer dt.jm.mu.Unlock()
 	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	actualJob, ok := dt.jm.jobs[objectPath]
-	AssertTrue(ok)
-	AssertEq(job, actualJob)
+	dt.assert.True(ok)
+	dt.assert.Equal(job, actualJob)
 }
 
-func (dt *downloaderTest) Test_CreateJobIfNotExists_NotExisting_WithDefaultFileAndDirPerm() {
+func Test_CreateJobIfNotExists_NotExisting_WithDefaultFileAndDirPerm(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
 	_, ok := dt.jm.jobs[objectPath]
-	AssertFalse(ok)
+	dt.assert.False(ok)
 	dt.jm.mu.Unlock()
 
 	// Call CreateJobIfNotExists for job which doesn't exist.
 	job, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
-	ExpectEq(0700, job.fileSpec.DirPerm.Perm())
-	ExpectEq(0600, job.fileSpec.FilePerm.Perm())
+	dt.assert.Equal(os.FileMode(0700), job.fileSpec.DirPerm.Perm())
+	dt.assert.Equal(os.FileMode(0600), job.fileSpec.FilePerm.Perm())
 }
 
-func (dt *downloaderTest) Test_GetJob_NotExisting() {
+func Test_GetJob_NotExisting(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
 	_, ok := dt.jm.jobs[objectPath]
-	AssertFalse(ok)
+	dt.assert.False(ok)
 	dt.jm.mu.Unlock()
 
 	// Call GetJob for job which doesn't exist.
 	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
 
-	AssertEq(nil, job)
+	dt.assert.Nil(job)
 	dt.jm.mu.Lock()
 	defer dt.jm.mu.Unlock()
 	_, ok = dt.jm.jobs[objectPath]
-	AssertFalse(ok)
+	dt.assert.False(ok)
 }
 
-func (dt *downloaderTest) Test_GetJob_Existing() {
+func Test_GetJob_Existing(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	// First create and store new job
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
@@ -198,11 +213,14 @@ func (dt *downloaderTest) Test_GetJob_Existing() {
 	// Call GetJob for existing job.
 	job := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
 
-	AssertEq(dt.job, job)
+	dt.assert.Equal(dt.job, job)
 	dt.verifyJob(job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 }
 
-func (dt *downloaderTest) Test_GetJob_Concurrent() {
+func Test_GetJob_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	// First create and store new job
 	dt.jm.mu.Lock()
 	objectPath := util.GetObjectPath(dt.bucket.Name(), dt.object.Name)
@@ -226,51 +244,60 @@ func (dt *downloaderTest) Test_GetJob_Concurrent() {
 	dt.verifyJob(dt.job, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	// Verify all jobs
 	for i := range 5 {
-		ExpectEq(dt.job, jobs[i])
+		dt.assert.Equal(dt.job, jobs[i])
 	}
 }
 
-func (dt *downloaderTest) Test_InvalidateAndRemoveJob_NotExisting() {
+func Test_InvalidateAndRemoveJob_NotExisting(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	expectedJob := dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
-	AssertEq(nil, expectedJob)
+	dt.assert.Nil(expectedJob)
 
 	dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
 
 	// Verify that job is invalidated and removed from job manager.
 	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
-	AssertEq(nil, expectedJob)
+	dt.assert.Nil(expectedJob)
 }
 
-func (dt *downloaderTest) Test_InvalidateAndRemoveJob_Existing() {
+func Test_InvalidateAndRemoveJob_Existing(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	// First create new job
 	expectedJob, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.jm.mu.Lock()
 	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	dt.jm.mu.Unlock()
 	// Start the job
 	_, err = expectedJob.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// InvalidateAndRemove the job
 	dt.jm.InvalidateAndRemoveJob(dt.object.Name, dt.bucket.Name())
 
 	// Verify no job existing
-	AssertEq(Invalid, expectedJob.GetStatus().Name)
+	dt.assert.Equal(Invalid, expectedJob.GetStatus().Name)
 	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
-	AssertEq(nil, expectedJob)
+	dt.assert.Nil(expectedJob)
 }
 
-func (dt *downloaderTest) Test_InvalidateAndRemoveJob_Concurrent() {
+func Test_InvalidateAndRemoveJob_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	// First create new job
 	expectedJob, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.jm.mu.Lock()
 	dt.verifyJob(expectedJob, &dt.object, dt.bucket, dt.jm.sequentialReadSizeMb)
 	dt.jm.mu.Unlock()
 	// Start the job
 	_, err = expectedJob.Download(context.Background(), 0, false)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	wg := sync.WaitGroup{}
 
 	// Make concurrent requests
@@ -285,12 +312,15 @@ func (dt *downloaderTest) Test_InvalidateAndRemoveJob_Concurrent() {
 	wg.Wait()
 
 	// Verify job in invalidated and removed from job manager.
-	AssertEq(Invalid, expectedJob.GetStatus().Name)
+	dt.assert.Equal(Invalid, expectedJob.GetStatus().Name)
 	expectedJob = dt.jm.GetJob(dt.object.Name, dt.bucket.Name())
-	AssertEq(nil, expectedJob)
+	dt.assert.Nil(expectedJob)
 }
 
-func (dt *downloaderTest) Test_Destroy() {
+func Test_Destroy(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectSize := 50
 	objectContent := testutil.GenerateRandomBytes(objectSize)
 	// Create new jobs
@@ -298,42 +328,45 @@ func (dt *downloaderTest) Test_Destroy() {
 	dt.initJobTest(objectName1, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 	object1 := dt.object
 	job1, err := dt.jm.CreateJobIfNotExists(&object1, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	objectName2 := "path/in/gcs/foo2.txt"
 	dt.initJobTest(objectName2, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 	object2 := dt.object
 	job2, err := dt.jm.CreateJobIfNotExists(&object2, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Start the job
 	_, err = job2.Download(context.Background(), 2, false)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	objectName3 := "path/in/gcs/foo3.txt"
 	dt.initJobTest(objectName3, objectContent, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
 	object3 := dt.object
 	job3, err := dt.jm.CreateJobIfNotExists(&object3, dt.bucket)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Start the job
 	_, err = job3.Download(context.Background(), 2, false)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	dt.jm.Destroy()
 
 	// Verify all jobs are invalidated
-	AssertEq(Invalid, job1.GetStatus().Name)
-	AssertEq(Invalid, job2.GetStatus().Name)
-	AssertEq(Invalid, job3.GetStatus().Name)
+	dt.assert.Equal(Invalid, job1.GetStatus().Name)
+	dt.assert.Equal(Invalid, job2.GetStatus().Name)
+	dt.assert.Equal(Invalid, job3.GetStatus().Name)
 	// Verify all jobs are removed
-	AssertEq(nil, dt.jm.GetJob(objectName1, dt.bucket.Name()))
-	AssertEq(nil, dt.jm.GetJob(objectName2, dt.bucket.Name()))
-	AssertEq(nil, dt.jm.GetJob(objectName3, dt.bucket.Name()))
+	dt.assert.Nil(dt.jm.GetJob(objectName1, dt.bucket.Name()))
+	dt.assert.Nil(dt.jm.GetJob(objectName2, dt.bucket.Name()))
+	dt.assert.Nil(dt.jm.GetJob(objectName3, dt.bucket.Name()))
 }
 
-func (dt *downloaderTest) Test_CreateJobIfNotExists_InvalidateAndRemoveJob_Concurrent() {
+func Test_CreateJobIfNotExists_InvalidateAndRemoveJob_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
+
 	wg := sync.WaitGroup{}
 	createNewJob := func() {
 		job, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-		AssertEq(nil, err)
-		AssertNe(nil, job)
+		dt.require.NoError(err)
+		dt.assert.NotNil(job)
 		wg.Done()
 	}
 	invalidateJob := func() {

--- a/internal/cache/file/downloader/downloader_test.go
+++ b/internal/cache/file/downloader/downloader_test.go
@@ -365,7 +365,7 @@ func Test_CreateJobIfNotExists_InvalidateAndRemoveJob_Concurrent(t *testing.T) {
 	wg := sync.WaitGroup{}
 	createNewJob := func() {
 		job, err := dt.jm.CreateJobIfNotExists(&dt.object, dt.bucket)
-		dt.require.NoError(err)
+		dt.assert.NoError(err)
 		dt.assert.NotNil(job)
 		wg.Done()
 	}

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -23,9 +23,9 @@ import (
 	"os"
 	"path"
 	"reflect"
-	"strings"
 	"sync"
 	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
@@ -36,7 +36,6 @@ import (
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
-	. "github.com/jacobsa/ogletest"
 	"golang.org/x/sync/semaphore"
 )
 
@@ -55,7 +54,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	ctx := context.Background()
 	objects := map[string][]byte{objectName: objectContent}
 	err := storageutil.CreateObjects(ctx, dt.bucket, objects)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.object = getMinObject(objectName, dt.bucket)
 	dt.fileSpec = data.FileSpec{
 		Path:     dt.fileCachePath(dt.bucket.Name(), dt.object.Name),
@@ -71,47 +70,49 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 	}
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, dt.object.Size, 0, false, nil, 1)
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 }
 
 func (dt *downloaderTest) verifyInvalidError(err error) {
-	AssertTrue((nil == err) || (errors.Is(err, context.Canceled)) || errors.Is(err, lru.ErrEntryNotExist),
+	dt.require.True((nil == err) || (errors.Is(err, context.Canceled)) || errors.Is(err, lru.ErrEntryNotExist),
 		fmt.Sprintf("actual error:%v is not as expected", err))
 }
 
 func (dt *downloaderTest) verifyFile(content []byte) {
 	fileStat, err := os.Stat(dt.fileSpec.Path)
-	AssertEq(nil, err)
-	AssertEq(dt.fileSpec.FilePerm, fileStat.Mode())
-	AssertLe(len(content), fileStat.Size())
+	dt.require.NoError(err)
+	dt.require.Equal(dt.fileSpec.FilePerm, fileStat.Mode())
+	dt.require.LessOrEqual(int64(len(content)), fileStat.Size())
 	// Verify the content of file downloaded only till the size of content passed.
 	fileContent, err := os.ReadFile(dt.fileSpec.Path)
-	AssertEq(nil, err)
-	AssertTrue(reflect.DeepEqual(content, fileContent[:len(content)]))
+	dt.require.NoError(err)
+	dt.require.Equal(content, fileContent[:len(content)])
 }
 
 func (dt *downloaderTest) verifyFileInfoEntry(offset uint64) {
 	fileInfo := dt.getFileInfo()
-	AssertTrue(fileInfo != nil)
-	AssertEq(dt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
-	AssertLe(offset, fileInfo.(data.FileInfo).Offset)
-	AssertEq(dt.object.Size, fileInfo.(data.FileInfo).ContentSize())
+	dt.require.NotNil(fileInfo)
+	dt.require.Equal(dt.object.Generation, fileInfo.(data.FileInfo).ObjectGeneration)
+	dt.require.LessOrEqual(offset, fileInfo.(data.FileInfo).Offset)
+	dt.require.Equal(dt.object.Size, fileInfo.(data.FileInfo).ContentSize())
 }
 
 func (dt *downloaderTest) getFileInfo() lru.ValueType {
 	fileInfoKey := data.FileInfoKey{BucketName: dt.bucket.Name(), ObjectName: dt.object.Name}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	return dt.cache.LookUp(fileInfoKeyName)
 }
 
 func (dt *downloaderTest) fileCachePath(bucketName string, objectName string) string {
-	return path.Join(cacheDir, bucketName, objectName)
+	return path.Join(dt.cacheDir, bucketName, objectName)
 }
 
-func (dt *downloaderTest) Test_init() {
+func Test_init(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	// Explicitly changing initialized values first.
 	dt.job.status.Name = Downloading
 	dt.job.status.Err = fmt.Errorf("some error")
@@ -120,32 +121,36 @@ func (dt *downloaderTest) Test_init() {
 
 	dt.job.init()
 
-	AssertEq(NotStarted, dt.job.status.Name)
-	AssertEq(nil, dt.job.status.Err)
-	AssertEq(0, dt.job.status.Offset)
-	AssertTrue(reflect.DeepEqual(list.List{}, dt.job.subscribers))
+	dt.require.Equal(NotStarted, dt.job.status.Name)
+	dt.require.NoError(dt.job.status.Err)
+	dt.require.Equal(int64(0), dt.job.status.Offset)
+	dt.require.Equal(list.List{}, dt.job.subscribers)
 }
 
-func (dt *downloaderTest) Test_subscribe() {
+func Test_subscribe(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset1 := int64(0)
 	subscriberOffset2 := int64(1)
 
 	notificationC1 := dt.job.subscribe(subscriberOffset1)
 	notificationC2 := dt.job.subscribe(subscriberOffset2)
 
-	AssertEq(2, dt.job.subscribers.Len())
+	dt.require.Equal(2, dt.job.subscribers.Len())
 	receivingC := make(<-chan JobStatus, 1)
-	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
-	AssertEq(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
+	dt.require.Equal(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC1))
+	dt.require.Equal(reflect.TypeOf(receivingC), reflect.TypeOf(notificationC2))
 	// Check 1st and 2nd subscribers
 	var subscriber jobSubscriber
-	AssertEq(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Front().Value.(jobSubscriber)))
-	AssertEq(0, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
-	AssertEq(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Back().Value.(jobSubscriber)))
-	AssertEq(1, dt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
+	dt.require.Equal(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Front().Value.(jobSubscriber)))
+	dt.require.Equal(int64(0), dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+	dt.require.Equal(reflect.TypeOf(subscriber), reflect.TypeOf(dt.job.subscribers.Back().Value.(jobSubscriber)))
+	dt.require.Equal(int64(1), dt.job.subscribers.Back().Value.(jobSubscriber).subscribedOffset)
 }
 
-func (dt *downloaderTest) Test_notifySubscriber_Failed() {
+func Test_notifySubscriber_Failed(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
 	dt.job.status.Name = Failed
@@ -154,28 +159,32 @@ func (dt *downloaderTest) Test_notifySubscriber_Failed() {
 
 	dt.job.notifySubscribers()
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 0}
-	AssertTrue(reflect.DeepEqual(jobStatus, notification))
-	AssertEq(true, ok)
+	dt.require.Equal(jobStatus, notification)
+	dt.require.True(ok)
 }
 
-func (dt *downloaderTest) Test_notifySubscriber_Invalid() {
+func Test_notifySubscriber_Invalid(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
 	dt.job.status.Name = Invalid
 
 	dt.job.notifySubscribers()
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Invalid, Err: nil, Offset: 0}
-	AssertTrue(reflect.DeepEqual(jobStatus, notification))
-	AssertEq(true, ok)
+	dt.require.Equal(jobStatus, notification)
+	dt.require.True(ok)
 }
 
-func (dt *downloaderTest) Test_notifySubscriber_SubscribedOffset() {
+func Test_notifySubscriber_SubscribedOffset(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset1 := int64(3)
 	subscriberOffset2 := int64(5)
 	notificationC1 := dt.job.subscribe(subscriberOffset1)
@@ -185,16 +194,18 @@ func (dt *downloaderTest) Test_notifySubscriber_SubscribedOffset() {
 
 	dt.job.notifySubscribers()
 
-	AssertEq(1, dt.job.subscribers.Len())
+	dt.require.Equal(1, dt.job.subscribers.Len())
 	notification1, ok := <-notificationC1
 	jobStatus := JobStatus{Name: Downloading, Err: nil, Offset: 4}
-	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
-	AssertEq(true, ok)
+	dt.require.Equal(jobStatus, notification1)
+	dt.require.True(ok)
 	// Check 2nd subscriber's offset
-	AssertEq(subscriberOffset2, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
+	dt.require.Equal(subscriberOffset2, dt.job.subscribers.Front().Value.(jobSubscriber).subscribedOffset)
 }
 
-func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
+func Test_updateStatusAndNotifySubscribers(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	// Failed with error
 	subscriberOffset1 := int64(3)
 	subscriberOffset2 := int64(5)
@@ -205,15 +216,15 @@ func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
 	customErr := fmt.Errorf("custom error")
 	dt.job.updateStatusAndNotifySubscribers(Failed, customErr)
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification1, ok1 := <-notificationC1
 	notification2, ok2 := <-notificationC2
 	jobStatus := JobStatus{Name: Failed, Err: customErr, Offset: 4}
 	// Check 1st and 2nd subscriber notifications
-	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
-	AssertEq(true, ok1)
-	AssertTrue(reflect.DeepEqual(jobStatus, notification2))
-	AssertEq(true, ok2)
+	dt.require.Equal(jobStatus, notification1)
+	dt.require.True(ok1)
+	dt.require.Equal(jobStatus, notification2)
+	dt.require.True(ok2)
 
 	// Complete without error
 	subscriberOffset1 = int64(3)
@@ -222,15 +233,17 @@ func (dt *downloaderTest) Test_updateStatusAndNotifySubscribers() {
 
 	dt.job.updateStatusAndNotifySubscribers(Completed, nil)
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification1, ok1 = <-notificationC1
 	jobStatus = JobStatus{Name: Completed, Err: nil, Offset: 4}
 	// Check subscriber notification
-	AssertTrue(reflect.DeepEqual(jobStatus, notification1))
-	AssertEq(true, ok1)
+	dt.require.Equal(jobStatus, notification1)
+	dt.require.True(ok1)
 }
 
-func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
+func Test_updateStatusOffset_UpdateEntry(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	// Add an entry into
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
@@ -238,9 +251,9 @@ func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
 	}
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.job.object.Generation, dt.job.object.Size, 0, false, nil, 1)
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.job.mu.Lock()
 	dt.job.status.Name = Downloading
 	notificationCh := dt.job.subscribe(5)
@@ -248,63 +261,69 @@ func (dt *downloaderTest) Test_updateStatusOffset_UpdateEntry() {
 
 	err = dt.job.updateStatusOffset(10)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Confirm fileInfoCache is updated with new offset.
 	lookupResult := dt.cache.LookUp(fileInfoKeyName)
-	AssertFalse(lookupResult == nil)
+	dt.require.NotNil(lookupResult)
 	fileInfo = lookupResult.(data.FileInfo)
-	AssertEq(10, fileInfo.Offset)
-	AssertEq(dt.job.object.Generation, fileInfo.ObjectGeneration)
-	AssertEq(dt.job.object.Size, fileInfo.FileSize)
+	dt.require.Equal(uint64(10), fileInfo.Offset)
+	dt.require.Equal(dt.job.object.Generation, fileInfo.ObjectGeneration)
+	dt.require.Equal(dt.job.object.Size, fileInfo.FileSize)
 	// Confirm job's status offset
-	AssertEq(10, dt.job.status.Offset)
+	dt.require.Equal(int64(10), dt.job.status.Offset)
 	// Check the subscriber's notification
 	notification, ok := <-notificationCh
-	AssertEq(true, ok)
+	dt.require.True(ok)
 	jobStatus := JobStatus{Name: Downloading, Err: nil, Offset: 10}
-	AssertTrue(reflect.DeepEqual(jobStatus, notification))
+	dt.require.Equal(jobStatus, notification)
 }
 
-func (dt *downloaderTest) Test_updateStatusOffset_InsertNew() {
+func Test_updateStatusOffset_InsertNew(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
 		ObjectName: dt.object.Name,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	value := dt.cache.Erase(fileInfoKeyName)
-	AssertTrue(value != nil)
+	dt.require.NotNil(value)
 
 	err = dt.job.updateStatusOffset(10)
 
-	AssertNe(nil, err)
-	AssertTrue(errors.Is(err, lru.ErrEntryNotExist))
+	dt.require.Error(err)
+	dt.require.ErrorIs(err, lru.ErrEntryNotExist)
 	// Confirm job's status offset
-	AssertEq(0, dt.job.status.Offset)
+	dt.require.Equal(int64(0), dt.job.status.Offset)
 }
 
-func (dt *downloaderTest) Test_updateStatusOffset_Fail() {
+func Test_updateStatusOffset_Fail(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	fileInfoKey := data.FileInfoKey{
 		BucketName: storage.TestBucketName,
 		ObjectName: DefaultObjectName,
 	}
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.job.object.Generation, dt.job.object.Size, 0, false, nil, 1)
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// Change the size of object and then try to update file info cache.
 	dt.job.object.Size = 10
 	err = dt.job.updateStatusOffset(15)
 
-	AssertNe(nil, err)
-	AssertTrue(errors.Is(err, lru.ErrInvalidUpdateEntrySize))
+	dt.require.Error(err)
+	dt.require.ErrorIs(err, lru.ErrInvalidUpdateEntrySize)
 	// Confirm job's status offset
-	AssertEq(0, dt.job.status.Offset)
+	dt.require.Equal(int64(0), dt.job.status.Offset)
 }
 
-func (dt *downloaderTest) Test_cleanUpDownloadAsyncJob() {
+func Test_cleanUpDownloadAsyncJob(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	dt.job.mu.Lock()
 	var callbackExecuted atomic.Bool
 	removeCallback := func() { callbackExecuted.Store(true) }
@@ -316,21 +335,23 @@ func (dt *downloaderTest) Test_cleanUpDownloadAsyncJob() {
 	dt.job.cleanUpDownloadAsyncJob()
 
 	// Verify context is canceled
-	AssertTrue(errors.Is(cancelCtx.Err(), context.Canceled))
+	dt.require.ErrorIs(cancelCtx.Err(), context.Canceled)
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	// doneCh is closed
 	_, ok := <-dt.job.doneCh
-	AssertFalse(ok)
+	dt.require.False(ok)
 	// References to context and cancel function are removed
-	AssertEq(nil, dt.job.cancelCtx)
-	AssertEq(nil, dt.job.cancelFunc)
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.Nil(dt.job.cancelCtx)
+	dt.require.Nil(dt.job.cancelFunc)
+	dt.require.Nil(dt.job.removeJobCallback)
 	// Call back function should have been called
-	AssertTrue(callbackExecuted.Load())
+	dt.require.True(callbackExecuted.Load())
 }
 
-func (dt *downloaderTest) Test_downloadObjectToFile() {
+func Test_downloadObjectToFile(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -341,7 +362,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile() {
 	notificationC := dt.job.subscribe(subscribedOffset)
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -349,11 +370,11 @@ func (dt *downloaderTest) Test_downloadObjectToFile() {
 	// Start download
 	err = dt.job.downloadObjectToFile(file)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	jobStatus, ok := <-notificationC
-	AssertEq(true, ok)
+	dt.require.True(ok)
 	// Check the notification is sent after subscribed offset
-	AssertGe(jobStatus.Offset, subscribedOffset)
+	dt.require.GreaterOrEqual(jobStatus.Offset, subscribedOffset)
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	// Verify file is downloaded
@@ -362,7 +383,9 @@ func (dt *downloaderTest) Test_downloadObjectToFile() {
 	dt.verifyFileInfoEntry(uint64(objectSize))
 }
 
-func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
+func Test_downloadObjectToFile_CtxCancelled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/cancel.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -370,7 +393,7 @@ func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -378,13 +401,15 @@ func (dt *downloaderTest) Test_downloadObjectToFile_CtxCancelled() {
 	dt.job.cancelFunc()
 	err = dt.job.downloadObjectToFile(file)
 
-	AssertTrue(errors.Is(err, context.Canceled), fmt.Sprintf("didn't get context canceled error: %v", err))
+	dt.require.ErrorIs(err, context.Canceled, fmt.Sprintf("didn't get context canceled error: %v", err))
 }
 
 // Note: We can't test Test_downloadObjectAsync_MoreThanSequentialReadSize as
 // the fake storage bucket/server in the testing environment doesn't support
 // reading ranges (start and limit in NewReader call)
-func (dt *downloaderTest) Test_downloadObjectAsync_LessThanSequentialReadSize() {
+func Test_downloadObjectAsync_LessThanSequentialReadSize(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	// Create new object in bucket and create new job for it.
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 50 * util.MiB
@@ -401,17 +426,19 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanSequentialReadSize() 
 	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
+	dt.require.Equal(jobStatus, dt.job.status)
 	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	AssertTrue(callbackExecuted.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.True(callbackExecuted.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
+func Test_downloadObjectAsync_LessThanChunkSize(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 2 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -427,17 +454,19 @@ func (dt *downloaderTest) Test_downloadObjectAsync_LessThanChunkSize() {
 	jobStatus := JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
+	dt.require.Equal(jobStatus, dt.job.status)
 	// Verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	AssertTrue(callbackExecuted.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.True(callbackExecuted.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
+func Test_downloadObjectAsync_Notification(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 25 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -454,22 +483,24 @@ func (dt *downloaderTest) Test_downloadObjectAsync_Notification() {
 
 	jobStatus := <-notificationC
 	// check the notification is sent after subscribed offset
-	AssertGe(jobStatus.Offset, subscribedOffset)
+	dt.require.GreaterOrEqual(jobStatus.Offset, subscribedOffset)
 	// check job completed successfully
 	jobStatus = JobStatus{Completed, nil, int64(objectSize)}
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertTrue(reflect.DeepEqual(jobStatus, dt.job.status))
+	dt.require.Equal(jobStatus, dt.job.status)
 	// verify file is downloaded
 	dt.verifyFile(objectContent)
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(objectSize))
 	// Verify callback is executed and removed
-	AssertTrue(callbackExecuted.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.True(callbackExecuted.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_Download_WhenNotStarted() {
+func Test_Download_WhenNotStarted(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -479,18 +510,20 @@ func (dt *downloaderTest) Test_Download_WhenNotStarted() {
 	offset := int64(8 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify that jobStatus is downloading and downloaded more than 8 Mib.
-	AssertEq(Downloading, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	AssertGe(jobStatus.Offset, offset)
+	dt.require.Equal(Downloading, jobStatus.Name)
+	dt.require.NoError(jobStatus.Err)
+	dt.require.GreaterOrEqual(jobStatus.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
-func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
+func Test_Download_WhenAlreadyDownloading(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	// Create new object in bucket and create new job for it.
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 50 * util.MiB
@@ -499,25 +532,27 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyDownloading() {
 	// Start download but not wait for download
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, 1, false)
-	AssertEq(nil, err)
-	AssertEq(Downloading, jobStatus.Name)
+	dt.require.NoError(err)
+	dt.require.Equal(Downloading, jobStatus.Name)
 
 	// Again call download but wait for download this time.
 	offset := int64(25 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify that jobStatus is downloading and downloaded at least 25 Mib.
-	AssertEq(Downloading, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	AssertGe(jobStatus.Offset, offset)
+	dt.require.Equal(Downloading, jobStatus.Name)
+	dt.require.NoError(jobStatus.Err)
+	dt.require.GreaterOrEqual(jobStatus.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// verify file info cache
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
-func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
+func Test_Download_WhenAlreadyCompleted(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -525,30 +560,32 @@ func (dt *downloaderTest) Test_Download_WhenAlreadyCompleted() {
 	// Wait for whole download to be completed.
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize), true)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify that jobStatus is Downloading but offset is object size
 	expectedJobStatus := JobStatus{Downloading, nil, int64(objectSize)}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
+	dt.require.Equal(expectedJobStatus, jobStatus)
 	dt.waitForCrcCheckToBeCompleted()
-	AssertEq(Completed, dt.job.status.Name)
+	dt.require.Equal(Completed, dt.job.status.Name)
 
 	// Try to request for some offset when job was already completed.
 	offset := int64(16 * util.MiB)
 	jobStatus, err = dt.job.Download(ctx, offset, true)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify that jobStatus is completed & offset returned is still 16 MiB
 	// this ensures that async job is not started again.
-	AssertEq(Completed, jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
-	AssertGe(jobStatus.Offset, objectSize)
+	dt.require.Equal(Completed, jobStatus.Name)
+	dt.require.NoError(jobStatus.Err)
+	dt.require.GreaterOrEqual(jobStatus.Offset, int64(objectSize))
 	// Verify file
 	dt.verifyFile(objectContent)
 	// Verify file info cache
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 }
 
-func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
+func Test_Download_WhenAsyncFails(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -563,18 +600,20 @@ func (dt *downloaderTest) Test_Download_WhenAsyncFails() {
 	ctx := context.Background()
 	jobStatus, err := dt.job.Download(ctx, int64(objectSize-10), true)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify that jobStatus is failed
-	AssertEq(Failed, jobStatus.Name)
-	AssertGe(jobStatus.Offset, 0)
-	AssertTrue(errors.Is(jobStatus.Err, lru.ErrInvalidUpdateEntrySize))
+	dt.require.Equal(Failed, jobStatus.Name)
+	dt.require.GreaterOrEqual(jobStatus.Offset, int64(0))
+	dt.require.ErrorIs(jobStatus.Err, lru.ErrInvalidUpdateEntrySize)
 	// Wait for the async goroutine to complete its cleanup.
 	<-dt.job.doneCh
 	// Verify callback is executed
-	AssertTrue(callbackExecuted.Load())
+	dt.require.True(callbackExecuted.Load())
 }
 
-func (dt *downloaderTest) Test_Download_AlreadyFailed() {
+func Test_Download_AlreadyFailed(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -586,12 +625,14 @@ func (dt *downloaderTest) Test_Download_AlreadyFailed() {
 	// Requesting again from download job which is in failed state
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize-1), true)
 
-	AssertEq(nil, err)
-	AssertEq(Failed, jobStatus.Name)
-	AssertTrue(errors.Is(jobStatus.Err, lru.ErrInvalidUpdateEntrySize))
+	dt.require.NoError(err)
+	dt.require.Equal(Failed, jobStatus.Name)
+	dt.require.ErrorIs(jobStatus.Err, lru.ErrInvalidUpdateEntrySize)
 }
 
-func (dt *downloaderTest) Test_Download_AlreadyInvalid() {
+func Test_Download_AlreadyInvalid(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -604,12 +645,14 @@ func (dt *downloaderTest) Test_Download_AlreadyInvalid() {
 	// Requesting download when already invalid.
 	jobStatus, err := dt.job.Download(context.Background(), int64(objectSize), true)
 
-	AssertEq(nil, err)
-	AssertEq(Invalid, jobStatus.Name)
+	dt.require.NoError(err)
+	dt.require.Equal(Invalid, jobStatus.Name)
 	dt.verifyInvalidError(jobStatus.Err)
 }
 
-func (dt *downloaderTest) Test_Download_InvalidOffset() {
+func Test_Download_InvalidOffset(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -621,14 +664,16 @@ func (dt *downloaderTest) Test_Download_InvalidOffset() {
 	offset := int64(objectSize) + 1
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
 
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), fmt.Sprintf("download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size)))
+	dt.require.Error(err)
+	dt.require.Contains(err.Error(), fmt.Sprintf("download: the requested offset %d is greater than the size of object %d", offset, dt.object.Size))
 	expectedJobStatus := JobStatus{NotStarted, nil, 0}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, jobStatus))
-	AssertFalse(callbackExecuted.Load())
+	dt.require.Equal(expectedJobStatus, jobStatus)
+	dt.require.False(callbackExecuted.Load())
 }
 
-func (dt *downloaderTest) Test_Download_CtxCancelled() {
+func Test_Download_CtxCancelled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/cancel.txt"
 	objectSize := 16 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -643,28 +688,30 @@ func (dt *downloaderTest) Test_Download_CtxCancelled() {
 	offset := int64(objectSize)
 	jobStatus, err := dt.job.Download(ctx, offset, true)
 
-	AssertNe(nil, err)
-	AssertTrue(errors.Is(err, context.DeadlineExceeded))
+	dt.require.Error(err)
+	dt.require.ErrorIs(err, context.DeadlineExceeded)
 	// jobStatus is empty in this case.
-	AssertEq("", jobStatus.Name)
-	AssertEq(nil, jobStatus.Err)
+	dt.require.Equal(jobStatusName(""), jobStatus.Name)
+	dt.require.NoError(jobStatus.Err)
 	// job should be either Downloading or Completed.
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertTrue(dt.job.status.Name == Downloading || dt.job.status.Name == Completed)
+	dt.require.True(dt.job.status.Name == Downloading || dt.job.status.Name == Completed)
 	if dt.job.status.Name == Downloading {
-		AssertFalse(callbackExecuted.Load())
+		dt.require.False(callbackExecuted.Load())
 	} else {
-		AssertTrue(callbackExecuted.Load())
+		dt.require.True(callbackExecuted.Load())
 	}
-	AssertEq(nil, dt.job.status.Err)
+	dt.require.NoError(dt.job.status.Err)
 	// Verify file
 	dt.verifyFile(objectContent[:dt.job.status.Offset])
 	// Verify file info cache
 	dt.verifyFileInfoEntry(uint64(dt.job.status.Offset))
 }
 
-func (dt *downloaderTest) Test_Download_Concurrent() {
+func Test_Download_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 25 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -678,14 +725,14 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 		var jobStatus JobStatus
 		var err error
 		jobStatus, err = dt.job.Download(ctx, expectedOffset, true)
-		AssertNe(Failed, jobStatus.Name)
+		dt.require.NotEqual(Failed, jobStatus.Name)
 		if expectedErr != nil {
-			AssertTrue(strings.Contains(err.Error(), expectedErr.Error()))
+			dt.require.Contains(err.Error(), expectedErr.Error())
 			return
 		} else {
-			AssertEq(expectedErr, err)
+			dt.require.NoError(err)
 		}
-		AssertGe(jobStatus.Offset, expectedOffset)
+		dt.require.GreaterOrEqual(jobStatus.Offset, expectedOffset)
 	}
 
 	// Start concurrent downloads
@@ -699,14 +746,16 @@ func (dt *downloaderTest) Test_Download_Concurrent() {
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	expectedJobStatus := JobStatus{Completed, nil, int64(objectSize)}
-	AssertTrue(reflect.DeepEqual(expectedJobStatus, dt.job.status))
+	dt.require.Equal(expectedJobStatus, dt.job.status)
 	// Verify file
 	dt.verifyFile(objectContent)
 	// Verify file info cache
 	dt.verifyFileInfoEntry(uint64(objectSize))
 }
 
-func (dt *downloaderTest) Test_GetStatus() {
+func Test_GetStatus(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 20 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -714,20 +763,22 @@ func (dt *downloaderTest) Test_GetStatus() {
 	ctx := context.Background()
 	// Start download
 	jobStatus, err := dt.job.Download(ctx, util.MiB, true)
-	AssertEq(nil, err)
-	AssertEq(Downloading, jobStatus.Name)
+	dt.require.NoError(err)
+	dt.require.Equal(Downloading, jobStatus.Name)
 
 	// GetStatus in between downloading
 	jobStatus = dt.job.GetStatus()
 
-	AssertTrue((jobStatus.Name == Downloading) || (jobStatus.Name == Completed))
-	AssertEq(nil, jobStatus.Err)
-	AssertGe(jobStatus.Offset, 0)
+	dt.require.True((jobStatus.Name == Downloading) || (jobStatus.Name == Completed))
+	dt.require.NoError(jobStatus.Err)
+	dt.require.GreaterOrEqual(jobStatus.Offset, int64(0))
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 }
 
-func (dt *downloaderTest) Test_Invalidate_WhenDownloading() {
+func Test_Invalidate_WhenDownloading(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -737,20 +788,22 @@ func (dt *downloaderTest) Test_Invalidate_WhenDownloading() {
 	ctx := context.Background()
 	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
-	AssertEq(nil, err)
-	AssertEq(Downloading, jobStatus.Name)
+	dt.require.NoError(err)
+	dt.require.Equal(Downloading, jobStatus.Name)
 
 	dt.job.Invalidate()
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	dt.verifyInvalidError(dt.job.status.Err)
-	AssertEq(Invalid, dt.job.status.Name)
-	AssertTrue(callbackExecuted.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.Equal(Invalid, dt.job.status.Name)
+	dt.require.True(callbackExecuted.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_Invalidate_NotStarted() {
+func Test_Invalidate_NotStarted(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -762,13 +815,15 @@ func (dt *downloaderTest) Test_Invalidate_NotStarted() {
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertEq(nil, dt.job.status.Err)
-	AssertEq(Invalid, dt.job.status.Name)
-	AssertTrue(callbackExecuted.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.NoError(dt.job.status.Err)
+	dt.require.Equal(Invalid, dt.job.status.Name)
+	dt.require.True(callbackExecuted.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
+func Test_Invalidate_WhenAlreadyCompleted(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -778,22 +833,24 @@ func (dt *downloaderTest) Test_Invalidate_WhenAlreadyCompleted() {
 	ctx := context.Background()
 	// Start download with waiting
 	_, err := dt.job.Download(ctx, int64(objectSize), true)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.waitForCrcCheckToBeCompleted()
 	jobStatus := dt.job.GetStatus()
-	AssertEq(Completed, jobStatus.Name)
+	dt.require.Equal(Completed, jobStatus.Name)
 
 	dt.job.Invalidate()
 
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertEq(Invalid, dt.job.status.Name)
+	dt.require.Equal(Invalid, dt.job.status.Name)
 	dt.verifyInvalidError(dt.job.status.Err)
-	AssertEq(1, callbackExecutionCount.Load())
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.Equal(int32(1), callbackExecutionCount.Load())
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_Invalidate_Concurrent() {
+func Test_Invalidate_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 20 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -803,14 +860,14 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	ctx := context.Background()
 	// Start download without waiting
 	jobStatus, err := dt.job.Download(ctx, 0, false)
-	AssertEq(nil, err)
-	AssertEq(Downloading, jobStatus.Name)
+	dt.require.NoError(err)
+	dt.require.Equal(Downloading, jobStatus.Name)
 	wg := sync.WaitGroup{}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		AssertEq(Invalid, currJobStatus.Name)
+		dt.require.Equal(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 
@@ -821,13 +878,15 @@ func (dt *downloaderTest) Test_Invalidate_Concurrent() {
 	}
 	wg.Wait()
 
-	AssertEq(1, callbackExecutionCount.Load())
+	dt.require.Equal(int32(1), callbackExecutionCount.Load())
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
+func Test_Invalidate_Download_Concurrent(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -840,19 +899,19 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 		ctx := context.Background()
 		// Start download without waiting
 		jobStatus, err := dt.job.Download(ctx, offset, waitForDownload)
-		AssertEq(nil, err)
-		AssertTrue(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
+		dt.require.NoError(err)
+		dt.require.True(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
 		// If status is downloading/complete and wait for download is true then
 		// status offset should be at least requested offset.
 		if waitForDownload && (jobStatus.Name == Downloading || jobStatus.Name == Completed) {
-			AssertGe(jobStatus.Offset, offset)
+			dt.require.GreaterOrEqual(jobStatus.Offset, offset)
 		}
 	}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		AssertEq(Invalid, currJobStatus.Name)
+		dt.require.Equal(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 
@@ -869,13 +928,15 @@ func (dt *downloaderTest) Test_Invalidate_Download_Concurrent() {
 	}
 	wg.Wait()
 
-	AssertEq(1, callbackExecutionCount.Load())
+	dt.require.Equal(int32(1), callbackExecutionCount.Load())
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
-	AssertEq(nil, dt.job.removeJobCallback)
+	dt.require.Nil(dt.job.removeJobCallback)
 }
 
-func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue() {
+func Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/file1.txt"
 	objectSize := 8 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -883,32 +944,34 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsTrue() 
 	// Start download
 	offset := int64(8 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Here the crc check will be successful
 	dt.waitForCrcCheckToBeCompleted()
-	AssertEq(Completed, dt.job.status.Name)
-	AssertEq(nil, dt.job.status.Err)
-	AssertGe(dt.job.status.Offset, offset)
+	dt.require.Equal(Completed, dt.job.status.Name)
+	dt.require.NoError(dt.job.status.Err)
+	dt.require.GreaterOrEqual(dt.job.status.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 	// Tamper the file
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "checksum mismatch detected"))
-	AssertEq(nil, dt.getFileInfo())
+	dt.require.Error(err)
+	dt.require.Contains(err.Error(), "checksum mismatch detected")
+	dt.require.Nil(dt.getFileInfo())
 	_, err = os.Stat(dt.fileSpec.Path)
-	AssertNe(nil, err)
-	AssertTrue(strings.Contains(err.Error(), "no such file or directory"))
+	dt.require.Error(err)
+	dt.require.Contains(err.Error(), "no such file or directory")
 }
 
-func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse() {
+func Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/file2.txt"
 	objectSize := 1 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -916,25 +979,25 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse()
 	// Start download
 	offset := int64(1 * util.MiB)
 	jobStatus, err := dt.job.Download(context.Background(), offset, true)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Here the crc check will be successful
 	dt.waitForCrcCheckToBeCompleted()
-	AssertEq(Completed, dt.job.status.Name)
-	AssertEq(nil, dt.job.status.Err)
-	AssertGe(dt.job.status.Offset, offset)
+	dt.require.Equal(Completed, dt.job.status.Name)
+	dt.require.NoError(dt.job.status.Err)
+	dt.require.GreaterOrEqual(dt.job.status.Offset, offset)
 	// Verify file
 	dt.verifyFile(objectContent[:jobStatus.Offset])
 	// Verify fileInfoCache update
 	dt.verifyFileInfoEntry(uint64(jobStatus.Offset))
 	// Tamper the file
 	err = os.WriteFile(dt.fileSpec.Path, []byte("test"), 0644)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	dt.job.fileCacheConfig.EnableCrc = false
 
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	err = dt.job.validateCRC()
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Verify file
 	dt.verifyFile([]byte("test"))
 	// Verify fileInfoCache update
@@ -943,7 +1006,9 @@ func (dt *downloaderTest) Test_validateCRC_ForTamperedFileWhenEnableCRCIsFalse()
 
 // Disabled because it's flaky.
 /*
-func (dt *downloaderTest) Test_validateCRC_WheContextIsCancelled() {
+func Test_validateCRC_WheContextIsCancelled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	objectName := "path/in/gcs/file2.txt"
 	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -951,10 +1016,10 @@ func (dt *downloaderTest) Test_validateCRC_WheContextIsCancelled() {
 	// Start download
 	offset := int64(10 * util.MiB)
 	_, err := dt.job.Download(context.Background(), offset, true)
-	AssertEq(nil, err)
-	AssertTrue((dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
-	AssertEq(nil, dt.job.status.Err)
-	AssertGe(dt.job.status.Offset, offset)
+	dt.require.NoError(err)
+	dt.require.True((dt.job.status.Name == Downloading) || (dt.job.status.Name == Completed), fmt.Sprintf("got job status: %v", dt.job.status.Name))
+	dt.require.NoError(dt.job.status.Err)
+	dt.require.GreaterOrEqual(dt.job.status.Offset, offset)
 
 	// Taking lock to ensure cancelFunc is valid before calling it.
 	dt.job.mu.Lock()
@@ -964,12 +1029,14 @@ func (dt *downloaderTest) Test_validateCRC_WheContextIsCancelled() {
 	dt.job.mu.Unlock()
 	dt.waitForCrcCheckToBeCompleted()
 
-	AssertEq(Invalid, dt.job.status.Name)
+	dt.require.Equal(Invalid, dt.job.status.Name)
 	dt.verifyInvalidError(dt.job.status.Err)
 }
 */
 
-func (dt *downloaderTest) Test_handleError_SetStatusAsInvalidWhenContextIsCancelled() {
+func Test_handleError_SetStatusAsInvalidWhenContextIsCancelled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
 	err := errors.Join(context.Canceled)
@@ -977,15 +1044,17 @@ func (dt *downloaderTest) Test_handleError_SetStatusAsInvalidWhenContextIsCancel
 	err = fmt.Errorf("Wrapping with custom message %w", err)
 	dt.job.handleError(err)
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
-	AssertEq(Invalid, notification.Name)
+	dt.require.Equal(Invalid, notification.Name)
 	dt.verifyInvalidError(notification.Err)
-	AssertEq(0, notification.Offset)
-	AssertEq(true, ok)
+	dt.require.Equal(int64(0), notification.Offset)
+	dt.require.True(ok)
 }
 
-func (dt *downloaderTest) Test_handleError_SetStatusAsErrorWhenContextIsNotCancelled() {
+func Test_handleError_SetStatusAsErrorWhenContextIsNotCancelled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	subscriberOffset := int64(1)
 	notificationC := dt.job.subscribe(subscriberOffset)
 	err := errors.New("custom error")
@@ -993,80 +1062,94 @@ func (dt *downloaderTest) Test_handleError_SetStatusAsErrorWhenContextIsNotCance
 	updatedErr := fmt.Errorf("Custom message %w", err)
 	dt.job.handleError(updatedErr)
 
-	AssertEq(0, dt.job.subscribers.Len())
+	dt.require.Equal(0, dt.job.subscribers.Len())
 	notification, ok := <-notificationC
 	jobStatus := JobStatus{Name: Failed, Err: updatedErr, Offset: 0}
 	fmt.Println(notification)
-	AssertTrue(reflect.DeepEqual(jobStatus, notification))
-	AssertEq(true, ok)
+	dt.require.Equal(jobStatus, notification)
+	dt.require.True(ok)
 }
 
-func (dt *downloaderTest) Test_When_Parallel_Download_Is_Enabled() {
+func Test_When_Parallel_Download_Is_Enabled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.EnableParallelDownloads = true
 
 	result := dt.job.IsParallelDownloadsEnabled()
 
-	AssertTrue(result)
+	dt.require.True(result)
 }
 
-func (dt *downloaderTest) Test_When_Parallel_Download_Is_Disabled() {
+func Test_When_Parallel_Download_Is_Disabled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.EnableParallelDownloads = false
 
 	result := dt.job.IsParallelDownloadsEnabled()
 
-	AssertFalse(result)
+	dt.require.False(result)
 }
 
-func (dt *downloaderTest) Test_When_Experimental_Default_Parallel_Download_Explicitly_Set_On() {
+func Test_When_Experimental_Default_Parallel_Download_Explicitly_Set_On(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.ExperimentalParallelDownloadsDefaultOn = true
 
 	result := dt.job.IsExperimentalParallelDownloadsDefaultOn()
 
-	AssertTrue(result)
+	dt.require.True(result)
 }
 
-func (dt *downloaderTest) Test_When_Experimental_Default_Parallel_Download_On() {
+func Test_When_Experimental_Default_Parallel_Download_On(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 
 	result := dt.job.IsExperimentalParallelDownloadsDefaultOn()
 
-	AssertTrue(result)
+	dt.require.True(result)
 }
 
-func (dt *downloaderTest) Test_createCacheFile_WhenNonParallelDownloads() {
+func Test_createCacheFile_WhenNonParallelDownloads(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.EnableParallelDownloads = false
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()
 }
 
-func (dt *downloaderTest) Test_createCacheFile_WhenParallelDownloads() {
+func Test_createCacheFile_WhenParallelDownloads(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.EnableParallelDownloads = true
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()
 }
 
-func (dt *downloaderTest) Test_createCacheFile_WhenParallelDownloadsEnabledAndODirectDisabled() {
+func Test_createCacheFile_WhenParallelDownloadsEnabledAndODirectDisabled(t *testing.T) {
+	dt := newDownloaderTest(t)
+	defer dt.tearDown()
 	//Arrange - initJobTest is being called in setup of downloader.go
 	dt.job.fileCacheConfig.EnableParallelDownloads = true
 	dt.job.fileCacheConfig.EnableODirect = false
 
 	cacheFile, err := dt.job.createCacheFile()
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = cacheFile.Close()
 	}()

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -725,14 +725,14 @@ func Test_Download_Concurrent(t *testing.T) {
 		var jobStatus JobStatus
 		var err error
 		jobStatus, err = dt.job.Download(ctx, expectedOffset, true)
-		dt.require.NotEqual(Failed, jobStatus.Name)
+		dt.assert.NotEqual(Failed, jobStatus.Name)
 		if expectedErr != nil {
-			dt.require.Contains(err.Error(), expectedErr.Error())
+			dt.assert.Contains(err.Error(), expectedErr.Error())
 			return
 		} else {
-			dt.require.NoError(err)
+			dt.assert.NoError(err)
 		}
-		dt.require.GreaterOrEqual(jobStatus.Offset, expectedOffset)
+		dt.assert.GreaterOrEqual(jobStatus.Offset, expectedOffset)
 	}
 
 	// Start concurrent downloads
@@ -867,7 +867,7 @@ func Test_Invalidate_Concurrent(t *testing.T) {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		dt.require.Equal(Invalid, currJobStatus.Name)
+		dt.assert.Equal(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 
@@ -899,19 +899,19 @@ func Test_Invalidate_Download_Concurrent(t *testing.T) {
 		ctx := context.Background()
 		// Start download without waiting
 		jobStatus, err := dt.job.Download(ctx, offset, waitForDownload)
-		dt.require.NoError(err)
-		dt.require.True(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
+		dt.assert.NoError(err)
+		dt.assert.True(jobStatus.Name == Downloading || jobStatus.Name == Invalid || jobStatus.Name == Completed)
 		// If status is downloading/complete and wait for download is true then
 		// status offset should be at least requested offset.
 		if waitForDownload && (jobStatus.Name == Downloading || jobStatus.Name == Completed) {
-			dt.require.GreaterOrEqual(jobStatus.Offset, offset)
+			dt.assert.GreaterOrEqual(jobStatus.Offset, offset)
 		}
 	}
 	invalidateFunc := func() {
 		defer wg.Done()
 		dt.job.Invalidate()
 		currJobStatus := dt.job.GetStatus()
-		dt.require.Equal(Invalid, currJobStatus.Name)
+		dt.assert.Equal(Invalid, currJobStatus.Name)
 		dt.verifyInvalidError(currJobStatus.Err)
 	}
 

--- a/internal/cache/file/downloader/job_test.go
+++ b/internal/cache/file/downloader/job_test.go
@@ -76,7 +76,7 @@ func (dt *downloaderTest) initJobTest(objectName string, objectContent []byte, s
 }
 
 func (dt *downloaderTest) verifyInvalidError(err error) {
-	dt.require.True((nil == err) || (errors.Is(err, context.Canceled)) || errors.Is(err, lru.ErrEntryNotExist),
+	dt.assert.True((nil == err) || (errors.Is(err, context.Canceled)) || errors.Is(err, lru.ErrEntryNotExist),
 		fmt.Sprintf("actual error:%v is not as expected", err))
 }
 

--- a/internal/cache/file/downloader/parallel_downloads_job_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_test.go
@@ -19,11 +19,9 @@ package downloader
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"sync/atomic"
 	"testing"
 
@@ -31,21 +29,22 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-// TestParallelDownloader runs all the tests with parallel downloads job that
-// are run without parallel downloads job as part of TestDownloader in
-// downloader_test.go
-func TestParallelDownloader(t *testing.T) { RunTests(t) }
 
 type parallelDownloaderTest struct {
 	downloaderTest
 }
 
-func init() { RegisterTestSuite(&parallelDownloaderTest{}) }
-
-func (dt *parallelDownloaderTest) SetUp(*TestInfo) {
+func newParallelDownloaderTest(t *testing.T) *parallelDownloaderTest {
+	dt := &parallelDownloaderTest{
+		downloaderTest: downloaderTest{
+			t:       t,
+			assert:  assert.New(t),
+			require: require.New(t),
+		},
+	}
 	dt.defaultFileCacheConfig = &cfg.FileCacheConfig{
 		ExperimentalParallelDownloadsDefaultOn: true,
 		EnableParallelDownloads:                true,
@@ -55,9 +54,13 @@ func (dt *parallelDownloaderTest) SetUp(*TestInfo) {
 		WriteBufferSize:                        4 * 1024 * 1024,
 	}
 	dt.setupHelper()
+	return dt
 }
 
-func (dt *parallelDownloaderTest) Test_downloadRange() {
+func TestParallel_downloadRange(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	// Create object in fake GCS
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
@@ -69,15 +72,15 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	defer dt.job.cancelFunc()
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	verifyContentAtOffset := func(file *os.File, start, end int64) {
 		_, err = file.Seek(int64(start), 0)
-		AssertEq(nil, err)
+		dt.require.NoError(err)
 		buf := make([]byte, end-start)
 		_, err = file.Read(buf)
-		AssertEq(nil, err)
+		dt.require.NoError(err)
 		// If content don't match then print start and end for easy debuggability.
-		AssertTrue(reflect.DeepEqual(objectContent[start:end], buf), fmt.Sprintf("content didn't match for start: %v and end: %v", start, end))
+		dt.require.Equal(objectContent[start:end], buf, fmt.Sprintf("content didn't match for start: %v and end: %v", start, end))
 	}
 
 	// Download end 1MiB of object
@@ -86,35 +89,38 @@ func (dt *parallelDownloaderTest) Test_downloadRange() {
 	rangeMap := make(map[int64]int64)
 
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	verifyContentAtOffset(file, start, end)
 
 	// Download start 4MiB of object
 	start, end = int64(0*util.MiB), int64(4*util.MiB)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(4*util.MiB), rangeMap[start])
+	dt.require.Equal(int64(4*util.MiB), rangeMap[start])
 
 	// Download middle 1B of object
 	start, end = int64(5*util.MiB), int64(5*util.MiB+1)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(5*util.MiB+1), rangeMap[start])
+	dt.require.Equal(int64(5*util.MiB+1), rangeMap[start])
 
 	// Download 0B of object
 	start, end = int64(5*util.MiB), int64(5*util.MiB)
 	offsetWriter = io.NewOffsetWriter(file, start)
 	_, err = dt.job.downloadRange(context.Background(), offsetWriter, start, end, nil, rangeMap)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	verifyContentAtOffset(file, start, end)
-	AssertEq(int64(5*util.MiB+1), rangeMap[start])
+	dt.require.Equal(int64(5*util.MiB+1), rangeMap[start])
 }
 
-func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
+func TestParallel_parallelDownloadObjectToFile(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "path/in/gcs/foo.txt"
 	objectSize := 10 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -126,7 +132,7 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
 	notificationC := dt.job.subscribe(subscribedOffset)
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -134,11 +140,11 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
 	// Start download
 	err = dt.job.parallelDownloadObjectToFile(file)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	jobStatus, ok := <-notificationC
-	AssertEq(true, ok)
+	dt.require.True(ok)
 	// Check the notification is sent after subscribed offset
-	AssertGe(jobStatus.Offset, subscribedOffset)
+	dt.require.GreaterOrEqual(jobStatus.Offset, subscribedOffset)
 	dt.job.mu.Lock()
 	defer dt.job.mu.Unlock()
 	// Verify file is downloaded
@@ -147,7 +153,10 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile() {
 	dt.verifyFileInfoEntry(uint64(objectSize))
 }
 
-func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile_CtxCancelled() {
+func TestParallel_parallelDownloadObjectToFile_CtxCancelled(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "path/in/gcs/cancel.txt"
 	objectSize := util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -155,7 +164,7 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile_CtxCancelled
 	dt.job.cancelCtx, dt.job.cancelFunc = context.WithCancel(context.Background())
 	file, err := util.CreateFile(data.FileSpec{Path: dt.job.fileSpec.Path,
 		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer func() {
 		_ = file.Close()
 	}()
@@ -163,21 +172,27 @@ func (dt *parallelDownloaderTest) Test_parallelDownloadObjectToFile_CtxCancelled
 	dt.job.cancelFunc()
 	err = dt.job.parallelDownloadObjectToFile(file)
 
-	AssertTrue(errors.Is(err, context.Canceled), fmt.Sprintf("didn't get context canceled error: %v", err))
+	dt.require.ErrorIs(err, context.Canceled)
 }
 
-func (dt *parallelDownloaderTest) Test_updateRangeMap_withNoEntries() {
+func TestParallel_updateRangeMap_withNoEntries(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	rangeMap := make(map[int64]int64)
 
 	err := dt.job.updateRangeMap(rangeMap, 0, 10)
 
-	AssertEq(nil, err)
-	AssertEq(2, len(rangeMap))
-	AssertEq(10, rangeMap[0])
-	AssertEq(0, rangeMap[10])
+	dt.require.NoError(err)
+	dt.require.Len(rangeMap, 2)
+	dt.require.Equal(int64(10), rangeMap[0])
+	dt.require.Equal(int64(0), rangeMap[10])
 }
 
-func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithEndOffset() {
+func TestParallel_updateRangeMap_withInputContinuousWithEndOffset(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 2
 	rangeMap[2] = 0
@@ -186,15 +201,18 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithEnd
 
 	err := dt.job.updateRangeMap(rangeMap, 6, 8)
 
-	AssertEq(nil, err)
-	AssertEq(4, len(rangeMap))
-	AssertEq(2, rangeMap[0])
-	AssertEq(0, rangeMap[2])
-	AssertEq(8, rangeMap[4])
-	AssertEq(4, rangeMap[8])
+	dt.require.NoError(err)
+	dt.require.Len(rangeMap, 4)
+	dt.require.Equal(int64(2), rangeMap[0])
+	dt.require.Equal(int64(0), rangeMap[2])
+	dt.require.Equal(int64(8), rangeMap[4])
+	dt.require.Equal(int64(4), rangeMap[8])
 }
 
-func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithStartOffset() {
+func TestParallel_updateRangeMap_withInputContinuousWithStartOffset(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	rangeMap := make(map[int64]int64)
 	rangeMap[2] = 4
 	rangeMap[4] = 2
@@ -203,15 +221,18 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputContinuousWithSta
 
 	err := dt.job.updateRangeMap(rangeMap, 0, 2)
 
-	AssertEq(nil, err)
-	AssertEq(4, len(rangeMap))
-	AssertEq(4, rangeMap[0])
-	AssertEq(0, rangeMap[4])
-	AssertEq(10, rangeMap[8])
-	AssertEq(8, rangeMap[10])
+	dt.require.NoError(err)
+	dt.require.Len(rangeMap, 4)
+	dt.require.Equal(int64(4), rangeMap[0])
+	dt.require.Equal(int64(0), rangeMap[4])
+	dt.require.Equal(int64(10), rangeMap[8])
+	dt.require.Equal(int64(8), rangeMap[10])
 }
 
-func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputFillingTheMissingRange() {
+func TestParallel_updateRangeMap_withInputFillingTheMissingRange(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 4
 	rangeMap[4] = 0
@@ -220,13 +241,16 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputFillingTheMissing
 
 	err := dt.job.updateRangeMap(rangeMap, 4, 6)
 
-	AssertEq(nil, err)
-	AssertEq(2, len(rangeMap))
-	AssertEq(8, rangeMap[0])
-	AssertEq(0, rangeMap[8])
+	dt.require.NoError(err)
+	dt.require.Len(rangeMap, 2)
+	dt.require.Equal(int64(8), rangeMap[0])
+	dt.require.Equal(int64(0), rangeMap[8])
 }
 
-func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputNotOverlappingWithAnyRanges() {
+func TestParallel_updateRangeMap_withInputNotOverlappingWithAnyRanges(t *testing.T) {
+	dt := newParallelDownloaderTest(t)
+	defer dt.tearDown()
+
 	rangeMap := make(map[int64]int64)
 	rangeMap[0] = 4
 	rangeMap[4] = 0
@@ -235,12 +259,12 @@ func (dt *parallelDownloaderTest) Test_updateRangeMap_withInputNotOverlappingWit
 
 	err := dt.job.updateRangeMap(rangeMap, 8, 10)
 
-	AssertEq(nil, err)
-	AssertEq(6, len(rangeMap))
-	AssertEq(0, rangeMap[4])
-	AssertEq(4, rangeMap[0])
-	AssertEq(8, rangeMap[10])
-	AssertEq(10, rangeMap[8])
-	AssertEq(12, rangeMap[14])
-	AssertEq(14, rangeMap[12])
+	dt.require.NoError(err)
+	dt.require.Len(rangeMap, 6)
+	dt.require.Equal(int64(0), rangeMap[4])
+	dt.require.Equal(int64(4), rangeMap[0])
+	dt.require.Equal(int64(8), rangeMap[10])
+	dt.require.Equal(int64(10), rangeMap[8])
+	dt.require.Equal(int64(12), rangeMap[14])
+	dt.require.Equal(int64(14), rangeMap[12])
 }

--- a/internal/cache/file/downloader/sparse_downloads_job_test.go
+++ b/internal/cache/file/downloader/sparse_downloads_job_test.go
@@ -18,9 +18,7 @@ package downloader
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"reflect"
 	"sync/atomic"
 	"testing"
 
@@ -28,19 +26,22 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/util"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-// TestSparseDownloader runs all tests for sparse file downloads
-func TestSparseDownloader(t *testing.T) { RunTests(t) }
 
 type sparseDownloaderTest struct {
 	downloaderTest
 }
 
-func init() { RegisterTestSuite(&sparseDownloaderTest{}) }
-
-func (dt *sparseDownloaderTest) SetUp(*TestInfo) {
+func newSparseDownloaderTest(t *testing.T) *sparseDownloaderTest {
+	dt := &sparseDownloaderTest{
+		downloaderTest: downloaderTest{
+			t:       t,
+			assert:  assert.New(t),
+			require: require.New(t),
+		},
+	}
 	dt.defaultFileCacheConfig = &cfg.FileCacheConfig{
 		ExperimentalEnableChunkCache:           true,
 		DownloadChunkSizeMb:                    20, // 20MB chunks for sparse files
@@ -48,9 +49,13 @@ func (dt *sparseDownloaderTest) SetUp(*TestInfo) {
 		ExperimentalParallelDownloadsDefaultOn: true,
 	}
 	dt.setupHelper()
+	return dt
 }
 
-func (dt *sparseDownloaderTest) Test_getChunksToDownload() {
+func TestSparse_getChunksToDownload(t *testing.T) {
+	dt := newSparseDownloaderTest(t)
+	defer dt.tearDown()
+
 	tests := []struct {
 		name           string
 		offset         int64
@@ -115,32 +120,37 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload() {
 	}
 
 	for _, tt := range tests {
-		objectName := "test/sparse_chunk_boundaries.txt"
-		dt.initJobTest(objectName, nil, DefaultSequentialReadSizeMb, tt.objectSize, func() {})
-		dt.job.fileCacheConfig.DownloadChunkSizeMb = tt.chunkSizeMb
-		// Manually insert FileInfo with DownloadedChunks
-		fileInfoKey := data.FileInfoKey{
-			BucketName: dt.job.bucket.Name(),
-			ObjectName: dt.job.object.Name,
-		}
-		chunkSizeBytes := uint64(tt.chunkSizeMb) * util.MiB
-		fileInfo := data.NewFileInfo(fileInfoKey, dt.job.object.Generation, tt.objectSize, ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, tt.objectSize), 1)
-
-		chunks, _, err := dt.job.getChunksToDownload(fileInfo, tt.offset, tt.requiredOffset)
-
-		if tt.expectError {
-			AssertNe(nil, err, fmt.Sprintf("Test case %q: expected error but got none", tt.name))
-		} else {
-			AssertEq(nil, err, fmt.Sprintf("Test case %q: unexpected error: %v", tt.name, err))
-			AssertEq(len(tt.expectedChunks), len(chunks), fmt.Sprintf("Test case %q: chunks count mismatch", tt.name))
-			for i, chunkID := range chunks {
-				AssertEq(tt.expectedChunks[i], chunkID, fmt.Sprintf("Test case %q: chunk %d mismatch", tt.name, i))
+		t.Run(tt.name, func(t *testing.T) {
+			objectName := "test/sparse_chunk_boundaries.txt"
+			dt.initJobTest(objectName, nil, DefaultSequentialReadSizeMb, tt.objectSize, func() {})
+			dt.job.fileCacheConfig.DownloadChunkSizeMb = tt.chunkSizeMb
+			// Manually insert FileInfo with DownloadedChunks
+			fileInfoKey := data.FileInfoKey{
+				BucketName: dt.job.bucket.Name(),
+				ObjectName: dt.job.object.Name,
 			}
-		}
+			chunkSizeBytes := uint64(tt.chunkSizeMb) * util.MiB
+			fileInfo := data.NewFileInfo(fileInfoKey, dt.job.object.Generation, tt.objectSize, ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, tt.objectSize), 1)
+
+			chunks, _, err := dt.job.getChunksToDownload(fileInfo, tt.offset, tt.requiredOffset)
+
+			if tt.expectError {
+				dt.require.Error(err)
+			} else {
+				dt.require.NoError(err)
+				dt.require.Len(chunks, len(tt.expectedChunks))
+				for i, chunkID := range chunks {
+					dt.require.Equal(tt.expectedChunks[i], chunkID)
+				}
+			}
+		})
 	}
 }
 
-func (dt *sparseDownloaderTest) Test_getChunksToDownload_WithInflight() {
+func TestSparse_getChunksToDownload_WithInflight(t *testing.T) {
+	dt := newSparseDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "test/sparse_inflight.txt"
 	objectSize := 100 * util.MiB
 	dt.initJobTest(objectName, nil, DefaultSequentialReadSizeMb, uint64(objectSize), func() {})
@@ -162,26 +172,29 @@ func (dt *sparseDownloaderTest) Test_getChunksToDownload_WithInflight() {
 
 	chunks, waitChans, err := dt.job.getChunksToDownload(fileInfo, 0, 60*util.MiB)
 
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	// Should have 2 chunks to download: Chunk 0 and Chunk 2
-	AssertEq(2, len(chunks))
-	AssertEq(uint64(0), chunks[0]) // Chunk 0
-	AssertEq(uint64(2), chunks[1]) // Chunk 2
+	dt.require.Len(chunks, 2)
+	dt.require.Equal(uint64(0), chunks[0]) // Chunk 0
+	dt.require.Equal(uint64(2), chunks[1]) // Chunk 2
 	// Should have 1 wait channel
-	AssertEq(1, len(waitChans))
-	AssertEq(inflightCh, waitChans[0])
+	dt.require.Len(waitChans, 1)
+	dt.require.Equal(inflightCh, waitChans[0])
 	// Verify inflightChunks map was updated
 	dt.job.mu.Lock()
 	_, ok0 := dt.job.inflightChunks[0]
 	_, ok1 := dt.job.inflightChunks[1]
 	_, ok2 := dt.job.inflightChunks[2]
 	dt.job.mu.Unlock()
-	AssertTrue(ok0, "Chunk 0 should be marked inflight")
-	AssertTrue(ok1, "Chunk 1 should remain inflight")
-	AssertTrue(ok2, "Chunk 2 should be marked inflight")
+	dt.require.True(ok0, "Chunk 0 should be marked inflight")
+	dt.require.True(ok1, "Chunk 1 should remain inflight")
+	dt.require.True(ok2, "Chunk 2 should be marked inflight")
 }
 
-func (dt *sparseDownloaderTest) Test_DownloadRange() {
+func TestSparse_DownloadRange(t *testing.T) {
+	dt := newSparseDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "test/sparse_download_range.txt"
 	objectSize := 50 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -199,7 +212,7 @@ func (dt *sparseDownloaderTest) Test_DownloadRange() {
 		FilePerm: os.FileMode(0600),
 		DirPerm:  os.FileMode(0700),
 	}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer file.Close()
 
 	// Set up sparse file info in cache
@@ -208,35 +221,38 @@ func (dt *sparseDownloaderTest) Test_DownloadRange() {
 		ObjectName: objectName,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	chunkSizeBytes := uint64(20) * 1024 * 1024
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize)), 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// Download a range [10MB, 30MB)
 	start := uint64(10 * util.MiB)
 	end := uint64(30 * util.MiB)
 	err = dt.job.downloadSparseRange(context.Background(), start, end)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// Verify the content was written correctly
 	_, err = file.Seek(int64(start), 0)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	buf := make([]byte, end-start)
 	_, err = file.Read(buf)
-	AssertEq(nil, err)
-	AssertTrue(reflect.DeepEqual(objectContent[start:end], buf), "Downloaded content doesn't match")
+	dt.require.NoError(err)
+	dt.require.Equal(objectContent[start:end], buf, "Downloaded content doesn't match")
 
 	// Verify the downloaded range was tracked in ByteRangeMap
 	updatedFileInfoVal := dt.cache.LookUpWithoutChangingOrder(fileInfoKeyName)
-	AssertTrue(updatedFileInfoVal != nil, "FileInfo should exist in cache")
+	dt.require.NotNil(updatedFileInfoVal, "FileInfo should exist in cache")
 	updatedFileInfo := updatedFileInfoVal.(data.FileInfo)
-	AssertTrue(updatedFileInfo.DownloadedChunks.ContainsRange(start, end), "Downloaded range not tracked in ByteRangeMap")
+	dt.require.True(updatedFileInfo.DownloadedChunks.ContainsRange(start, end), "Downloaded range not tracked in ByteRangeMap")
 }
 
-func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
+func TestSparse_HandleSparseRead_AlreadyDownloaded(t *testing.T) {
+	dt := newSparseDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "test/sparse_already_downloaded.txt"
 	objectSize := 50 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -251,7 +267,7 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
 		ObjectName: objectName,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	chunkSizeBytes := uint64(20) * 1024 * 1024
 	downloadedRanges := data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize))
@@ -259,18 +275,21 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_AlreadyDownloaded() {
 
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, downloadedRanges, 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// Request a range that's already downloaded [5MB, 10MB)
 	offset := int64(5 * util.MiB)
 	requiredOffset := int64(10 * util.MiB)
 	cacheHit, err := dt.job.HandleSparseRead(context.Background(), offset, requiredOffset)
 
-	AssertEq(nil, err)
-	AssertTrue(cacheHit, "Should be a cache hit for already downloaded range")
+	dt.require.NoError(err)
+	dt.require.True(cacheHit, "Should be a cache hit for already downloaded range")
 }
 
-func (dt *sparseDownloaderTest) Test_HandleSparseRead_NeedsDownload() {
+func TestSparse_HandleSparseRead_NeedsDownload(t *testing.T) {
+	dt := newSparseDownloaderTest(t)
+	defer dt.tearDown()
+
 	objectName := "test/sparse_needs_download.txt"
 	objectSize := 100 * util.MiB
 	objectContent := testutil.GenerateRandomBytes(objectSize)
@@ -285,7 +304,7 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_NeedsDownload() {
 		FilePerm: os.FileMode(0600),
 		DirPerm:  os.FileMode(0700),
 	}, os.O_TRUNC|os.O_RDWR)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	defer file.Close()
 
 	// Set up sparse file info with empty downloaded ranges
@@ -294,35 +313,34 @@ func (dt *sparseDownloaderTest) Test_HandleSparseRead_NeedsDownload() {
 		ObjectName: objectName,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	chunkSizeBytes := uint64(20) * 1024 * 1024
 	fileInfo := data.NewFileInfo(fileInfoKey, dt.object.Generation, uint64(objectSize), ^uint64(0), true, data.NewByteRangeMap(chunkSizeBytes, uint64(objectSize)), 1)
 	_, err = dt.cache.Insert(fileInfoKeyName, fileInfo)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 
 	// Request a range that needs to be downloaded [15MB, 25MB)
 	offset := int64(15 * util.MiB)
 	requiredOffset := int64(25 * util.MiB)
 	cacheHit, err := dt.job.HandleSparseRead(context.Background(), offset, requiredOffset)
 
-	AssertEq(nil, err)
-	AssertTrue(cacheHit, "Should be a cache hit after successful download")
+	dt.require.NoError(err)
+	dt.require.True(cacheHit, "Should be a cache hit after successful download")
 
 	// Verify the chunk was downloaded [0, 40MB) due to alignment
 	// offset 15MB rounds down to 0, requiredOffset 25MB rounds up to 40MB
 	updatedFileInfoVal := dt.cache.LookUpWithoutChangingOrder(fileInfoKeyName)
-	AssertTrue(updatedFileInfoVal != nil, "FileInfo should exist in cache")
+	dt.require.NotNil(updatedFileInfoVal, "FileInfo should exist in cache")
 	updatedFileInfo := updatedFileInfoVal.(data.FileInfo)
-	AssertTrue(updatedFileInfo.DownloadedChunks.ContainsRange(0, 40*util.MiB),
+	dt.require.True(updatedFileInfo.DownloadedChunks.ContainsRange(0, 40*util.MiB),
 		"Expected range [0, 40MB) to be downloaded")
 
 	// Verify the content
 	_, err = file.Seek(int64(offset), 0)
-	AssertEq(nil, err)
+	dt.require.NoError(err)
 	buf := make([]byte, requiredOffset-offset)
 	_, err = file.Read(buf)
-	AssertEq(nil, err)
-	AssertTrue(reflect.DeepEqual(objectContent[offset:requiredOffset], buf),
-		"Downloaded content doesn't match")
+	dt.require.NoError(err)
+	dt.require.Equal(objectContent[offset:requiredOffset], buf, "Downloaded content doesn't match")
 }

--- a/internal/cache/file/downloader/sparse_downloads_job_test.go
+++ b/internal/cache/file/downloader/sparse_downloads_job_test.go
@@ -135,12 +135,12 @@ func TestSparse_getChunksToDownload(t *testing.T) {
 			chunks, _, err := dt.job.getChunksToDownload(fileInfo, tt.offset, tt.requiredOffset)
 
 			if tt.expectError {
-				dt.require.Error(err)
+				require.Error(t, err)
 			} else {
-				dt.require.NoError(err)
-				dt.require.Len(chunks, len(tt.expectedChunks))
+				require.NoError(t, err)
+				require.Len(t, chunks, len(tt.expectedChunks))
 				for i, chunkID := range chunks {
-					dt.require.Equal(tt.expectedChunks[i], chunkID)
+					assert.Equal(t, tt.expectedChunks[i], chunkID)
 				}
 			}
 		})


### PR DESCRIPTION
### Description
Migrate tests in `internal/cache/file/downloader` from legacy `ogletest` to `testify`:
- **`downloader_test.go`**: Convert to standard `Test_*` functions with `newDownloaderTest(t)` helper, `t.TempDir()`, and `assert`/`require`.
- **`job_test.go`**: Convert suite methods to standalone tests using `newJobTest(t)` and testify assertions.
- **`parallel_downloads_job_test.go`**: Migrate parallel download test suite to testify.
- **`sparse_downloads_job_test.go`**: Migrate sparse download tests to table-driven tests with testify.
### Link to the issue in case of a bug fix.
N/A
### Testing details
1. Manual - `make build` passed.
2. Unit tests - `go test -v -count=1 ./internal/cache/file/downloader/...` passed.
3. Integration tests - N/A
### Any backward incompatible change? If so, please explain.
N/A