### PR TITLE
feat(Improvements): Migrate gcsx integration and random_reader tests to testify

### DIFF
--- a/internal/gcsx/file_cache_reader.go
+++ b/internal/gcsx/file_cache_reader.go
@@ -33,10 +33,12 @@ import (
 	"github.com/jacobsa/fuse/fuseops"
 )
 
+type readContextKey string
+
 const (
 	// ReadOp ("readOp") is the value used in read context to store pointer to the read operation.
-	ReadOp = "readOp"
-	MiB    = 1 << 20
+	ReadOp readContextKey = "readOp"
+	MiB                   = 1 << 20
 )
 
 // FileCacheReader is a reader that attempts to satisfy read requests for a GCS

--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -16,6 +16,7 @@ package gcsx_test
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -24,23 +25,14 @@ import (
 	"testing"
 	"time"
 
-	"context"
-
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/storageutil"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/gcsx"
-	. "github.com/jacobsa/oglematchers"
-	. "github.com/jacobsa/ogletest"
 	"github.com/jacobsa/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
-
-func TestIntegration(t *testing.T) { RunTests(t) }
-
-////////////////////////////////////////////////////////////////////////
-// Boilerplate
-////////////////////////////////////////////////////////////////////////
 
 // Create random content of the given length, which must be a multiple of 4.
 func randBytes(n int) (b []byte) {
@@ -64,26 +56,28 @@ func randBytes(n int) (b []byte) {
 // Boilerplate
 ////////////////////////////////////////////////////////////////////////
 
-type IntegrationTest struct {
-	ctx    context.Context
-	bucket gcs.Bucket
-	clock  timeutil.SimulatedClock
-	syncer gcsx.Syncer
-
-	tf gcsx.TempFile
+type integrationTestHelper struct {
+	t       *testing.T
+	assert  *assert.Assertions
+	require *require.Assertions
+	ctx     context.Context
+	bucket  gcs.Bucket
+	clock   timeutil.SimulatedClock
+	syncer  gcsx.Syncer
+	tf      gcsx.TempFile
 }
 
-var _ SetUpInterface = &IntegrationTest{}
-var _ TearDownInterface = &IntegrationTest{}
-
-func init() { RegisterTestSuite(&IntegrationTest{}) }
-
-func (t *IntegrationTest) SetUp(ti *TestInfo) {
-	t.ctx = ti.Ctx
-	t.bucket = fake.NewFakeBucket(&t.clock, "some_bucket", gcs.BucketType{})
+func newIntegrationTestHelper(t *testing.T) *integrationTestHelper {
+	h := &integrationTestHelper{
+		t:       t,
+		assert:  assert.New(t),
+		require: require.New(t),
+		ctx:     context.Background(),
+	}
+	h.bucket = fake.NewFakeBucket(&h.clock, "some_bucket", gcs.BucketType{})
 
 	// Set up a fixed, non-zero time.
-	t.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
+	h.clock.SetTime(time.Date(2012, 8, 15, 22, 56, 0, 0, time.Local))
 
 	// Set up the syncer.
 	const appendThreshold = 0
@@ -91,49 +85,58 @@ func (t *IntegrationTest) SetUp(ti *TestInfo) {
 	const chunkTransferTimeoutSecs = 10
 	const tmpObjectPrefix = ".gcsfuse_tmp/"
 
-	t.syncer = gcsx.NewSyncer(
+	h.syncer = gcsx.NewSyncer(
 		appendThreshold,
 		chunkRetryDeadlineSecs,
 		chunkTransferTimeoutSecs,
 		tmpObjectPrefix,
-		t.bucket)
+		h.bucket)
+
+	return h
 }
 
-func (t *IntegrationTest) TearDown() {
-	if t.tf != nil {
-		t.tf.Destroy()
+func (h *integrationTestHelper) tearDown() {
+	if h.tf != nil {
+		h.tf.Destroy()
 	}
 }
 
-func (t *IntegrationTest) create(o *gcs.Object) {
+func (h *integrationTestHelper) create(o *gcs.Object) {
+	if h.tf != nil {
+		h.tf.Destroy()
+	}
 	if o.Finalized.IsZero() {
-		o.Finalized = t.clock.Now()
+		o.Finalized = h.clock.Now()
 	}
 
 	// Set up a reader.
-	rc, err := t.bucket.NewReaderWithReadHandle(
-		t.ctx,
+	rc, err := h.bucket.NewReaderWithReadHandle(
+		h.ctx,
 		&gcs.ReadObjectRequest{
 			Name:       o.Name,
 			Generation: o.Generation,
 		})
-
-	AssertEq(nil, err)
+	h.require.NoError(err)
 
 	// Use it to create the temp file.
-	t.tf, err = gcsx.NewTempFile(rc, "", &t.clock)
-	AssertEq(nil, err)
+	h.tf, err = gcsx.NewTempFile(rc, h.t.TempDir(), &h.clock)
+	h.require.NoError(err)
 
 	// Close it.
 	err = rc.Close()
-	AssertEq(nil, err)
+	h.require.NoError(err)
+}
+
+// Helper to write to h.tf avoiding linter issues with embedded interfaces.
+func (h *integrationTestHelper) writeAt(p []byte, off int64) (int, error) {
+	return h.tf.(io.WriterAt).WriteAt(p, off)
 }
 
 // Return the object generation, or -1 if non-existent. Panic on error.
-func (t *IntegrationTest) objectGeneration(name string) (gen int64) {
+func (h *integrationTestHelper) objectGeneration(name string) (gen int64) {
 	// Stat.
 	req := &gcs.StatObjectRequest{Name: name}
-	m, _, err := t.bucket.StatObject(t.ctx, req)
+	m, _, err := h.bucket.StatObject(h.ctx, req)
 
 	var notFoundErr *gcs.NotFoundError
 	if errors.As(err, &notFoundErr) {
@@ -141,366 +144,383 @@ func (t *IntegrationTest) objectGeneration(name string) (gen int64) {
 		return
 	}
 
-	if err != nil {
-		panic(err)
-	}
-
+	h.require.NoError(err)
 	gen = m.Generation
 	return
 }
 
-func (t *IntegrationTest) sync(src *gcs.Object) (o *gcs.Object, err error) {
-	o, err = t.syncer.SyncObject(t.ctx, src.Name, src, t.tf)
+func (h *integrationTestHelper) sync(src *gcs.Object) (*gcs.Object, error) {
+	o, err := h.syncer.SyncObject(h.ctx, src.Name, src, h.tf)
 	if err == nil && o != nil {
-		t.tf = nil
+		h.tf = nil
 	}
+	return o, err
+}
 
-	return
+func (h *integrationTestHelper) verifyBucketContents(expectedNames []string) {
+	objects, runs, err := storageutil.ListAll(h.ctx, h.bucket, &gcs.ListObjectsRequest{})
+	h.require.NoError(err)
+	h.assert.Equal(0, len(runs))
+
+	var names []string
+	for _, o := range objects {
+		names = append(names, o.Name)
+	}
+	h.assert.ElementsMatch(expectedNames, names)
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *IntegrationTest) ReadThenSync() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_ReadThenSync(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Read the contents.
 	buf := make([]byte, 1024)
-	n, err := t.tf.ReadAt(buf, 0)
+	n, err := h.tf.ReadAt(buf, 0)
 
-	AssertThat(err, AnyOf(io.EOF, nil))
-	ExpectEq(len("taco"), n)
-	ExpectEq("taco", string(buf[:n]))
+	h.require.True(err == nil || errors.Is(err, io.EOF))
+	h.assert.Equal(len("taco"), n)
+	h.assert.Equal("taco", string(buf[:n]))
 
 	// Sync doesn't need to do anything.
-	newObj, err := t.sync(o)
+	newObj, err := h.sync(o)
 
-	AssertEq(nil, err)
-	ExpectEq(nil, newObj)
+	h.require.NoError(err)
+	h.assert.Nil(newObj)
 }
 
-func (t *IntegrationTest) SyncEmptyLocalFile() {
+func TestIntegration_SyncEmptyLocalFile(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
+
 	// Create a temp file and write some contents to it.
-	tf, err := gcsx.NewTempFile(io.NopCloser(strings.NewReader("")), "", &t.clock)
-	AssertEq(nil, err)
+	tf, err := gcsx.NewTempFile(io.NopCloser(strings.NewReader("")), h.t.TempDir(), &h.clock)
+	h.require.NoError(err)
+	defer tf.Destroy()
 
 	// Sync should update the object in GCS.
-	newObj, err := t.syncer.SyncObject(t.ctx, "test", nil, tf)
+	newObj, err := h.syncer.SyncObject(h.ctx, "test", nil, tf)
 
-	AssertEq(nil, err)
-	ExpectEq(t.objectGeneration("test"), newObj.Generation)
+	h.require.NoError(err)
+	h.assert.Equal(h.objectGeneration("test"), newObj.Generation)
 	_, ok := newObj.Metadata["gcsfuse_mtime"]
-	AssertFalse(ok)
+	h.assert.False(ok)
+
 	// Read via the bucket.
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, "test")
-	AssertEq(nil, err)
-	ExpectEq("", string(contents))
-	// There should be no junk left over in the bucket besides the object of
-	// interest.
-	objects, runs, err := storageutil.ListAll(
-		t.ctx,
-		t.bucket,
-		&gcs.ListObjectsRequest{})
-	AssertEq(nil, err)
-	AssertEq(1, len(objects))
-	AssertEq(0, len(runs))
-	ExpectEq("test", objects[0].Name)
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, "test")
+	h.require.NoError(err)
+	h.assert.Equal("", string(contents))
+
+	// Verify bucket contents.
+	h.verifyBucketContents([]string{"test"})
 }
 
-func (t *IntegrationTest) SyncNonEmptyLocalFile() {
+func TestIntegration_SyncNonEmptyLocalFile(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
+
 	// Create a temp file and write some contents to it.
-	tf, err := gcsx.NewTempFile(io.NopCloser(strings.NewReader("")), "", &t.clock)
-	AssertEq(nil, err)
-	t.clock.AdvanceTime(time.Second)
-	writeTime := t.clock.Now()
-	n, err := tf.WriteAt([]byte("tacobell"), 0)
-	AssertEq(nil, err)
-	AssertEq(8, n)
-	t.clock.AdvanceTime(time.Second)
+	tf, err := gcsx.NewTempFile(io.NopCloser(strings.NewReader("")), h.t.TempDir(), &h.clock)
+	h.require.NoError(err)
+	defer tf.Destroy()
+	h.clock.AdvanceTime(time.Second)
+	writeTime := h.clock.Now()
+	n, err := tf.(io.WriterAt).WriteAt([]byte("tacobell"), 0)
+	h.require.NoError(err)
+	h.assert.Equal(8, n)
+	h.clock.AdvanceTime(time.Second)
 
 	// Sync should update the object in GCS.
-	newObj, err := t.syncer.SyncObject(t.ctx, "test", nil, tf)
+	newObj, err := h.syncer.SyncObject(h.ctx, "test", nil, tf)
 
-	AssertEq(nil, err)
-	ExpectEq(t.objectGeneration("test"), newObj.Generation)
-	ExpectEq(
+	h.require.NoError(err)
+	h.assert.Equal(h.objectGeneration("test"), newObj.Generation)
+	h.assert.Equal(
 		writeTime.UTC().Format(time.RFC3339Nano),
 		newObj.Metadata["gcsfuse_mtime"])
+
 	// Read via the bucket.
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, "test")
-	AssertEq(nil, err)
-	ExpectEq("tacobell", string(contents))
-	// There should be no junk left over in the bucket besides the object of
-	// interest.
-	objects, runs, err := storageutil.ListAll(
-		t.ctx,
-		t.bucket,
-		&gcs.ListObjectsRequest{})
-	AssertEq(nil, err)
-	AssertEq(1, len(objects))
-	AssertEq(0, len(runs))
-	ExpectEq("test", objects[0].Name)
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, "test")
+	h.require.NoError(err)
+	h.assert.Equal("tacobell", string(contents))
+
+	// Verify bucket contents.
+	h.verifyBucketContents([]string{"test"})
 }
 
-func (t *IntegrationTest) WriteThenSync() {
+func TestIntegration_WriteThenSync(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
+
 	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
 
-	t.create(o)
+	h.create(o)
 
-	// Overwrite the first byte.
-	t.clock.AdvanceTime(time.Second)
-	writeTime := t.clock.Now()
-	n, err := t.tf.WriteAt([]byte("p"), 0)
-	t.clock.AdvanceTime(time.Second)
+	// Overwrite.
+	h.clock.AdvanceTime(time.Second)
+	writeTime := h.clock.Now()
+	n, err := h.writeAt([]byte("burrito"), 0)
+	h.clock.AdvanceTime(time.Second)
 
-	AssertEq(nil, err)
-	ExpectEq(1, n)
+	h.require.NoError(err)
+	h.assert.Equal(len("burrito"), n)
 
 	// Sync should save out the new generation.
-	newObj, err := t.sync(o)
-	AssertEq(nil, err)
+	newObj, err := h.sync(o)
+	h.require.NoError(err)
 
-	ExpectNe(o.Generation, newObj.Generation)
-	ExpectEq(t.objectGeneration("foo"), newObj.Generation)
-	ExpectEq(
+	h.assert.NotEqual(o.Generation, newObj.Generation)
+	h.assert.Equal(h.objectGeneration("foo"), newObj.Generation)
+	h.assert.Equal(
 		writeTime.UTC().Format(time.RFC3339Nano),
 		newObj.Metadata["gcsfuse_mtime"])
 
 	// Read via the bucket.
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("paco", string(contents))
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, "foo")
+	h.require.NoError(err)
+	h.assert.Equal("burrito", string(contents))
 
-	// There should be no junk left over in the bucket besides the object of
-	// interest.
-	objects, runs, err := storageutil.ListAll(
-		t.ctx,
-		t.bucket,
-		&gcs.ListObjectsRequest{})
-
-	AssertEq(nil, err)
-	AssertEq(1, len(objects))
-	AssertEq(0, len(runs))
-
-	ExpectEq("foo", objects[0].Name)
+	// Verify bucket contents.
+	h.verifyBucketContents([]string{"foo"})
 }
 
-func (t *IntegrationTest) AppendThenSync() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_AppendThenSync(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Append some data.
-	t.clock.AdvanceTime(time.Second)
-	writeTime := t.clock.Now()
-	n, err := t.tf.WriteAt([]byte("burrito"), 4)
-	t.clock.AdvanceTime(time.Second)
+	h.clock.AdvanceTime(time.Second)
+	writeTime := h.clock.Now()
+	n, err := h.writeAt([]byte("burrito"), 4)
+	h.clock.AdvanceTime(time.Second)
 
-	AssertEq(nil, err)
-	ExpectEq(len("burrito"), n)
+	h.require.NoError(err)
+	h.assert.Equal(len("burrito"), n)
 
 	// Sync should save out the new generation.
-	newObj, err := t.sync(o)
-	AssertEq(nil, err)
+	newObj, err := h.sync(o)
+	h.require.NoError(err)
 
-	ExpectNe(o.Generation, newObj.Generation)
-	ExpectEq(t.objectGeneration("foo"), newObj.Generation)
-	ExpectEq(
+	h.assert.NotEqual(o.Generation, newObj.Generation)
+	h.assert.Equal(h.objectGeneration("foo"), newObj.Generation)
+	h.assert.Equal(
 		writeTime.UTC().Format(time.RFC3339Nano),
 		newObj.Metadata["gcsfuse_mtime"])
 
 	// Read via the bucket.
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("tacoburrito", string(contents))
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, "foo")
+	h.require.NoError(err)
+	h.assert.Equal("tacoburrito", string(contents))
 
-	// There should be no junk left over in the bucket besides the object of
-	// interest.
-	objects, runs, err := storageutil.ListAll(
-		t.ctx,
-		t.bucket,
-		&gcs.ListObjectsRequest{})
-
-	AssertEq(nil, err)
-	AssertEq(1, len(objects))
-	AssertEq(0, len(runs))
-
-	ExpectEq("foo", objects[0].Name)
+	// Verify bucket contents.
+	h.verifyBucketContents([]string{"foo"})
 }
 
-func (t *IntegrationTest) TruncateThenSync() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_TruncateThenSync(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Truncate.
-	t.clock.AdvanceTime(time.Second)
-	truncateTime := t.clock.Now()
-	err = t.tf.Truncate(2)
-	t.clock.AdvanceTime(time.Second)
+	h.clock.AdvanceTime(time.Second)
+	truncateTime := h.clock.Now()
+	err = h.tf.Truncate(2)
+	h.clock.AdvanceTime(time.Second)
 
-	AssertEq(nil, err)
+	h.require.NoError(err)
 
 	// Sync should save out the new generation.
-	newObj, err := t.sync(o)
-	AssertEq(nil, err)
+	newObj, err := h.sync(o)
+	h.require.NoError(err)
 
-	ExpectNe(o.Generation, newObj.Generation)
-	ExpectEq(t.objectGeneration("foo"), newObj.Generation)
-	ExpectEq(
+	h.assert.NotEqual(o.Generation, newObj.Generation)
+	h.assert.Equal(h.objectGeneration("foo"), newObj.Generation)
+	h.assert.Equal(
 		truncateTime.UTC().Format(time.RFC3339Nano),
 		newObj.Metadata["gcsfuse_mtime"])
 
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, "foo")
-	AssertEq(nil, err)
-	ExpectEq("ta", string(contents))
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, "foo")
+	h.require.NoError(err)
+	h.assert.Equal("ta", string(contents))
 }
 
-func (t *IntegrationTest) Stat_InitialState() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_Stat_InitialState(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Stat.
-	sr, err := t.tf.Stat()
-	AssertEq(nil, err)
+	sr, err := h.tf.Stat()
+	h.require.NoError(err)
 
-	ExpectEq(o.Size, sr.Size)
-	ExpectEq(o.Size, sr.DirtyThreshold)
-	ExpectEq(nil, sr.Mtime)
+	h.assert.Equal(int64(o.Size), sr.Size)
+	h.assert.Equal(int64(o.Size), sr.DirtyThreshold)
+	h.assert.Nil(sr.Mtime)
 }
 
-func (t *IntegrationTest) Stat_Dirty() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_Stat_Dirty(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Dirty.
-	t.clock.AdvanceTime(time.Second)
-	truncateTime := t.clock.Now()
+	h.clock.AdvanceTime(time.Second)
+	truncateTime := h.clock.Now()
 
-	err = t.tf.Truncate(2)
-	AssertEq(nil, err)
+	err = h.tf.Truncate(2)
+	h.require.NoError(err)
 
-	t.clock.AdvanceTime(time.Second)
+	h.clock.AdvanceTime(time.Second)
 
 	// Stat.
-	sr, err := t.tf.Stat()
-	AssertEq(nil, err)
+	sr, err := h.tf.Stat()
+	h.require.NoError(err)
 
-	ExpectEq(2, sr.Size)
-	ExpectEq(2, sr.DirtyThreshold)
-	ExpectThat(sr.Mtime, Pointee(timeutil.TimeEq(truncateTime)))
+	h.assert.Equal(int64(2), sr.Size)
+	h.assert.Equal(int64(2), sr.DirtyThreshold)
+	if h.assert.NotNil(sr.Mtime) {
+		h.assert.True(sr.Mtime.Equal(truncateTime))
+	}
 }
 
-func (t *IntegrationTest) BackingObjectHasBeenDeleted() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_BackingObjectHasBeenDeleted(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Fault in the contents.
-	_, err = t.tf.ReadAt([]byte{}, 0)
-	AssertEq(nil, err)
+	_, err = h.tf.ReadAt([]byte{}, 0)
+	h.require.NoError(err)
 
 	// Delete the backing object.
-	err = t.bucket.DeleteObject(t.ctx, &gcs.DeleteObjectRequest{Name: o.Name})
-	AssertEq(nil, err)
+	err = h.bucket.DeleteObject(h.ctx, &gcs.DeleteObjectRequest{Name: o.Name})
+	h.require.NoError(err)
 
 	// Reading and modications should still work.
-	_, err = t.tf.ReadAt([]byte{}, 0)
-	AssertEq(nil, err)
+	_, err = h.tf.ReadAt([]byte{}, 0)
+	h.require.NoError(err)
 
-	_, err = t.tf.WriteAt([]byte("a"), 0)
-	AssertEq(nil, err)
+	_, err = h.writeAt([]byte("a"), 0)
+	h.require.NoError(err)
 
-	truncateTime := t.clock.Now()
-	err = t.tf.Truncate(1)
-	AssertEq(nil, err)
-	t.clock.AdvanceTime(time.Second)
+	truncateTime := h.clock.Now()
+	err = h.tf.Truncate(1)
+	h.require.NoError(err)
+	h.clock.AdvanceTime(time.Second)
 
 	// Stat should see the current state.
-	sr, err := t.tf.Stat()
-	AssertEq(nil, err)
+	sr, err := h.tf.Stat()
+	h.require.NoError(err)
 
-	ExpectEq(1, sr.Size)
-	ExpectEq(0, sr.DirtyThreshold)
-	ExpectThat(sr.Mtime, Pointee(timeutil.TimeEq(truncateTime)))
+	h.assert.Equal(int64(1), sr.Size)
+	h.assert.Equal(int64(0), sr.DirtyThreshold)
+	if h.assert.NotNil(sr.Mtime) {
+		h.assert.True(sr.Mtime.Equal(truncateTime))
+	}
 
 	// Sync should fail with a precondition error.
-	_, err = t.sync(o)
+	_, err = h.sync(o)
 	var preconditionErr *gcs.PreconditionError
-	ExpectTrue(errors.As(err, &preconditionErr))
+	h.assert.ErrorAs(err, &preconditionErr)
 
 	// Nothing should have been created.
-	_, err = storageutil.ReadObject(t.ctx, t.bucket, o.Name)
+	_, err = storageutil.ReadObject(h.ctx, h.bucket, o.Name)
 	var notFoundErr *gcs.NotFoundError
-	ExpectTrue(errors.As(err, &notFoundErr))
+	h.assert.ErrorAs(err, &notFoundErr)
 }
 
-func (t *IntegrationTest) BackingObjectHasBeenOverwritten() {
-	// Create.
-	o, err := storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("taco"))
-	AssertEq(nil, err)
+func TestIntegration_BackingObjectHasBeenOverwritten(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
 
-	t.create(o)
+	// Create.
+	o, err := storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("taco"))
+	h.require.NoError(err)
+
+	h.create(o)
 
 	// Fault in the contents.
-	_, err = t.tf.ReadAt([]byte{}, 0)
-	AssertEq(nil, err)
+	_, err = h.tf.ReadAt([]byte{}, 0)
+	h.require.NoError(err)
 
 	// Overwrite the backing object.
-	_, err = storageutil.CreateObject(t.ctx, t.bucket, "foo", []byte("burrito"))
-	AssertEq(nil, err)
+	_, err = storageutil.CreateObject(h.ctx, h.bucket, "foo", []byte("burrito"))
+	h.require.NoError(err)
 
 	// Reading and modications should still work.
-	_, err = t.tf.ReadAt([]byte{}, 0)
-	AssertEq(nil, err)
+	_, err = h.tf.ReadAt([]byte{}, 0)
+	h.require.NoError(err)
 
-	_, err = t.tf.WriteAt([]byte("a"), 0)
-	AssertEq(nil, err)
+	_, err = h.writeAt([]byte("a"), 0)
+	h.require.NoError(err)
 
-	truncateTime := t.clock.Now()
-	err = t.tf.Truncate(3)
-	AssertEq(nil, err)
-	t.clock.AdvanceTime(time.Second)
+	truncateTime := h.clock.Now()
+	err = h.tf.Truncate(3)
+	h.require.NoError(err)
+	h.clock.AdvanceTime(time.Second)
 
 	// Stat should see the current state.
-	sr, err := t.tf.Stat()
-	AssertEq(nil, err)
+	sr, err := h.tf.Stat()
+	h.require.NoError(err)
 
-	ExpectEq(3, sr.Size)
-	ExpectEq(0, sr.DirtyThreshold)
-	ExpectThat(sr.Mtime, Pointee(timeutil.TimeEq(truncateTime)))
+	h.assert.Equal(int64(3), sr.Size)
+	h.assert.Equal(int64(0), sr.DirtyThreshold)
+	if h.assert.NotNil(sr.Mtime) {
+		h.assert.True(sr.Mtime.Equal(truncateTime))
+	}
 
 	// Sync should fail with a precondition error.
-	_, err = t.sync(o)
+	_, err = h.sync(o)
 	var preconditionErr *gcs.PreconditionError
-	ExpectTrue(errors.As(err, &preconditionErr))
+	h.assert.ErrorAs(err, &preconditionErr)
 
 	// The newer version should still be present.
-	contents, err := storageutil.ReadObject(t.ctx, t.bucket, o.Name)
-	AssertEq(nil, err)
-	ExpectEq("burrito", string(contents))
+	contents, err := storageutil.ReadObject(h.ctx, h.bucket, o.Name)
+	h.require.NoError(err)
+	h.assert.Equal("burrito", string(contents))
 }
 
-func (t *IntegrationTest) MultipleInteractions() {
+func TestIntegration_MultipleInteractions(t *testing.T) {
+	h := newIntegrationTestHelper(t)
+	defer h.tearDown()
+
 	// We will run through the script below for multiple interesting object
 	// sizes.
 	sizes := []int{
@@ -533,24 +553,19 @@ func (t *IntegrationTest) MultipleInteractions() {
 		copy(expectedContents, randData)
 
 		o, err := storageutil.CreateObject(
-			t.ctx,
-			t.bucket,
+			h.ctx,
+			h.bucket,
 			name,
 			expectedContents)
-
-		AssertEq(nil, err)
+		h.require.NoError(err, desc)
 
 		// Create a temp file around it.
-		t.create(o)
+		h.create(o)
 
 		// Read the contents of the temp file.
-		_, err = t.tf.ReadAt(buf, 0)
-
-		AssertThat(err, AnyOf(nil, io.EOF))
-		if !bytes.Equal(buf, expectedContents) {
-			AddFailure("Contents mismatch for %s", desc)
-			AbortTest()
-		}
+		_, err = h.tf.ReadAt(buf, 0)
+		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
+		h.assert.True(bytes.Equal(buf, expectedContents), desc)
 
 		// Modify some bytes.
 		if size > 0 {
@@ -558,65 +573,50 @@ func (t *IntegrationTest) MultipleInteractions() {
 			expectedContents[size/2] = 19
 			expectedContents[size-1] = 23
 
-			_, err = t.tf.WriteAt([]byte{17}, 0)
-			AssertEq(nil, err)
+			_, err = h.writeAt([]byte{17}, 0)
+			h.require.NoError(err, desc)
 
-			_, err = t.tf.WriteAt([]byte{19}, int64(size/2))
-			AssertEq(nil, err)
+			_, err = h.writeAt([]byte{19}, int64(size/2))
+			h.require.NoError(err, desc)
 
-			_, err = t.tf.WriteAt([]byte{23}, int64(size-1))
-			AssertEq(nil, err)
+			_, err = h.writeAt([]byte{23}, int64(size-1))
+			h.require.NoError(err, desc)
 		}
 
 		// Compare contents again.
-		_, err = t.tf.ReadAt(buf, 0)
-
-		AssertThat(err, AnyOf(nil, io.EOF))
-		if !bytes.Equal(buf, expectedContents) {
-			AddFailure("Contents mismatch for %s", desc)
-			AbortTest()
-		}
+		_, err = h.tf.ReadAt(buf, 0)
+		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
+		h.assert.True(bytes.Equal(buf, expectedContents), desc)
 
 		// Sync and recreate if necessary.
-		newObj, err := t.sync(o)
-		AssertEq(nil, err)
+		newObj, err := h.sync(o)
+		h.require.NoError(err, desc)
 
 		if newObj != nil {
-			t.create(newObj)
+			h.create(newObj)
 		}
 
 		// Check the new backing object's contents.
-		objContents, err := storageutil.ReadObject(t.ctx, t.bucket, name)
-		AssertEq(nil, err)
-		if !bytes.Equal(objContents, expectedContents) {
-			AddFailure("Contents mismatch for %s", desc)
-			AbortTest()
-		}
+		objContents, err := storageutil.ReadObject(h.ctx, h.bucket, name)
+		h.require.NoError(err, desc)
+		h.assert.True(bytes.Equal(objContents, expectedContents), desc)
 
 		// Compare contents again.
-		_, err = t.tf.ReadAt(buf, 0)
-
-		AssertThat(err, AnyOf(nil, io.EOF))
-		if !bytes.Equal(buf, expectedContents) {
-			AddFailure("Contents mismatch for %s", desc)
-			AbortTest()
-		}
+		_, err = h.tf.ReadAt(buf, 0)
+		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
+		h.assert.True(bytes.Equal(buf, expectedContents), desc)
 
 		// Dirty again.
 		if size > 0 {
 			expectedContents[0] = 29
 
-			_, err = t.tf.WriteAt([]byte{29}, 0)
-			AssertEq(nil, err)
+			_, err = h.writeAt([]byte{29}, 0)
+			h.require.NoError(err, desc)
 		}
 
 		// Compare contents again.
-		_, err = t.tf.ReadAt(buf, 0)
-
-		AssertThat(err, AnyOf(nil, io.EOF))
-		if !bytes.Equal(buf, expectedContents) {
-			AddFailure("Contents mismatch for %s", desc)
-			AbortTest()
-		}
+		_, err = h.tf.ReadAt(buf, 0)
+		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
+		h.assert.True(bytes.Equal(buf, expectedContents), desc)
 	}
 }

--- a/internal/gcsx/integration_test.go
+++ b/internal/gcsx/integration_test.go
@@ -15,7 +15,6 @@
 package gcsx_test
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -565,7 +564,7 @@ func TestIntegration_MultipleInteractions(t *testing.T) {
 		// Read the contents of the temp file.
 		_, err = h.tf.ReadAt(buf, 0)
 		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
-		h.assert.True(bytes.Equal(buf, expectedContents), desc)
+		h.assert.Equal(expectedContents, buf, desc)
 
 		// Modify some bytes.
 		if size > 0 {
@@ -586,7 +585,7 @@ func TestIntegration_MultipleInteractions(t *testing.T) {
 		// Compare contents again.
 		_, err = h.tf.ReadAt(buf, 0)
 		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
-		h.assert.True(bytes.Equal(buf, expectedContents), desc)
+		h.assert.Equal(expectedContents, buf, desc)
 
 		// Sync and recreate if necessary.
 		newObj, err := h.sync(o)
@@ -599,12 +598,12 @@ func TestIntegration_MultipleInteractions(t *testing.T) {
 		// Check the new backing object's contents.
 		objContents, err := storageutil.ReadObject(h.ctx, h.bucket, name)
 		h.require.NoError(err, desc)
-		h.assert.True(bytes.Equal(objContents, expectedContents), desc)
+		h.assert.Equal(expectedContents, objContents, desc)
 
 		// Compare contents again.
 		_, err = h.tf.ReadAt(buf, 0)
 		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
-		h.assert.True(bytes.Equal(buf, expectedContents), desc)
+		h.assert.Equal(expectedContents, buf, desc)
 
 		// Dirty again.
 		if size > 0 {
@@ -617,6 +616,6 @@ func TestIntegration_MultipleInteractions(t *testing.T) {
 		// Compare contents again.
 		_, err = h.tf.ReadAt(buf, 0)
 		h.require.True(err == nil || errors.Is(err, io.EOF), desc)
-		h.assert.True(bytes.Equal(buf, expectedContents), desc)
+		h.assert.Equal(expectedContents, buf, desc)
 	}
 }

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -15,20 +15,16 @@
 package gcsx
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"os"
-	"path"
 	"reflect"
 	"strings"
 	"testing"
 	"testing/iotest"
 	"time"
-
-	"github.com/googlecloudplatform/gcsfuse/v3/internal/util/diskutil"
-
-	"context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/file"
@@ -40,17 +36,14 @@ import (
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/fake"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/storage/gcs"
 	testutil "github.com/googlecloudplatform/gcsfuse/v3/internal/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/internal/util/diskutil"
 	"github.com/googlecloudplatform/gcsfuse/v3/metrics"
 	"github.com/googlecloudplatform/gcsfuse/v3/tracing"
 	"github.com/jacobsa/fuse/fuseops"
-	. "github.com/jacobsa/oglematchers"
-	. "github.com/jacobsa/oglemock"
-	. "github.com/jacobsa/ogletest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
-
-// NOTE: Please add new tests in random_reader_stretchr_test.go file. This file
-// is deprecated and these tests will be moved to the random_reader_stretchr_test.go
-func TestRandomReader(t *testing.T) { RunTests(t) }
 
 ////////////////////////////////////////////////////////////////////////
 // Invariant-checking random reader
@@ -102,56 +95,15 @@ func (br *blockingReader) Read(p []byte) (n int, err error) {
 }
 
 ////////////////////////////////////////////////////////////////////////
-// Helpers
+// Helper Struct and Constructor
 ////////////////////////////////////////////////////////////////////////
 
-func rangeStartIs(expected uint64) (m Matcher) {
-	pred := func(c any) (err error) {
-		req := c.(*gcs.ReadObjectRequest)
-		if req.Range == nil {
-			err = errors.New("which has a nil range")
-			return
-		}
-
-		if req.Range.Start != expected {
-			err = fmt.Errorf("which has Start == %d", req.Range.Start)
-			return
-		}
-
-		return
-	}
-
-	m = NewMatcher(pred, fmt.Sprintf("has range start %d", expected))
-	return
-}
-
-func rangeLimitIs(expected uint64) (m Matcher) {
-	pred := func(c any) (err error) {
-		req := c.(*gcs.ReadObjectRequest)
-		if req.Range == nil {
-			err = errors.New("which has a nil range")
-			return
-		}
-
-		if req.Range.Limit != expected {
-			err = fmt.Errorf("which has Limit == %d", req.Range.Limit)
-			return
-		}
-
-		return
-	}
-
-	m = NewMatcher(pred, fmt.Sprintf("has range limit %d", expected))
-	return
-}
-
-////////////////////////////////////////////////////////////////////////
-// Boilerplate
-////////////////////////////////////////////////////////////////////////
-
-type RandomReaderTest struct {
+type randomReaderTestHelper struct {
+	t            *testing.T
+	assert       *assert.Assertions
+	require      *require.Assertions
 	object       *gcs.MinObject
-	bucket       storage.MockBucket
+	bucket       *storage.TestifyMockBucket
 	rr           checkingRandomReader
 	cacheDir     string
 	jobManager   *downloader.JobManager
@@ -159,952 +111,954 @@ type RandomReaderTest struct {
 	bucketType   gcs.BucketType
 }
 
-func init() {
-	RegisterTestSuite(&RandomReaderTest{bucketType: gcs.BucketType{}})
-	RegisterTestSuite(&RandomReaderTest{bucketType: gcs.BucketType{Zonal: true, Hierarchical: true}})
-}
+func newRandomReaderTestHelper(t *testing.T, bucketType gcs.BucketType) *randomReaderTestHelper {
+	h := &randomReaderTestHelper{
+		t:          t,
+		assert:     assert.New(t),
+		require:    require.New(t),
+		bucketType: bucketType,
+	}
 
-var _ SetUpInterface = &RandomReaderTest{}
-var _ TearDownInterface = &RandomReaderTest{}
-
-func (t *RandomReaderTest) SetUp(ti *TestInfo) {
 	readOp := fuseops.ReadFileOp{Handle: 1}
-	t.rr.ctx = context.WithValue(ti.Ctx, ReadOp, &readOp)
+	h.rr.ctx = context.WithValue(context.Background(), ReadOp, &readOp)
 
 	// Manufacture an object record.
-	t.object = &gcs.MinObject{
+	h.object = &gcs.MinObject{
 		Name:       "foo",
 		Size:       17,
 		Generation: 1234,
 	}
 
 	// Create the bucket.
-	t.bucket = storage.NewMockBucket(ti.MockController, "bucket")
+	h.bucket = &storage.TestifyMockBucket{}
 
-	t.cacheDir = path.Join(os.Getenv("HOME"), "cache/dir")
+	h.cacheDir = t.TempDir()
 	lruCache := lru.NewCache(cacheMaxSize)
 	fileCacheConfig := &cfg.FileCacheConfig{
 		EnableCrc: false,
 	}
-	cacheDirVolumeBlockSize := diskutil.GetVolumeBlockSize(t.cacheDir)
-	t.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, t.cacheDir, sequentialReadSizeInMb, fileCacheConfig, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), cacheDirVolumeBlockSize)
-	t.cacheHandler = file.NewCacheHandler(lruCache, t.jobManager, t.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "", "", false, cacheDirVolumeBlockSize)
+	cacheDirVolumeBlockSize := diskutil.GetVolumeBlockSize(h.cacheDir)
+	h.jobManager = downloader.NewJobManager(lruCache, util.DefaultFilePerm, util.DefaultDirPerm, h.cacheDir, sequentialReadSizeInMb, fileCacheConfig, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), cacheDirVolumeBlockSize)
+	h.cacheHandler = file.NewCacheHandler(lruCache, h.jobManager, h.cacheDir, util.DefaultFilePerm, util.DefaultDirPerm, "", "", false, cacheDirVolumeBlockSize)
 
 	// Set up the reader.
-	rr := NewRandomReader(t.object, t.bucket, sequentialReadSizeInMb, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), nil, nil, 0)
-	t.rr.wrapped = rr.(*randomReader)
+	rr := NewRandomReader(h.object, h.bucket, sequentialReadSizeInMb, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), nil, nil, 0)
+	h.rr.wrapped = rr.(*randomReader)
+
+	return h
 }
 
-func (t *RandomReaderTest) TearDown() {
-	t.rr.Destroy()
+func (h *randomReaderTestHelper) tearDown() {
+	h.rr.Destroy()
+	h.bucket.AssertExpectations(h.t)
 }
 
-func (t *RandomReaderTest) mockNewReaderWithHandleCallForTestBucket(start uint64, limit uint64, rd gcs.StorageReader) {
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(
-		Any(), AllOf(rangeStartIs(start), rangeLimitIs(limit))).
-		WillRepeatedly(Return(rd, nil))
+func (h *randomReaderTestHelper) mockNewReaderWithHandleCallForTestBucket(start uint64, limit uint64, rd gcs.StorageReader) {
+	h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		if req.Range == nil {
+			return false
+		}
+		return req.Range.Start == start && req.Range.Limit == limit
+	})).Return(rd, nil).Once()
+}
+
+func runTest(t *testing.T, testFunc func(h *randomReaderTestHelper)) {
+	h := newRandomReaderTestHelper(t, gcs.BucketType{})
+	defer h.tearDown()
+	testFunc(h)
 }
 
 ////////////////////////////////////////////////////////////////////////
 // Tests
 ////////////////////////////////////////////////////////////////////////
 
-func (t *RandomReaderTest) EmptyRead() {
-	// Nothing should happen.
-	buf := make([]byte, 0)
+func TestRandomReader_EmptyRead(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		buf := make([]byte, 0)
 
-	objectData, err := t.rr.ReadAt(buf, 0)
+		objectData, err := h.rr.ReadAt(buf, 0)
 
-	ExpectEq(0, objectData.Size)
-	ExpectEq(nil, err)
+		h.assert.Equal(0, objectData.Size)
+		h.assert.NoError(err)
+	})
 }
 
-func (t *RandomReaderTest) ReadAtEndOfObject() {
-	buf := make([]byte, 1)
+func TestRandomReader_ReadAtEndOfObject(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		buf := make([]byte, 1)
 
-	objectData, err := t.rr.ReadAt(buf, int64(t.object.Size))
+		objectData, err := h.rr.ReadAt(buf, int64(h.object.Size))
 
-	ExpectEq(0, objectData.Size)
-	ExpectEq(io.EOF, err)
+		h.assert.Equal(0, objectData.Size)
+		h.assert.Equal(io.EOF, err)
+	})
 }
 
-func (t *RandomReaderTest) ReadPastEndOfObject() {
-	buf := make([]byte, 1)
+func TestRandomReader_ReadPastEndOfObject(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		buf := make([]byte, 1)
 
-	objectData, err := t.rr.ReadAt(buf, int64(t.object.Size)+1)
+		objectData, err := h.rr.ReadAt(buf, int64(h.object.Size)+1)
 
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(0, objectData.Size)
-	ExpectEq(io.EOF, err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.Equal(0, objectData.Size)
+		h.assert.Equal(io.EOF, err)
+	})
 }
 
-func (t *RandomReaderTest) NoExistingReader() {
-	// The bucket should be called to set up a new reader.
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(nil, errors.New("")))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
-	buf := make([]byte, 1)
+func TestRandomReader_NoExistingReader(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(nil, errors.New("")).Once()
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
+		buf := make([]byte, 1)
 
-	_, err := t.rr.ReadAt(buf, 0)
+		_, err := h.rr.ReadAt(buf, 0)
 
-	AssertNe(nil, err)
+		h.require.Error(err)
+	})
 }
 
-func (t *RandomReaderTest) ExistingReader_ReadAtOffsetAfterTheReaderPosition() {
-	var currentStartOffset int64 = 2
-	var readerLimit int64 = 15
-	var readAtOffset int64 = 10
-	var readSize int64 = 1
-	var expectedStartOffsetAfterRead = readAtOffset + readSize
-	// Simulate an existing reader.
-	nopCloser := io.NopCloser(strings.NewReader(strings.Repeat("x", int(readerLimit))))
-	rc := &fake.FakeReader{ReadCloser: nopCloser}
-	t.rr.wrapped.reader = rc
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = currentStartOffset
-	t.rr.wrapped.limit = readerLimit
+func TestRandomReader_ExistingReader_ReadAtOffsetAfterTheReaderPosition(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		var currentStartOffset int64 = 2
+		var readerLimit int64 = 15
+		var readAtOffset int64 = 10
+		var readSize int64 = 1
+		var expectedStartOffsetAfterRead = readAtOffset + readSize
 
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		nopCloser := io.NopCloser(strings.NewReader(strings.Repeat("x", int(readerLimit))))
+		rc := &fake.FakeReader{ReadCloser: nopCloser}
+		h.rr.wrapped.reader = rc
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = currentStartOffset
+		h.rr.wrapped.limit = readerLimit
 
-	buf := make([]byte, readSize)
-	_, err := t.rr.ReadAt(buf, readAtOffset)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	AssertEq(nil, err)
-	ExpectThat(rc, DeepEquals(t.rr.wrapped.reader))
-	ExpectEq(expectedStartOffsetAfterRead, t.rr.wrapped.start)
-	ExpectEq(readerLimit, t.rr.wrapped.limit)
+		buf := make([]byte, readSize)
+		_, err := h.rr.ReadAt(buf, readAtOffset)
+
+		h.require.NoError(err)
+		h.assert.Equal(rc, h.rr.wrapped.reader)
+		h.assert.Equal(expectedStartOffsetAfterRead, h.rr.wrapped.start)
+		h.assert.Equal(readerLimit, h.rr.wrapped.limit)
+	})
 }
 
-func (t *RandomReaderTest) NewReaderReturnsError() {
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(nil, errors.New("taco")))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
-	buf := make([]byte, 1)
+func TestRandomReader_NewReaderReturnsError(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(nil, errors.New("taco")).Once()
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
+		buf := make([]byte, 1)
 
-	_, err := t.rr.ReadAt(buf, 0)
+		_, err := h.rr.ReadAt(buf, 0)
 
-	ExpectThat(err, Error(HasSubstr("NewReaderWithReadHandle")))
-	ExpectThat(err, Error(HasSubstr("taco")))
+		h.assert.Error(err)
+		h.assert.Contains(err.Error(), "NewReaderWithReadHandle")
+		h.assert.Contains(err.Error(), "taco")
+	})
 }
 
-func (t *RandomReaderTest) ReaderFails() {
-	// Bucket
-	r := iotest.OneByteReader(iotest.TimeoutReader(strings.NewReader("xxx")))
-	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+func TestRandomReader_ReaderFails(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		r := iotest.OneByteReader(iotest.TimeoutReader(strings.NewReader("xxx")))
+		rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(rc, nil).Once()
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Call
-	buf := make([]byte, 3)
-	_, err := t.rr.ReadAt(buf, 0)
+		buf := make([]byte, 3)
+		_, err := h.rr.ReadAt(buf, 0)
 
-	ExpectThat(err, Error(HasSubstr("readFull")))
-	ExpectThat(err, Error(HasSubstr(iotest.ErrTimeout.Error())))
+		h.assert.Error(err)
+		h.assert.Contains(err.Error(), "readFull")
+		h.assert.Contains(err.Error(), iotest.ErrTimeout.Error())
+	})
 }
 
-func (t *RandomReaderTest) ReaderNotExhausted() {
-	// Set up a reader that has three bytes left to give.
-	cc := &countingCloser{
-		Reader: strings.NewReader("abc"),
-	}
-	rc := &fake.FakeReader{ReadCloser: cc}
+func TestRandomReader_ReaderNotExhausted(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		cc := &countingCloser{
+			Reader: strings.NewReader("abc"),
+		}
+		rc := &fake.FakeReader{ReadCloser: cc}
 
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	t.rr.wrapped.reader = rc
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 4
+		h.rr.wrapped.reader = rc
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 4
 
-	// Read two bytes.
-	buf := make([]byte, 2)
-	objectData, err := t.rr.ReadAt(buf, 1)
-
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(2, objectData.Size)
-	ExpectEq(nil, err)
-	ExpectEq("ab", string(buf[:objectData.Size]))
-
-	ExpectEq(0, cc.closeCount)
-	ExpectEq(rc, t.rr.wrapped.reader)
-	ExpectEq(3, t.rr.wrapped.start)
-	ExpectEq(4, t.rr.wrapped.limit)
-}
-
-func (t *RandomReaderTest) ReaderExhausted_ReadFinished() {
-	// Set up a reader that has three bytes left to give.
-	rc := &countingCloser{
-		Reader: strings.NewReader("abc"),
-	}
-
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
-
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: rc}
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 4
-
-	// Read three bytes.
-	buf := make([]byte, 3)
-	objectData, err := t.rr.ReadAt(buf, 1)
-
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(3, objectData.Size)
-	ExpectEq(nil, err)
-	ExpectEq("abc", string(buf[:objectData.Size]))
-
-	ExpectEq(1, rc.closeCount)
-	ExpectEq(nil, t.rr.wrapped.reader)
-	ExpectEq(nil, t.rr.wrapped.cancel)
-	ExpectEq(4, t.rr.wrapped.limit)
-}
-
-func (t *RandomReaderTest) PropagatesCancellation() {
-	// Set up a reader that will block until we tell it to return.
-	finishRead := make(chan struct{})
-	rc := io.NopCloser(&blockingReader{finishRead})
-
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
-
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: rc}
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 4
-	t.rr.wrapped.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
-
-	// Snoop on when cancel is called.
-	cancelCalled := make(chan struct{})
-	t.rr.wrapped.cancel = func() { close(cancelCalled) }
-
-	// Start a read in the background using a context that we control. It should
-	// not yet return.
-	readReturned := make(chan struct{})
-	ctx, cancel := context.WithCancel(context.Background())
-
-	go func() {
 		buf := make([]byte, 2)
-		t.rr.wrapped.ReadAt(ctx, buf, 1)
-		close(readReturned)
-	}()
+		objectData, err := h.rr.ReadAt(buf, 1)
 
-	select {
-	case <-time.After(10 * time.Millisecond):
-	case <-readReturned:
-		AddFailure("Read returned early.")
-		AbortTest()
-	}
+		h.assert.False(objectData.CacheHit)
+		h.assert.Equal(2, objectData.Size)
+		h.assert.NoError(err)
+		h.assert.Equal("ab", string(buf[:objectData.Size]))
 
-	// When we cancel our context, the random reader should cancel the read
-	// context.
-	cancel()
-	<-cancelCalled
-
-	// Clean up.
-	close(finishRead)
-	<-readReturned
+		h.assert.Equal(0, cc.closeCount)
+		h.assert.Equal(rc, h.rr.wrapped.reader)
+		h.assert.Equal(int64(3), h.rr.wrapped.start)
+		h.assert.Equal(int64(4), h.rr.wrapped.limit)
+	})
 }
 
-func (t *RandomReaderTest) DoesntPropagateCancellationAfterReturning() {
-	// Set up a reader that will return three bytes.
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 4
+func TestRandomReader_ReaderExhausted_ReadFinished(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		rc := &countingCloser{
+			Reader: strings.NewReader("abc"),
+		}
 
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Snoop on when cancel is called.
-	cancelCalled := make(chan struct{})
-	t.rr.wrapped.cancel = func() { close(cancelCalled) }
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: rc}
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 4
 
-	// Successfully read two bytes using a context whose cancellation we control.
-	ctx, cancel := context.WithCancel(context.Background())
-	buf := make([]byte, 2)
-	objectData, err := t.rr.wrapped.ReadAt(ctx, buf, 1)
+		buf := make([]byte, 3)
+		objectData, err := h.rr.ReadAt(buf, 1)
 
-	AssertEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	AssertEq(2, objectData.Size)
+		h.assert.False(objectData.CacheHit)
+		h.assert.Equal(3, objectData.Size)
+		h.assert.NoError(err)
+		h.assert.Equal("abc", string(buf[:objectData.Size]))
 
-	// If we cancel the calling context now, it should not cause the underlying
-	// read context to be cancelled.
-	cancel()
-	select {
-	case <-time.After(10 * time.Millisecond):
-	case <-cancelCalled:
-		AddFailure("Read context unexpectedly cancelled.")
-		AbortTest()
-	}
+		h.assert.Equal(1, rc.closeCount)
+		h.assert.Nil(h.rr.wrapped.reader)
+		h.assert.Nil(h.rr.wrapped.cancel)
+		h.assert.Equal(int64(4), h.rr.wrapped.limit)
+	})
 }
 
-func (t *RandomReaderTest) UpgradesReadsToObjectSize() {
-	const objectSize = 2 * MiB
-	t.object.Size = objectSize
+func TestRandomReader_PropagatesCancellation(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		finishRead := make(chan struct{})
+		rc := io.NopCloser(&blockingReader{finishRead})
 
-	const readSize = 10
-	AssertLt(readSize, objectSize)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Simulate an existing reader at a mismatched offset.
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 2
-	t.rr.wrapped.limit = 5
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: rc}
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 4
+		h.rr.wrapped.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
 
-	// The bucket should be asked to read the entire object, even though we only
-	// ask for readSize bytes below, to minimize the cost for GCS requests.
-	r := strings.NewReader(strings.Repeat("x", objectSize))
-	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+		cancelCalled := make(chan struct{})
+		h.rr.wrapped.cancel = func() { close(cancelCalled) }
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(
-		Any(),
-		AllOf(rangeStartIs(1), rangeLimitIs(objectSize))).
-		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		readReturned := make(chan struct{})
+		ctx, cancel := context.WithCancel(context.Background())
 
-	// Call through.
-	buf := make([]byte, readSize)
-	objectData, err := t.rr.ReadAt(buf, 1)
+		go func() {
+			buf := make([]byte, 2)
+			h.rr.wrapped.ReadAt(ctx, buf, 1)
+			close(readReturned)
+		}()
 
-	// Check the state now.
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectEq(1+readSize, t.rr.wrapped.start)
-	ExpectEq(objectSize, t.rr.wrapped.limit)
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-readReturned:
+			h.t.Fatal("Read returned early.")
+		}
+
+		cancel()
+		<-cancelCalled
+
+		close(finishRead)
+		<-readReturned
+	})
 }
 
-func (t *RandomReaderTest) UpgradeReadsToAverageSize() {
-	t.object.Size = 1 << 40
-	const totalReadBytes = 6 * MiB
-	const numReads = 2
-	const avgReadBytes = totalReadBytes / numReads
+func TestRandomReader_DoesntPropagateCancellationAfterReturning(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 4
 
-	const expectedBytesToRead = avgReadBytes
-	const start = 1
-	const readSize = 2 * minReadSize
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Simulate an existing reader at a mismatched offset.
-	t.rr.wrapped.seeks.Store(numReads)
-	t.rr.wrapped.totalReadBytes.Store(totalReadBytes)
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 2
-	t.rr.wrapped.limit = 5
-	t.rr.wrapped.expectedOffset.Store(2)
+		cancelCalled := make(chan struct{})
+		h.rr.wrapped.cancel = func() { close(cancelCalled) }
 
-	// The bucket should be asked to read expectedBytesToRead bytes.
-	r := strings.NewReader(strings.Repeat("x", expectedBytesToRead))
-	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+		ctx, cancel := context.WithCancel(context.Background())
+		buf := make([]byte, 2)
+		objectData, err := h.rr.wrapped.ReadAt(ctx, buf, 1)
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(
-		Any(),
-		AllOf(
-			rangeStartIs(start),
-			rangeLimitIs(start+expectedBytesToRead),
-		)).WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.Equal(2, objectData.Size)
 
-	// Call through.
-	buf := make([]byte, readSize)
-	objectData, err := t.rr.ReadAt(buf, start)
-
-	// Check the state now.
-	ExpectFalse(objectData.CacheHit)
-	AssertEq(nil, err)
-	ExpectEq(start+expectedBytesToRead, t.rr.wrapped.limit)
+		cancel()
+		select {
+		case <-time.After(10 * time.Millisecond):
+		case <-cancelCalled:
+			h.t.Fatal("Read context unexpectedly cancelled.")
+		}
+	})
 }
 
