### PR TITLE
feat(native-retries): E2E emulator based tests for native retries

### DIFF
--- a/tools/integration_tests/emulator_tests/configs/mount_retry_403.yaml
+++ b/tools/integration_tests/emulator_tests/configs/mount_retry_403.yaml
@@ -1,0 +1,7 @@
+proxyType: grpc
+targetHost: "localhost:8888"
+retryConfig:
+- method: GetStorageLayout
+  retryInstruction: "return-403"
+  retryCount: 1
+  skipCount: 0

--- a/tools/integration_tests/emulator_tests/configs/mount_retry_404_bucket_not_found.yaml
+++ b/tools/integration_tests/emulator_tests/configs/mount_retry_404_bucket_not_found.yaml
@@ -1,0 +1,7 @@
+proxyType: grpc
+targetHost: "localhost:8888"
+retryConfig:
+- method: GetStorageLayout
+  retryInstruction: "return-404-bucket-does-not-exist"
+  retryCount: 1
+  skipCount: 0

--- a/tools/integration_tests/emulator_tests/configs/mount_retry_non_hns_403.yaml
+++ b/tools/integration_tests/emulator_tests/configs/mount_retry_non_hns_403.yaml
@@ -1,0 +1,6 @@
+targetHost: http://localhost:9000
+retryConfig:
+- method: JsonStat
+  retryInstruction: "return-403"
+  retryCount: 1
+  skipCount: 0

--- a/tools/integration_tests/emulator_tests/configs/mount_retry_non_hns_404_bucket_not_found.yaml
+++ b/tools/integration_tests/emulator_tests/configs/mount_retry_non_hns_404_bucket_not_found.yaml
@@ -1,0 +1,6 @@
+targetHost: http://localhost:9000
+retryConfig:
+- method: JsonStat
+  retryInstruction: "return-404-bucket-does-not-exist"
+  retryCount: 1
+  skipCount: 0

