### PR TITLE
feat(otel exporter): Disabling otel exporter test for GKE & Zonal

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -2106,6 +2106,6 @@ otel_exporter:
         compatible:
           flat: true
           hns: true
-          zonal: true
-        run_on_gke: true
+          zonal: false
+        run_on_gke: false
         run: "TestOTelExporterTestSuite"


### PR DESCRIPTION
### Description
Disabling OTEL exporter e2e tests for GKE. Also, we don't need to check for zonal buckets as well as it has nothing to do with bucket type.

### Link to the issue in case of a bug fix.
b/546350504

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