-func (t *RandomReaderTest) UpgradesSequentialReads_ExistingReader() {
-	t.object.Size = 1 << 40
-	const readSize = 10
+func TestRandomReader_UpgradesReadsToObjectSize(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		const objectSize = 2 * MiB
+		h.object.Size = objectSize
 
-	// Simulate an existing reader at the correct offset, which will be exhausted
-	// by the read below.
-	const existingSize = 3
-	r := strings.NewReader(strings.Repeat("x", existingSize))
+		const readSize = 10
+		h.require.Less(readSize, objectSize)
 
-	t.rr.wrapped.reader = &fake.FakeReader{ReadCloser: io.NopCloser(r)}
-	t.rr.wrapped.cancel = func() {}
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 1 + existingSize
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = 2
+		h.rr.wrapped.limit = 5
 
-	// The bucket should be asked to read up to the end of the object.
-	r = strings.NewReader(strings.Repeat("y", readSize))
-	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+		r := strings.NewReader(strings.Repeat("x", objectSize))
+		rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(
-		Any(),
-		AllOf(rangeStartIs(1), rangeLimitIs(1+sequentialReadSizeInBytes))).
-		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		h.mockNewReaderWithHandleCallForTestBucket(1, objectSize, rc)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Call through.
-	buf := make([]byte, readSize)
-	objectData, err := t.rr.ReadAt(buf, 1)
+		buf := make([]byte, readSize)
+		objectData, err := h.rr.ReadAt(buf, 1)
 
-	// Check the state now.
-	ExpectFalse(objectData.CacheHit)
-	AssertEq(nil, err)
-	ExpectEq(1+readSize, t.rr.wrapped.start)
-	// Limit is same as the byteRange of last GCS call made.
-	ExpectEq(1+sequentialReadSizeInBytes, t.rr.wrapped.limit)
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.Equal(int64(1+readSize), h.rr.wrapped.start)
+		h.assert.Equal(int64(objectSize), h.rr.wrapped.limit)
+	})
 }
 