--- a/tools/integration_tests/emulator_tests/mount_retry/mount_retry_test.go
+++ b/tools/integration_tests/emulator_tests/mount_retry/mount_retry_test.go
@@ -1,0 +1,196 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mount_retry
+
+import (
+	"fmt"
+	"os"
+	"path"
+	"testing"
+
+	emulator_tests "github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/emulator_tests/util"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/mounting/static_mounting"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/test_suite"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type mountRetryBase struct {
+	bucketName         string
+	port               int
+	proxyProcessId     int
+	proxyServerLogFile string
+	flags              []string
+	configFileName     string
+	testDirPath        string
+	isHTTP             bool
+	suite.Suite
+}
+
+func (m *mountRetryBase) SetupTest() {
+	m.proxyServerLogFile = setup.CreateProxyServerLogFile(m.T())
+	var err error
+	m.port, m.proxyProcessId, err = emulator_tests.StartProxyServer(m.configFileName, m.proxyServerLogFile)
+	require.NoError(m.T(), err)
+
+	// Copy flags to avoid mutating the original slice across suites
+	mountFlags := append([]string(nil), m.flags...)
+	if m.isHTTP {
+		mountFlags = append(mountFlags, fmt.Sprintf("--custom-endpoint=http://localhost:%d/storage/v1/", m.port))
+	} else {
+		mountFlags = append(mountFlags, fmt.Sprintf("--custom-endpoint=localhost:%d", m.port))
+	}
+	mountFlags = append(mountFlags, "--anonymous-access") // Required for emulator localhost endpoint
+
+	config := &test_suite.TestConfig{
+		TestBucket:              m.bucketName,
+		GKEMountedDirectory:     setup.MountedDirectory(),
+		GCSFuseMountedDirectory: setup.MntDir(),
+		LogFile:                 setup.LogFile(),
+	}
+	setup.MountGCSFuseWithGivenMountWithConfigFunc(config, mountFlags, static_mounting.MountGcsfuseWithStaticMountingWithConfigFile)
+	m.testDirPath = setup.SetupTestDirectory(m.T().Name())
+}
+
+func (m *mountRetryBase) TearDownTest() {
+	setup.UnmountGCSFuse(setup.MntDir())
+	if m.proxyProcessId > 0 {
+		assert.NoError(m.T(), emulator_tests.KillProxyServerProcess(m.proxyProcessId))
+	}
+	setup.SaveGCSFuseLogFileInCaseOfFailure(m.T())
+	setup.SaveProxyServerLogFileInCaseOfFailure(m.proxyServerLogFile, m.T())
+}
+
+func (m *mountRetryBase) verifyMountedDirectory(folderName string) {
+	folderPath := path.Join(m.testDirPath, folderName)
+	err := os.MkdirAll(folderPath, 0755)
+	require.NoError(m.T(), err)
+
+	info, err := os.Stat(folderPath)
+	require.NoError(m.T(), err)
+	assert.True(m.T(), info.IsDir())
+}
+
+func newMountRetryBase(bucketName string, flags []string, configFileName string, isHTTP bool) mountRetryBase {
+	return mountRetryBase{
+		bucketName:     bucketName,
+		flags:          flags,
+		configFileName: configFileName,
+		isHTTP:         isHTTP,
+	}
+}
+
+// --- HNS (gRPC) Test Suites ---
+
+type permissionDenied403HNSSuite struct{ mountRetryBase }
+
+// TestMountSucceedsWithTransient403PermissionDenied_HNS verifies that GCSFuse mount
+// completes successfully even when HTTP 403 / gRPC PermissionDenied error is returned
+// during initial GetStorageLayout calls, proving that ShouldRetryOnMount correctly
+// retries and recovers after 1 attempt.
+func (s *permissionDenied403HNSSuite) TestMountSucceedsWithTransient403PermissionDenied_HNS() {
+	s.verifyMountedDirectory("retry_folder_hns_403")
+}
+
+type bucketDoesNotExist404HNSSuite struct{ mountRetryBase }
+
+// TestMountSucceedsWithTransient404BucketDoesNotExist_HNS verifies that GCSFuse mount
+// completes successfully even when HTTP 404 / gRPC NotFound (bucket does not exist)
+// error is returned during initial GetStorageLayout calls, proving that ShouldRetryOnMount
+// correctly retries and recovers after 1 attempt.
+func (s *bucketDoesNotExist404HNSSuite) TestMountSucceedsWithTransient404BucketDoesNotExist_HNS() {
+	s.verifyMountedDirectory("retry_folder_hns_404")
+}
+
+// --- Non-HNS (HTTP) Test Suites ---
+
+type permissionDenied403NonHNSSuite struct{ mountRetryBase }
+
+// TestMountSucceedsWithTransient403PermissionDenied_NonHNS verifies that GCSFuse mount
+// completes successfully even when HTTP 403 error is returned during initial Attrs calls
+// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
+func (s *permissionDenied403NonHNSSuite) TestMountSucceedsWithTransient403PermissionDenied_NonHNS() {
+	s.verifyMountedDirectory("retry_folder_non_hns_403")
+}
+
+type bucketDoesNotExist404NonHNSSuite struct{ mountRetryBase }
+
+// TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS verifies that GCSFuse mount
+// completes successfully even when HTTP 404 (bucket does not exist) error is returned during initial Attrs calls
+// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
+func (s *bucketDoesNotExist404NonHNSSuite) TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS() {
+	s.verifyMountedDirectory("retry_folder_non_hns_404")
+}
+
+const (
+	hnsBucket    = "test-hns-bucket"
+	nonHnsBucket = "test-bucket"
+)
+
+func TestMountRetry(t *testing.T) {
+	hnsFlags := []string{
+		"--enable-mount-retries=true",
+		"--client-protocol=grpc",
+		"--metadata-cache-ttl-secs=0",
+	}
+
+	nonHnsFlags := []string{
+		"--enable-mount-retries=true",
+		"--enable-hns=false",
+		"--client-protocol=http1",
+		"--metadata-cache-ttl-secs=0",
+	}
+
+	suites := []suite.TestingSuite{
+		&permissionDenied403HNSSuite{
+			mountRetryBase: newMountRetryBase(
+				hnsBucket,
+				hnsFlags,
+				"../configs/mount_retry_403.yaml",
+				false,
+			),
+		},
+		&bucketDoesNotExist404HNSSuite{
+			mountRetryBase: newMountRetryBase(
+				hnsBucket,
+				hnsFlags,
+				"../configs/mount_retry_404_bucket_not_found.yaml",
+				false,
+			),
+		},
+		&permissionDenied403NonHNSSuite{
+			mountRetryBase: newMountRetryBase(
+				nonHnsBucket,
+				nonHnsFlags,
+				"../configs/mount_retry_non_hns_403.yaml",
+				true,
+			),
+		},
+		&bucketDoesNotExist404NonHNSSuite{
+			mountRetryBase: newMountRetryBase(
+				nonHnsBucket,
+				nonHnsFlags,
+				"../configs/mount_retry_non_hns_404_bucket_not_found.yaml",
+				true,
+			),
+		},
+	}
+
+	for _, s := range suites {
+		suite.Run(t, s)
+	}
+}

--- a/tools/integration_tests/emulator_tests/mount_retry/mount_retry_test.go
+++ b/tools/integration_tests/emulator_tests/mount_retry/mount_retry_test.go
@@ -94,46 +94,13 @@ func newMountRetryBase(bucketName string, flags []string, configFileName string,
 	}
 }
 