-func (t *RandomReaderTest) UpgradesSequentialReads_NoExistingReader() {
-	t.object.Size = 1 << 40
-	const readSize = 1 * MiB
-	// Set up the custom randomReader.
-	rr := NewRandomReader(t.object, t.bucket, readSize/MiB, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), nil, nil, 0)
-	t.rr.wrapped = rr.(*randomReader)
+func TestRandomReader_UpgradeReadsToAverageSize(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.object.Size = 1 << 40
+		const totalReadBytes = 6 * MiB
+		const numReads = 2
+		const avgReadBytes = totalReadBytes / numReads
 
-	// Simulate a previous exhausted reader that ended at the offset from which
-	// we read below.
-	t.rr.wrapped.start = 1
-	t.rr.wrapped.limit = 1
+		const expectedBytesToRead = avgReadBytes
+		const start = 1
+		const readSize = 2 * minReadSize
 
-	// The bucket should be asked to read up to the end of the object.
-	data := strings.Repeat("x", readSize)
-	r := strings.NewReader(data)
-	rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+		h.rr.wrapped.seeks.Store(numReads)
+		h.rr.wrapped.totalReadBytes.Store(totalReadBytes)
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: getReadCloser([]byte("xxx"))}
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = 2
+		h.rr.wrapped.limit = 5
+		h.rr.wrapped.expectedOffset.Store(2)
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(
-		Any(),
-		AllOf(rangeStartIs(1), rangeLimitIs(1+readSize))).
-		WillOnce(Return(rc, nil))
-	ExpectCall(t.bucket, "BucketType")().Times(2).WillOnce(Return(t.bucketType))
+		r := strings.NewReader(strings.Repeat("x", expectedBytesToRead))
+		rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
 
-	// Call through.
-	buf := make([]byte, readSize)
-	objectData, err := t.rr.ReadAt(buf, 1)
+		h.mockNewReaderWithHandleCallForTestBucket(start, start+expectedBytesToRead, rc)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
 
-	// Check the state now.
-	ExpectFalse(objectData.CacheHit)
-	AssertEq(nil, err)
-	ExpectEq(data, string(buf))
-	ExpectEq(1+readSize, t.rr.wrapped.start)
-	ExpectEq(1+readSize, t.rr.wrapped.limit)
+		buf := make([]byte, readSize)
+		objectData, err := h.rr.ReadAt(buf, start)
+
+		h.assert.False(objectData.CacheHit)
+		h.require.NoError(err)
+		h.assert.Equal(int64(start+expectedBytesToRead), h.rr.wrapped.limit)
+	})
+}
+
+func TestRandomReader_UpgradesSequentialReads_ExistingReader(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.object.Size = 1 << 40
+		const readSize = 10
+
+		const existingSize = 3
+		r := strings.NewReader(strings.Repeat("x", existingSize))
+
+		h.rr.wrapped.reader = &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+		h.rr.wrapped.cancel = func() {}
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 1 + existingSize
+
+		r = strings.NewReader(strings.Repeat("y", readSize))
+		rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+
+		h.mockNewReaderWithHandleCallForTestBucket(1, 1+sequentialReadSizeInBytes, rc)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
+
+		buf := make([]byte, readSize)
+		objectData, err := h.rr.ReadAt(buf, 1)
+
+		h.assert.False(objectData.CacheHit)
+		h.require.NoError(err)
+		h.assert.Equal(int64(1+readSize), h.rr.wrapped.start)
+		h.assert.Equal(int64(1+sequentialReadSizeInBytes), h.rr.wrapped.limit)
+	})
+}
+
+func TestRandomReader_UpgradesSequentialReads_NoExistingReader(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.object.Size = 1 << 40
+		const readSize = 1 * MiB
+		rr := NewRandomReader(h.object, h.bucket, readSize/MiB, nil, false, metrics.NewNoopMetrics(), tracing.NewNoopTracer(), nil, nil, 0)
+		h.rr.wrapped = rr.(*randomReader)
+
+		h.rr.wrapped.start = 1
+		h.rr.wrapped.limit = 1
+
+		data := strings.Repeat("x", readSize)
+		r := strings.NewReader(data)
+		rc := &fake.FakeReader{ReadCloser: io.NopCloser(r)}
+
+		h.mockNewReaderWithHandleCallForTestBucket(1, 1+readSize, rc)
+		h.bucket.On("BucketType").Return(h.bucketType).Times(2)
+
+		buf := make([]byte, readSize)
+		objectData, err := h.rr.ReadAt(buf, 1)
+
+		h.assert.False(objectData.CacheHit)
+		h.require.NoError(err)
+		h.assert.Equal(data, string(buf))
+		h.assert.Equal(int64(1+readSize), h.rr.wrapped.start)
+		h.assert.Equal(int64(1+readSize), h.rr.wrapped.limit)
+	})
 }
 
 /******************* File cache specific tests ***********************/
 