-// --- HNS (gRPC) Test Suites ---
-
-type permissionDenied403HNSSuite struct{ mountRetryBase }
-
-// TestMountSucceedsWithTransient403PermissionDenied_HNS verifies that GCSFuse mount
-// completes successfully even when HTTP 403 / gRPC PermissionDenied error is returned
-// during initial GetStorageLayout calls, proving that ShouldRetryOnMount correctly
-// retries and recovers after 1 attempt.
-func (s *permissionDenied403HNSSuite) TestMountSucceedsWithTransient403PermissionDenied_HNS() {
-	s.verifyMountedDirectory("retry_folder_hns_403")
+type mountRetrySuite struct {
+	mountRetryBase
+	folderName string
 }
 
-type bucketDoesNotExist404HNSSuite struct{ mountRetryBase }
-
-// TestMountSucceedsWithTransient404BucketDoesNotExist_HNS verifies that GCSFuse mount
-// completes successfully even when HTTP 404 / gRPC NotFound (bucket does not exist)
-// error is returned during initial GetStorageLayout calls, proving that ShouldRetryOnMount
-// correctly retries and recovers after 1 attempt.
-func (s *bucketDoesNotExist404HNSSuite) TestMountSucceedsWithTransient404BucketDoesNotExist_HNS() {
-	s.verifyMountedDirectory("retry_folder_hns_404")
-}
-
-// --- Non-HNS (HTTP) Test Suites ---
-
-type permissionDenied403NonHNSSuite struct{ mountRetryBase }
-
-// TestMountSucceedsWithTransient403PermissionDenied_NonHNS verifies that GCSFuse mount
-// completes successfully even when HTTP 403 error is returned during initial Attrs calls
-// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
-func (s *permissionDenied403NonHNSSuite) TestMountSucceedsWithTransient403PermissionDenied_NonHNS() {
-	s.verifyMountedDirectory("retry_folder_non_hns_403")
-}
-
-type bucketDoesNotExist404NonHNSSuite struct{ mountRetryBase }
-
-// TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS verifies that GCSFuse mount
-// completes successfully even when HTTP 404 (bucket does not exist) error is returned during initial Attrs calls
-// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
-func (s *bucketDoesNotExist404NonHNSSuite) TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS() {
-	s.verifyMountedDirectory("retry_folder_non_hns_404")
+func (s *mountRetrySuite) TestMountSucceeds() {
+	s.verifyMountedDirectory(s.folderName)
 }
 
 const (
@@ -141,56 +108,79 @@ const (
 	nonHnsBucket = "test-bucket"
 )
 
-func TestMountRetry(t *testing.T) {
-	hnsFlags := []string{
+var (
+	hnsFlags = []string{
 		"--enable-mount-retries=true",
 		"--client-protocol=grpc",
 		"--metadata-cache-ttl-secs=0",
 	}
 
-	nonHnsFlags := []string{
+	nonHnsFlags = []string{
 		"--enable-mount-retries=true",
 		"--enable-hns=false",
 		"--client-protocol=http1",
 		"--metadata-cache-ttl-secs=0",
 	}
+)
 
-	suites := []suite.TestingSuite{
-		&permissionDenied403HNSSuite{
-			mountRetryBase: newMountRetryBase(
-				hnsBucket,
-				hnsFlags,
-				"../configs/mount_retry_403.yaml",
-				false,
-			),
-		},
-		&bucketDoesNotExist404HNSSuite{
-			mountRetryBase: newMountRetryBase(
-				hnsBucket,
-				hnsFlags,
-				"../configs/mount_retry_404_bucket_not_found.yaml",
-				false,
-			),
-		},
-		&permissionDenied403NonHNSSuite{
-			mountRetryBase: newMountRetryBase(
-				nonHnsBucket,
-				nonHnsFlags,
-				"../configs/mount_retry_non_hns_403.yaml",
-				true,
-			),
-		},
-		&bucketDoesNotExist404NonHNSSuite{
-			mountRetryBase: newMountRetryBase(
-				nonHnsBucket,
-				nonHnsFlags,
-				"../configs/mount_retry_non_hns_404_bucket_not_found.yaml",
-				true,
-			),
-		},
-	}
+// TestMountSucceedsWithTransient403PermissionDenied_HNS verifies that GCSFuse mount
+// completes successfully even when HTTP 403 / gRPC PermissionDenied error is returned
+// during initial GetStorageLayout calls, proving that ShouldRetryOnMount correctly
+// retries and recovers after 1 attempt.
+func TestMountSucceedsWithTransient403PermissionDenied_HNS(t *testing.T) {
+	suite.Run(t, &mountRetrySuite{
+		mountRetryBase: newMountRetryBase(
+			hnsBucket,
+			hnsFlags,
+			"../configs/mount_retry_403.yaml",
+			false,
+		),
+		folderName: "retry_folder_hns_403",
+	})
+}
 
-	for _, s := range suites {
-		suite.Run(t, s)
-	}
+// TestMountSucceedsWithTransient404BucketDoesNotExist_HNS verifies that GCSFuse mount
+// completes successfully even when HTTP 404 / gRPC NotFound (bucket does not exist)
+// error is returned during initial GetStorageLayout calls, proving that ShouldRetryOnMount
+// correctly retries and recovers after 1 attempt.
+func TestMountSucceedsWithTransient404BucketDoesNotExist_HNS(t *testing.T) {
+	suite.Run(t, &mountRetrySuite{
+		mountRetryBase: newMountRetryBase(
+			hnsBucket,
+			hnsFlags,
+			"../configs/mount_retry_404_bucket_not_found.yaml",
+			false,
+		),
+		folderName: "retry_folder_hns_404",
+	})
+}
+
+// TestMountSucceedsWithTransient403PermissionDenied_NonHNS verifies that GCSFuse mount
+// completes successfully even when HTTP 403 error is returned during initial Attrs calls
+// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
+func TestMountSucceedsWithTransient403PermissionDenied_NonHNS(t *testing.T) {
+	suite.Run(t, &mountRetrySuite{
+		mountRetryBase: newMountRetryBase(
+			nonHnsBucket,
+			nonHnsFlags,
+			"../configs/mount_retry_non_hns_403.yaml",
+			true,
+		),
+		folderName: "retry_folder_non_hns_403",
+	})
+}
+
+// TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS verifies that GCSFuse mount
+// completes successfully even when HTTP 404 (bucket does not exist) error is returned during initial Attrs calls
+// in verifyNonHNSBucketAccess, proving that ShouldRetryOnMount correctly retries and recovers after 1 attempt.
+func TestMountSucceedsWithTransient404BucketDoesNotExist_NonHNS(t *testing.T) {
+	suite.Run(t, &mountRetrySuite{
+		mountRetryBase: newMountRetryBase(
+			nonHnsBucket,
+			nonHnsFlags,
+			"../configs/mount_retry_non_hns_404_bucket_not_found.yaml",
+			true,
+		),
+		folderName: "retry_folder_non_hns_404",
+	})
 }

--- a/tools/integration_tests/emulator_tests/mount_retry/setup_test.go
+++ b/tools/integration_tests/emulator_tests/mount_retry/setup_test.go
@@ -1,0 +1,39 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mount_retry
+
+import (
+	"log"
+	"os"
+	"testing"
+
+	"github.com/googlecloudplatform/gcsfuse/v3/tools/integration_tests/util/setup"
+)
+
+func TestMain(m *testing.M) {
+	setup.ParseSetUpFlags()
+
+	if setup.MountedDirectory() != "" {
+		log.Printf("These tests will not run with mounted directory.")
+		return
+	}
+
+	// Set up test directory.
+	setup.SetUpTestDirForTestBucketFlag()
+
+	log.Println("Running mount retry tests...")
+	successCode := m.Run()
+	os.Exit(successCode)
+}


### PR DESCRIPTION
### Description
- Added emulator-based E2E integration tests in `tools/integration_tests/emulator_tests/mount_retry/` to validate native mount retry and recovery logic.
- Added proxy configs to simulate transient HTTP 403 & 404 (bucket not found) errors for both HNS (gRPC `GetStorageLayout`) and Non-HNS (HTTP `Attrs`) buckets.

### Link to the issue in case of a bug fix.
b/504518066

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Ran emulator integration tests:
   `go test -v -p 1 -timeout 10m ./tools/integration_tests/emulator_tests/mount_retry/... --integrationTest --testbucket=test-bucket`

### Any backward incompatible change? If so, please explain.
No