-func (t *RandomReaderTest) Test_ReadAt_SequentialFullObject() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
+func TestRandomReader_Test_ReadAt_SequentialFullObject(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
 
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	ExpectTrue(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
+		h.assert.True(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_SequentialRangeRead() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
-	start := 0
-	end := 10 // not included
-	AssertLt(end, objectSize)
-	buf := make([]byte, end-start)
+func TestRandomReader_Test_ReadAt_SequentialRangeRead(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType).Once()
+		start := 0
+		end := 10
+		h.require.Less(end, int(objectSize))
+		buf := make([]byte, end-start)
 
-	objectData, err := t.rr.ReadAt(buf, int64(start))
+		objectData, err := h.rr.ReadAt(buf, int64(start))
 
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start:end], buf))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.object.Size = 20 * util.MiB
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	start1 := 0
-	end1 := util.MiB // not included
-	AssertLt(end1, objectSize)
-	// First call from offset 0 - sequential read
-	buf := make([]byte, end1-start1)
-	objectData, err := t.rr.ReadAt(buf, int64(start1))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start1:end1], buf))
-	start2 := 3*util.MiB + 4
-	end2 := start2 + util.MiB
-	buf2 := make([]byte, end2-start2)
+func TestRandomReader_Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChunkSize(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		h.object.Size = 20 * util.MiB
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		start1 := 0
+		end1 := util.MiB
+		h.require.Less(end1, int(objectSize))
+		buf := make([]byte, end1-start1)
+		objectData, err := h.rr.ReadAt(buf, int64(start1))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		start2 := 3*util.MiB + 4
+		end2 := start2 + util.MiB
+		buf2 := make([]byte, end2-start2)
 
-	// Assuming start2 offset download in progress
-	objectData, err = t.rr.ReadAt(buf2, int64(start2))
+		objectData, err = h.rr.ReadAt(buf2, int64(start2))
 
-	ExpectTrue(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start2:end2], buf2))
+		h.assert.True(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsFalse() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	t.rr.wrapped.cacheFileForRangeRead = false
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	start := 5
-	end := 10 // not included
-	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
-	t.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rc)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, end-start)
-	objectData, err := t.rr.ReadAt(buf, int64(start))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start:end], buf))
-	job, err := t.jobManager.CreateJobIfNotExists(t.object, t.bucket)
-	ExpectEq(nil, err)
-	jobStatus := job.GetStatus()
-	ExpectTrue(jobStatus.Name == downloader.NotStarted)
+func TestRandomReader_Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsFalse(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		h.rr.wrapped.cacheFileForRangeRead = false
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		start := 5
+		end := 10
+		rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
+		h.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rc)
+		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
+		h.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rc2)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, end-start)
+		objectData, err := h.rr.ReadAt(buf, int64(start))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+		job, err := h.jobManager.CreateJobIfNotExists(h.object, h.bucket)
+		h.require.NoError(err)
+		jobStatus := job.GetStatus()
+		h.assert.True(jobStatus.Name == downloader.NotStarted)
 
-	// Second read call should be a cache miss
-	objectData, err = t.rr.ReadAt(buf, int64(start))
+		objectData, err = h.rr.ReadAt(buf, int64(start))
 
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsTrue() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	t.rr.wrapped.cacheFileForRangeRead = true
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	start := 5
-	end := 10 // not included
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
-	// Mock for random-reader's NewReader call
-	t.mockNewReaderWithHandleCallForTestBucket(uint64(start), objectSize, rd)
-	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	// Mock for download job's NewReader call
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, end-start)
+func TestRandomReader_Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRangeReadIsTrue(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		h.rr.wrapped.cacheFileForRangeRead = true
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		start := 5
+		end := 10
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start:])}
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+			if req.Range == nil {
+				return false
+			}
+			return req.Range.Start == uint64(start) && req.Range.Limit == objectSize
+		})).Return(rd, nil).Once()
+		rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, end-start)
 
-	objectData, err := t.rr.ReadAt(buf, int64(start))
+		objectData, err := h.rr.ReadAt(buf, int64(start))
 
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start:end], buf))
-	job := t.jobManager.GetJob(t.object.Name, t.bucket.Name())
-	ExpectTrue(job == nil || job.GetStatus().Name == downloader.Downloading)
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+		// Second read call should be a cache hit
+		// Wait for the download job to complete first to avoid race.
+		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
+		h.require.NotNil(job)
+		for {
+			status := job.GetStatus()
+			if status.Name == downloader.Completed || status.Name == downloader.Failed {
+				break
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+
+		objectData, err = h.rr.ReadAt(buf, int64(start))
+
+		h.assert.NoError(err)
+		h.assert.True(objectData.CacheHit)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetMoreThanReadChunkSize() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.object.Size = 20 * util.MiB
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	// Mock for download job's NewReader call
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	start1 := 0
-	end1 := util.MiB // not included
-	AssertLt(end1, objectSize)
-	// First call from offset 0 - sequential read
-	buf := make([]byte, end1-start1)
-	objectData, err := t.rr.ReadAt(buf, int64(start1))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start1:end1], buf))
-	start2 := 16*util.MiB + 4
-	end2 := start2 + util.MiB
-	rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
-	// Mock for random-reader's NewReader call
-	t.mockNewReaderWithHandleCallForTestBucket(uint64(start2), objectSize, rd2)
-	buf2 := make([]byte, end2-start2)
+func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetMoreThanReadChunkSize(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		h.object.Size = 20 * util.MiB
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		start1 := 0
+		end1 := util.MiB
+		h.require.Less(end1, int(objectSize))
+		buf := make([]byte, end1-start1)
+		objectData, err := h.rr.ReadAt(buf, int64(start1))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		start2 := 16*util.MiB + 4
+		end2 := start2 + util.MiB
+		rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
+		h.mockNewReaderWithHandleCallForTestBucket(uint64(start2), objectSize, rd2)
+		buf2 := make([]byte, end2-start2)
 
-	// Assuming start2 offset download in progress
-	objectData, err = t.rr.ReadAt(buf2, int64(start2))
+		objectData, err = h.rr.ReadAt(buf2, int64(start2))
 
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start2:end2], buf2))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThanPrevious() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.object.Size = 20 * util.MiB
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	start1 := 0
-	end1 := util.MiB // not included
-	AssertLt(end1, objectSize)
-	// First call from offset 0 - sequential read
-	buf := make([]byte, end1-start1)
-	objectData, err := t.rr.ReadAt(buf, int64(start1))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start1:end1], buf))
-	start2 := 16*util.MiB + 4
-	end2 := start2 + util.MiB
-	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
-	t.mockNewReaderWithHandleCallForTestBucket(uint64(start2), objectSize, rc2)
-	buf2 := make([]byte, end2-start2)
-	// Assuming start2 offset download in progress
-	objectData, err = t.rr.ReadAt(buf2, int64(start2))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start2:end2], buf2))
-	start3 := util.MiB
-	end3 := start3 + util.MiB
-	buf3 := make([]byte, end3-start3)
+func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThanPrevious(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		h.object.Size = 20 * util.MiB
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		start1 := 0
+		end1 := util.MiB
+		h.require.Less(end1, int(objectSize))
+		buf := make([]byte, end1-start1)
+		objectData, err := h.rr.ReadAt(buf, int64(start1))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		start2 := 16*util.MiB + 4
+		end2 := start2 + util.MiB
+		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
+		h.mockNewReaderWithHandleCallForTestBucket(uint64(start2), objectSize, rc2)
+		buf2 := make([]byte, end2-start2)
+		objectData, err = h.rr.ReadAt(buf2, int64(start2))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+		start3 := util.MiB
+		end3 := start3 + util.MiB
+		buf3 := make([]byte, end3-start3)
 
-	objectData, err = t.rr.ReadAt(buf3, int64(start3))
+		objectData, err = h.rr.ReadAt(buf3, int64(start3))
 
-	ExpectEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent[start3:end3], buf3))
+		h.assert.NoError(err)
+		h.assert.True(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent[start3:end3], buf3))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_CacheMissDueToInvalidJob() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc1)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	job := t.jobManager.GetJob(t.object.Name, t.bucket.Name())
-	if job != nil {
-		jobStatus := job.GetStatus().Name
-		AssertTrue(jobStatus == downloader.Downloading || jobStatus == downloader.Completed, fmt.Sprintf("the actual status is %v", jobStatus))
-	}
+func TestRandomReader_Test_ReadAt_CacheMissDueToInvalidJob(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rc1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc1)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
+		if job != nil {
+			jobStatus := job.GetStatus().Name
+			h.require.True(jobStatus == downloader.Downloading || jobStatus == downloader.Completed, fmt.Sprintf("the actual status is %v", jobStatus))
+		}
 
-	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object.Name, t.bucket.Name())
-	AssertEq(nil, err)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
+		err = h.rr.wrapped.fileCacheHandler.InvalidateCache(h.object.Name, h.bucket.Name())
+		h.require.NoError(err)
+		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
 
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidJob() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	AssertFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	job := t.jobManager.GetJob(t.object.Name, t.bucket.Name())
-	if job != nil {
-		jobStatus := job.GetStatus().Name
-		AssertTrue(jobStatus == downloader.Downloading || jobStatus == downloader.Completed, fmt.Sprintf("the actual status is %v", jobStatus))
-	}
-	err = t.rr.wrapped.fileCacheHandler.InvalidateCache(t.object.Name, t.bucket.Name())
-	AssertEq(nil, err)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
-	objectData, err = t.rr.ReadAt(buf, 0)
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
-	rd3 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd3)
+func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidJob(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd1 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd1)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
+		if job != nil {
+			jobStatus := job.GetStatus().Name
+			h.require.True(jobStatus == downloader.Downloading || jobStatus == downloader.Completed, fmt.Sprintf("the actual status is %v", jobStatus))
+		}
+		err = h.rr.wrapped.fileCacheHandler.InvalidateCache(h.object.Name, h.bucket.Name())
+		h.require.NoError(err)
+		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
+		objectData, err = h.rr.ReadAt(buf, 0)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
+		rd3 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd3)
 
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFileHandle() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	AssertFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
-	err = t.rr.wrapped.fileCacheHandle.Close()
-	AssertEq(nil, err)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
-	objectData, err = t.rr.ReadAt(buf, 0)
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
-	rc3 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc3)
+func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFileHandle(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
+		err = h.rr.wrapped.fileCacheHandle.Close()
+		h.require.NoError(err)
+		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rc2)
+		objectData, err = h.rr.ReadAt(buf, 0)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
 
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	ExpectEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.NoError(err)
+		h.assert.True(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeleted() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	AssertFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
-	err = t.rr.wrapped.fileCacheHandle.Close()
-	AssertEq(nil, err)
-	t.rr.wrapped.fileCacheHandle = nil
-	// Delete the local cache file.
-	filePath, err := util.GetDownloadPath(t.cacheDir, util.GetObjectPath(t.bucket.Name(), t.object.Name))
-	AssertEq(nil, err)
-	err = os.Remove(filePath)
-	AssertEq(nil, err)
-	// Second reader (rd2) is required, since first reader (rd) is completely read.
-	// Reading again will return EOF.
-	rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd2)
+func TestRandomReader_Test_ReadAt_IfCacheFileGetsDeleted(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType).Once()
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
+		err = h.rr.wrapped.fileCacheHandle.Close()
+		h.require.NoError(err)
+		h.rr.wrapped.fileCacheHandle = nil
+		filePath, err := util.GetDownloadPath(h.cacheDir, util.GetObjectPath(h.bucket.Name(), h.object.Name))
+		h.require.NoError(err)
+		err = os.Remove(filePath)
+		h.require.NoError(err)
 
-	_, err = t.rr.ReadAt(buf, 0)
+		_, err = h.rr.ReadAt(buf, 0)
 
-	AssertNe(nil, err)
-	AssertTrue(errors.Is(err, util.ErrFileNotPresentInCache))
+		h.require.Error(err)
+		h.require.True(errors.Is(err, util.ErrFileNotPresentInCache))
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	AssertFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
-	// Delete the local cache file.
-	filePath, err := util.GetDownloadPath(t.cacheDir, util.GetObjectPath(t.bucket.Name(), t.object.Name))
-	AssertEq(nil, err)
-	err = os.Remove(filePath)
-	AssertEq(nil, err)
+func TestRandomReader_Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
+		filePath, err := util.GetDownloadPath(h.cacheDir, util.GetObjectPath(h.bucket.Name(), h.object.Name))
+		h.require.NoError(err)
+		err = os.Remove(filePath)
+		h.require.NoError(err)
 
-	// Read via cache only, as we have old fileHandle open and linux
-	// doesn't delete the file until the fileHandle count for the file is zero.
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	AssertEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.NoError(err)
+		h.assert.True(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_FailedJobRestartAndCacheHit() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	// First call goes to file cache succeeded by next call to random reader.
-	// First NewReaderWithReadHandle-call throws error, hence async job fails.
-	// Later NewReader-call returns a valid readCloser object hence fallback to
-	// GCS read will succeed.
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(nil, errors.New(""))).WillRepeatedly(Return(rc, nil))
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	objectData, err := t.rr.ReadAt(buf, 0)
-	AssertEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	job := t.jobManager.GetJob(t.object.Name, t.bucket.Name())
-	AssertTrue(job == nil || job.GetStatus().Name == downloader.Failed)
-	// Second reader (rc2) is required, since first reader (rc) is completely read.
-	// Reading again will return EOF.
-	rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd2)
-	// This call will populate the cache again.
-	objectData, err = t.rr.ReadAt(buf, 0)
-	ExpectEq(nil, err)
-	ExpectFalse(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+func TestRandomReader_Test_ReadAt_FailedJobRestartAndCacheHit(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rc := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(nil, errors.New("")).Once()
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(rc, nil).Once()
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		objectData, err := h.rr.ReadAt(buf, 0)
+		h.require.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.require.True(reflect.DeepEqual(testContent, buf))
+		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
+		h.require.True(job == nil || job.GetStatus().Name == downloader.Failed)
+		rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd2)
+		objectData, err = h.rr.ReadAt(buf, 0)
+		h.assert.NoError(err)
+		h.assert.False(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 
-	objectData, err = t.rr.ReadAt(buf, 0)
+		objectData, err = h.rr.ReadAt(buf, 0)
 
-	ExpectEq(nil, err)
-	ExpectTrue(objectData.CacheHit)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
-	ExpectNe(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.NoError(err)
+		h.assert.True(objectData.CacheHit)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-// Only writing two unit tests for tryReadingFromFileCache as
-// unit tests of ReadAt method covers all the workflows.
-func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheHit() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillRepeatedly(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	// First read will be a cache miss.
-	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
-	ExpectFalse(cacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
+func TestRandomReader_Test_tryReadingFromFileCache_CacheHit(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType)
+		buf := make([]byte, objectSize)
+		_, cacheHit, err := h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
+		h.assert.False(cacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
 
-	// Second read will be a cache hit.
-	_, cacheHit, err = t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
-	ExpectTrue(cacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent, buf))
+		_, cacheHit, err = h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
+		h.assert.True(cacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+	})
 }
 
-func (t *RandomReaderTest) Test_tryReadingFromFileCache_CacheMiss() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.rr.wrapped.cacheFileForRangeRead = false
-	start := 5
-	end := 10
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	buf := make([]byte, end-start)
+func TestRandomReader_Test_tryReadingFromFileCache_CacheMiss(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		h.rr.wrapped.cacheFileForRangeRead = false
+		start := 5
+		end := 10
+		h.bucket.On("Name").Return("test")
+		buf := make([]byte, end-start)
 
-	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, int64(start))
+		_, cacheHit, err := h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, int64(start))
 
-	ExpectFalse(cacheHit)
-	ExpectEq(nil, err)
+		h.assert.False(cacheHit)
+		h.assert.NoError(err)
+	})
 }
 
-func (t *RandomReaderTest) Test_ReadAt_OffsetEqualToObjectSize() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	t.object.Size = util.MiB
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
-	start1 := 0
-	end1 := util.MiB // equal to objectSize
-	// First call from offset 0 - objectSize
-	buf := make([]byte, end1-start1)
-	objectData, err := t.rr.ReadAt(buf, int64(start1))
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(nil, err)
-	ExpectTrue(reflect.DeepEqual(testContent[start1:end1], buf))
-	start2 := util.MiB // offset equal to objectSize
-	end2 := start2 + util.MiB
-	buf2 := make([]byte, end2-start2)
+func TestRandomReader_Test_ReadAt_OffsetEqualToObjectSize(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		h.object.Size = util.MiB
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType).Once()
+		start1 := 0
+		end1 := util.MiB
+		buf := make([]byte, end1-start1)
+		objectData, err := h.rr.ReadAt(buf, int64(start1))
+		h.assert.False(objectData.CacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		start2 := util.MiB
+		end2 := start2 + util.MiB
+		buf2 := make([]byte, end2-start2)
 
-	// read for offset equal to objectSize
-	objectData, err = t.rr.ReadAt(buf2, int64(start2))
+		objectData, err = h.rr.ReadAt(buf2, int64(start2))
 
-	// nothing should be read
-	ExpectFalse(objectData.CacheHit)
-	ExpectEq(io.EOF, err)
-	ExpectEq(0, objectData.Size)
+		h.assert.False(objectData.CacheHit)
+		h.assert.Equal(io.EOF, err)
+		h.assert.Equal(0, objectData.Size)
+	})
 }
 
-func (t *RandomReaderTest) Test_Destroy_NilCacheHandle() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
+func TestRandomReader_Test_Destroy_NilCacheHandle(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
 
-	t.rr.Destroy()
+		h.rr.Destroy()
 
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) Test_Destroy_NonNilCacheHandle() {
-	t.rr.wrapped.fileCacheHandler = t.cacheHandler
-	objectSize := t.object.Size
-	testContent := testutil.GenerateRandomBytes(int(objectSize))
-	rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
-	t.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
-	ExpectCall(t.bucket, "Name")().WillRepeatedly(Return("test"))
-	ExpectCall(t.bucket, "BucketType")().WillOnce(Return(t.bucketType))
-	buf := make([]byte, objectSize)
-	_, cacheHit, err := t.rr.wrapped.tryReadingFromFileCache(t.rr.ctx, buf, 0)
-	AssertFalse(cacheHit)
-	AssertEq(nil, err)
-	AssertTrue(reflect.DeepEqual(testContent, buf))
-	AssertNe(nil, t.rr.wrapped.fileCacheHandle)
+func TestRandomReader_Test_Destroy_NonNilCacheHandle(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		h.rr.wrapped.fileCacheHandler = h.cacheHandler
+		objectSize := h.object.Size
+		testContent := testutil.GenerateRandomBytes(int(objectSize))
+		rd := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
+		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd)
+		h.bucket.On("Name").Return("test")
+		h.bucket.On("BucketType").Return(h.bucketType).Once()
+		buf := make([]byte, objectSize)
+		_, cacheHit, err := h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
+		h.assert.False(cacheHit)
+		h.assert.NoError(err)
+		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 
-	t.rr.wrapped.Destroy()
+		h.rr.wrapped.Destroy()
 
-	ExpectEq(nil, t.rr.wrapped.fileCacheHandle)
+		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
+	})
 }
 
-func (t *RandomReaderTest) TestNewReader_FileClobbered() {
-	var notFoundError *gcs.NotFoundError
+func TestRandomReader_TestNewReader_FileClobbered(t *testing.T) {
+	runTest(t, func(h *randomReaderTestHelper) {
+		var notFoundError *gcs.NotFoundError
 
-	ExpectCall(t.bucket, "NewReaderWithReadHandle")(Any(), Any()).
-		WillOnce(Return(nil, notFoundError))
+		h.bucket.On("NewReaderWithReadHandle", mock.Anything, mock.Anything).
+			Return(nil, notFoundError).Once()
 
-	err := t.rr.wrapped.startRead(context.Background(), 0, 1, 0)
+		err := h.rr.wrapped.startRead(context.Background(), 0, 1, 0)
 
-	AssertNe(nil, err)
-	var clobberedErr *gcsfuse_errors.FileClobberedError
-	AssertTrue(errors.As(err, &clobberedErr))
+		h.assert.Error(err)
+		var clobberedErr *gcsfuse_errors.FileClobberedError
+		h.assert.True(errors.As(err, &clobberedErr))
+	})
 }
-
-// TODO (raj-prince) - to add unit tests for failed scenario while reading via cache.
-// This requires mocking CacheHandle object, whose read method will return some unexpected
-// error.

--- a/internal/gcsx/random_reader_test.go
+++ b/internal/gcsx/random_reader_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
 	"testing/iotest"
@@ -356,7 +355,7 @@ func TestRandomReader_PropagatesCancellation(t *testing.T) {
 
 		go func() {
 			buf := make([]byte, 2)
-			h.rr.wrapped.ReadAt(ctx, buf, 1)
+			_, _ = h.rr.wrapped.ReadAt(ctx, buf, 1)
 			close(readReturned)
 		}()
 
@@ -537,13 +536,13 @@ func TestRandomReader_Test_ReadAt_SequentialFullObject(t *testing.T) {
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 
 		objectData, err = h.rr.ReadAt(buf, 0)
 
 		h.assert.True(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 	})
 }
 
@@ -565,7 +564,7 @@ func TestRandomReader_Test_ReadAt_SequentialRangeRead(t *testing.T) {
 
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+		h.assert.Equal(testContent[start:end], buf)
 	})
 }
 
@@ -586,7 +585,7 @@ func TestRandomReader_Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChun
 		objectData, err := h.rr.ReadAt(buf, int64(start1))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		h.assert.Equal(testContent[start1:end1], buf)
 		start2 := 3*util.MiB + 4
 		end2 := start2 + util.MiB
 		buf2 := make([]byte, end2-start2)
@@ -595,7 +594,7 @@ func TestRandomReader_Test_ReadAt_SequentialSubsequentReadOffsetLessThanReadChun
 
 		h.assert.True(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+		h.assert.Equal(testContent[start2:end2], buf2)
 	})
 }
 
@@ -617,7 +616,7 @@ func TestRandomReader_Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRa
 		objectData, err := h.rr.ReadAt(buf, int64(start))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+		h.assert.Equal(testContent[start:end], buf)
 		job, err := h.jobManager.CreateJobIfNotExists(h.object, h.bucket)
 		h.require.NoError(err)
 		jobStatus := job.GetStatus()
@@ -655,18 +654,15 @@ func TestRandomReader_Test_ReadAt_RandomReadNotStartWithZeroOffsetWhenCacheForRa
 
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start:end], buf))
+		h.assert.Equal(testContent[start:end], buf)
 		// Second read call should be a cache hit
 		// Wait for the download job to complete first to avoid race.
 		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
 		h.require.NotNil(job)
-		for {
+		h.require.Eventually(func() bool {
 			status := job.GetStatus()
-			if status.Name == downloader.Completed || status.Name == downloader.Failed {
-				break
-			}
-			time.Sleep(10 * time.Millisecond)
-		}
+			return status.Name == downloader.Completed || status.Name == downloader.Failed
+		}, 2*time.Second, 10*time.Millisecond)
 
 		objectData, err = h.rr.ReadAt(buf, int64(start))
 
@@ -692,7 +688,7 @@ func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetMoreThan
 		objectData, err := h.rr.ReadAt(buf, int64(start1))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		h.assert.Equal(testContent[start1:end1], buf)
 		start2 := 16*util.MiB + 4
 		end2 := start2 + util.MiB
 		rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
@@ -703,7 +699,7 @@ func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetMoreThan
 
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+		h.assert.Equal(testContent[start2:end2], buf2)
 	})
 }
 
@@ -724,7 +720,7 @@ func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThan
 		objectData, err := h.rr.ReadAt(buf, int64(start1))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		h.assert.Equal(testContent[start1:end1], buf)
 		start2 := 16*util.MiB + 4
 		end2 := start2 + util.MiB
 		rc2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent[start2:])}
@@ -733,7 +729,7 @@ func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThan
 		objectData, err = h.rr.ReadAt(buf2, int64(start2))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start2:end2], buf2))
+		h.assert.Equal(testContent[start2:end2], buf2)
 		start3 := util.MiB
 		end3 := start3 + util.MiB
 		buf3 := make([]byte, end3-start3)
@@ -742,7 +738,7 @@ func TestRandomReader_Test_ReadAt_SequentialToRandomSubsequentReadOffsetLessThan
 
 		h.assert.NoError(err)
 		h.assert.True(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent[start3:end3], buf3))
+		h.assert.Equal(testContent[start3:end3], buf3)
 	})
 }
 
@@ -759,7 +755,7 @@ func TestRandomReader_Test_ReadAt_CacheMissDueToInvalidJob(t *testing.T) {
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
 		if job != nil {
 			jobStatus := job.GetStatus().Name
@@ -775,7 +771,7 @@ func TestRandomReader_Test_ReadAt_CacheMissDueToInvalidJob(t *testing.T) {
 
 		h.assert.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
 	})
 }
@@ -793,7 +789,7 @@ func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidJob(
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
 		if job != nil {
 			jobStatus := job.GetStatus().Name
@@ -806,7 +802,7 @@ func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidJob(
 		objectData, err = h.rr.ReadAt(buf, 0)
 		h.assert.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
 		rd3 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
 		h.mockNewReaderWithHandleCallForTestBucket(0, objectSize, rd3)
@@ -815,7 +811,7 @@ func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidJob(
 
 		h.assert.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 	})
 }
@@ -833,7 +829,7 @@ func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFile
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
 		err = h.rr.wrapped.fileCacheHandle.Close()
 		h.require.NoError(err)
@@ -842,14 +838,14 @@ func TestRandomReader_Test_ReadAt_CachePopulatedAndThenCacheMissDueToInvalidFile
 		objectData, err = h.rr.ReadAt(buf, 0)
 		h.assert.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.Nil(h.rr.wrapped.fileCacheHandle)
 
 		objectData, err = h.rr.ReadAt(buf, 0)
 
 		h.assert.NoError(err)
 		h.assert.True(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 	})
 }
@@ -867,7 +863,7 @@ func TestRandomReader_Test_ReadAt_IfCacheFileGetsDeleted(t *testing.T) {
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
 		err = h.rr.wrapped.fileCacheHandle.Close()
 		h.require.NoError(err)
@@ -897,7 +893,7 @@ func TestRandomReader_Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen(t *t
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		h.require.NotNil(h.rr.wrapped.fileCacheHandle)
 		filePath, err := util.GetDownloadPath(h.cacheDir, util.GetObjectPath(h.bucket.Name(), h.object.Name))
 		h.require.NoError(err)
@@ -908,7 +904,7 @@ func TestRandomReader_Test_ReadAt_IfCacheFileGetsDeletedWithCacheHandleOpen(t *t
 
 		h.assert.NoError(err)
 		h.assert.True(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 	})
 }
@@ -929,7 +925,7 @@ func TestRandomReader_Test_ReadAt_FailedJobRestartAndCacheHit(t *testing.T) {
 		objectData, err := h.rr.ReadAt(buf, 0)
 		h.require.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.require.True(reflect.DeepEqual(testContent, buf))
+		h.require.Equal(testContent, buf)
 		job := h.jobManager.GetJob(h.object.Name, h.bucket.Name())
 		h.require.True(job == nil || job.GetStatus().Name == downloader.Failed)
 		rd2 := &fake.FakeReader{ReadCloser: getReadCloser(testContent)}
@@ -937,14 +933,14 @@ func TestRandomReader_Test_ReadAt_FailedJobRestartAndCacheHit(t *testing.T) {
 		objectData, err = h.rr.ReadAt(buf, 0)
 		h.assert.NoError(err)
 		h.assert.False(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 
 		objectData, err = h.rr.ReadAt(buf, 0)
 
 		h.assert.NoError(err)
 		h.assert.True(objectData.CacheHit)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 	})
 }
@@ -962,12 +958,12 @@ func TestRandomReader_Test_tryReadingFromFileCache_CacheHit(t *testing.T) {
 		_, cacheHit, err := h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
 		h.assert.False(cacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 
 		_, cacheHit, err = h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
 		h.assert.True(cacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 	})
 }
 
@@ -1003,7 +999,7 @@ func TestRandomReader_Test_ReadAt_OffsetEqualToObjectSize(t *testing.T) {
 		objectData, err := h.rr.ReadAt(buf, int64(start1))
 		h.assert.False(objectData.CacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent[start1:end1], buf))
+		h.assert.Equal(testContent[start1:end1], buf)
 		start2 := util.MiB
 		end2 := start2 + util.MiB
 		buf2 := make([]byte, end2-start2)
@@ -1039,7 +1035,7 @@ func TestRandomReader_Test_Destroy_NonNilCacheHandle(t *testing.T) {
 		_, cacheHit, err := h.rr.wrapped.tryReadingFromFileCache(h.rr.ctx, buf, 0)
 		h.assert.False(cacheHit)
 		h.assert.NoError(err)
-		h.assert.True(reflect.DeepEqual(testContent, buf))
+		h.assert.Equal(testContent, buf)
 		h.assert.NotNil(h.rr.wrapped.fileCacheHandle)
 
 		h.rr.wrapped.Destroy()


### PR DESCRIPTION
### Description
Migrate tests in `internal/gcsx` from legacy `ogletest` to `testify`:
- **`integration_test.go`**: Convert helper and integration tests to use `testify/assert` and `testify/require`.
- **`random_reader_test.go`**: Migrate random reader unit tests and mock expectations to `testify/assert`, `testify/mock`, and `testify/require`, and use `t.TempDir()` for isolated cache directory testing.
Helps in standard IDE integration, moving away from unmaintained library, and unifying testing styles.
### Link to the issue in case of a bug fix.
N/A
### Testing details
1. Manual - `make build` passed.
2. Unit tests - `go test -v -count=1 ./internal/gcsx/...` passed.
3. Integration tests - N/A
### Any backward incompatible change? If so, please explain.
N/A