### PR TITLE
feat(cfg): implement flat protobuf schema generator and privacy scrubber

### DIFF
--- a/cfg/config.proto
+++ b/cfg/config.proto
@@ -1,0 +1,182 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT EDIT MANUALLY.
+
+syntax = "proto3";
+
+package gcsfuse.cfg.v1;
+
+option go_package = "github.com/googlecloudplatform/gcsfuse/v3/cfg/pb";
+
+message Config {
+  bool is_app_name_set = 1;
+  bool is_cache_dir_set = 2;
+  bool cloud_profiler_allocated_heap = 3;
+  bool cloud_profiler_cpu = 4;
+  bool cloud_profiler_enabled = 5;
+  bool cloud_profiler_goroutines = 6;
+  bool cloud_profiler_heap = 7;
+  bool is_cloud_profiler_label_set = 8;
+  bool cloud_profiler_mutex = 9;
+  bool is_cloud_profiler_service_name_set = 10;
+  bool debug_exit_on_invariant_violation = 11;
+  bool debug_fuse = 12;
+  bool debug_gcs = 13;
+  bool debug_log_mutex = 14;
+  bool disable_autoconfig = 15;
+  bool dummy_io_enable = 16;
+  int64 dummy_io_per_mb_latency = 17;
+  int64 dummy_io_reader_latency = 18;
+  bool enable_atomic_rename_object = 19;
+  bool enable_google_lib_auth = 20;
+  bool enable_hns = 21;
+  bool enable_new_reader = 22;
+  bool enable_standard_symlinks = 23;
+  bool enable_type_cache_deprecation = 24;
+  bool enable_unsupported_path_support = 25;
+  bool file_cache_cache_file_for_range_read = 26;
+  int32 file_cache_download_chunk_size_mb = 27;
+  bool file_cache_enable_crc = 28;
+  bool file_cache_enable_experimental_shared_chunk_cache = 29;
+  bool file_cache_enable_o_direct = 30;
+  bool file_cache_enable_parallel_downloads = 31;
+  bool is_file_cache_exclude_regex_set = 32;
+  bool file_cache_experimental_disable_size_calculation_fix = 33;
+  bool file_cache_experimental_enable_chunk_cache = 34;
+  bool file_cache_experimental_parallel_downloads_default_on = 35;
+  bool is_file_cache_include_regex_set = 36;
+  int32 file_cache_max_parallel_downloads = 37;
+  int32 file_cache_max_size_mb = 38;
+  int32 file_cache_parallel_downloads_per_file = 39;
+  int32 file_cache_shared_cache_chunk_size_mb = 40;
+  int32 file_cache_write_buffer_size = 41;
+  int32 file_system_congestion_threshold = 42;
+  int32 file_system_dir_mode = 43;
+  bool file_system_disable_parallel_dirops = 44;
+  bool file_system_enable_kernel_reader = 45;
+  bool file_system_experimental_enable_dentry_cache = 46;
+  bool file_system_experimental_enable_pirlo = 47;
+  bool file_system_experimental_enable_readdirplus = 48;
+  bool file_system_experimental_o_direct = 49;
+  int32 file_system_file_mode = 50;
+  int32 file_system_fuse_max_request_size_kb = 51;
+  int32 file_system_fuse_max_write_size_kb = 52;
+  bool is_file_system_fuse_options_set = 53;
+  int32 file_system_gid = 54;
+  bool file_system_ignore_interrupts = 55;
+  int32 file_system_inactive_mrd_cache_size = 56;
+  int32 file_system_kernel_list_cache_ttl_secs = 57;
+  bool is_file_system_kernel_params_file_set = 58;
+  int32 file_system_max_background = 59;
+  int32 file_system_max_read_ahead_kb = 60;
+  int32 file_system_rename_dir_limit = 61;
+  bool file_system_strong_consistency_on_open = 62;
+  bool is_file_system_temp_dir_set = 63;
+  int32 file_system_uid = 64;
+  bool foreground = 65;
+  bool gcs_auth_anonymous_access = 66;
+  bool is_gcs_auth_key_file_set = 67;
+  bool gcs_auth_reuse_token_from_url = 68;
+  bool is_gcs_auth_token_url_set = 69;
+  bool is_gcs_connection_billing_project_set = 70;
+  string gcs_connection_client_protocol = 71;
+  bool is_gcs_connection_custom_endpoint_set = 72;
+  bool gcs_connection_enable_http_dns_cache = 73;
+  bool gcs_connection_experimental_enable_json_read = 74;
+  bool is_gcs_connection_experimental_local_socket_address_set = 75;
+  int32 gcs_connection_grpc_conn_pool_size = 76;
+  string gcs_connection_grpc_path_strategy = 77;
+  int64 gcs_connection_http_client_timeout = 78;
+  double gcs_connection_limit_bytes_per_sec = 79;
+  double gcs_connection_limit_ops_per_sec = 80;
+  int32 gcs_connection_max_conns_per_host = 81;
+  int32 gcs_connection_max_idle_conns_per_host = 82;
+  int32 gcs_connection_sequential_read_size_mb = 83;
+  int32 gcs_retries_chunk_retry_deadline_secs = 84;
+  int32 gcs_retries_chunk_transfer_timeout_secs = 85;
+  bool gcs_retries_enable_mount_retries = 86;
+  int32 gcs_retries_max_retry_attempts = 87;
+  int64 gcs_retries_max_retry_sleep = 88;
+  double gcs_retries_multiplier = 89;
+  bool gcs_retries_read_stall_enable = 90;
+  int64 gcs_retries_read_stall_initial_req_timeout = 91;
+  int64 gcs_retries_read_stall_max_req_timeout = 92;
+  int64 gcs_retries_read_stall_min_req_timeout = 93;
+  double gcs_retries_read_stall_req_increase_rate = 94;
+  double gcs_retries_read_stall_req_target_percentile = 95;
+  bool implicit_dirs = 96;
+  bool list_enable_empty_managed_folders = 97;
+  bool logging_experimental_enable_otel_logging = 98;
+  bool is_logging_experimental_otel_logging_endpoint_set = 99;
+  bool is_logging_experimental_otel_logging_project_id_set = 100;
+  bool is_logging_file_path_set = 101;
+  bool is_logging_format_set = 102;
+  int32 logging_log_rotate_backup_file_count = 103;
+  bool logging_log_rotate_compress = 104;
+  int32 logging_log_rotate_max_file_size_mb = 105;
+  string logging_severity = 106;
+  bool is_logging_wire_log_set = 107;
+  bool is_machine_type_set = 108;
+  int32 metadata_cache_deprecated_stat_cache_capacity = 109;
+  int64 metadata_cache_deprecated_stat_cache_ttl = 110;
+  int64 metadata_cache_deprecated_type_cache_ttl = 111;
+  bool metadata_cache_enable_metadata_prefetch = 112;
+  bool metadata_cache_enable_nonexistent_type_cache = 113;
+  bool metadata_cache_experimental_enable_optimized_metadata_cache = 114;
+  bool is_metadata_cache_experimental_metadata_prefetch_on_mount_set = 115;
+  int32 metadata_cache_metadata_prefetch_entries_limit = 116;
+  int32 metadata_cache_metadata_prefetch_max_workers = 117;
+  int32 metadata_cache_negative_ttl_secs = 118;
+  int32 metadata_cache_stat_cache_max_size_mb = 119;
+  int32 metadata_cache_ttl_secs = 120;
+  int32 metadata_cache_type_cache_max_size_mb = 121;
+  int32 metrics_buffer_size = 122;
+  int32 metrics_cloud_metrics_export_interval_secs = 123;
+  bool metrics_experimental_enable_grpc_metrics = 124;
+  bool metrics_experimental_enable_otel_metrics = 125;
+  bool is_metrics_experimental_otel_metrics_endpoint_set = 126;
+  bool is_metrics_experimental_otel_metrics_project_id_set = 127;
+  int32 metrics_prometheus_port = 128;
+  int64 metrics_stackdriver_export_interval = 129;
+  bool metrics_use_new_names = 130;
+  int32 metrics_workers = 131;
+  bool is_mount_id_set = 132;
+  int32 mrd_pool_size = 133;
+  bool is_only_dir_set = 134;
+  bool is_profile_set = 135;
+  int32 read_block_size_mb = 136;
+  bool read_enable_buffered_read = 137;
+  bool read_enable_grpc_read_checksums = 138;
+  int32 read_global_max_blocks = 139;
+  int64 read_inactive_stream_timeout = 140;
+  int32 read_max_blocks_per_handle = 141;
+  int32 read_min_blocks_per_handle = 142;
+  int32 read_random_seek_threshold = 143;
+  int32 read_start_blocks_per_handle = 144;
+  bool is_trace_exporters_set = 145;
+  bool is_trace_project_id_set = 146;
+  double trace_sampling_ratio = 147;
+  int32 workload_insight_forward_merge_threshold_mb = 148;
+  bool is_workload_insight_output_file_set = 149;
+  bool workload_insight_visualize = 150;
+  double write_block_size_mb = 151;
+  bool write_create_empty_file = 152;
+  bool write_enable_rapid_appends = 153;
+  bool write_enable_rapid_writes = 154;
+  bool write_enable_streaming_writes = 155;
+  bool write_finalize_file_for_rapid = 156;
+  int32 write_global_max_blocks = 157;
+  int32 write_max_blocks_per_file = 158;
+}

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,8 @@ type OptimizationRulesMap = map[string]shared.OptimizationRules
 type templateData struct {
 	TypeTemplateData      []typeTemplateData
 	FlagTemplateData      []flagTemplateData
+	ProtoFields           []protoFieldTemplateData
+	ReservedTags          string
 	MachineTypeToGroupMap map[string]string
 	MachineTypeGroups     map[string][]string
 	// Back-ticks are not supported in templates. So, passing as a parameter.
@@ -126,6 +128,8 @@ func main() {
 		panic(err)
 	}
 
+	protoFields := computeProtoFields(paramsYAML.Params)
+
 	// Sort to have reliable ordering.
 	slices.SortFunc(td, func(i, j typeTemplateData) int {
 		return cmp.Compare(i.TypeName, j.TypeName)
@@ -137,12 +141,20 @@ func main() {
 	// Create a map from given machine type to all the machine type groups that it belongs to.
 	machineTypeToGroupMap := invertMachineTypeGroups(paramsYAML.MachineTypeGroups)
 
-	for _, rootFileName := range []string{"config", "config_test"} {
-		generatedFilePath := path.Join(*outDir, rootFileName+".go")
-		templateFilePath := path.Join(*templateDir, rootFileName+".tpl")
+	outputFiles := []struct{ template, output string }{
+		{"config", "config.go"},
+		{"config_test", "config_test.go"},
+		{"config_proto", "config.proto"},
+	}
+
+	for _, file := range outputFiles {
+		generatedFilePath := path.Join(*outDir, file.output)
+		templateFilePath := path.Join(*templateDir, file.template+".tpl")
 		err = write(templateData{
 			FlagTemplateData:      fd,
 			TypeTemplateData:      td,
+			ProtoFields:           protoFields,
+			ReservedTags:          formatReservedTags(paramsYAML.RetiredParams),
 			MachineTypeToGroupMap: machineTypeToGroupMap,
 			MachineTypeGroups:     paramsYAML.MachineTypeGroups,
 			Backticks:             "`",
@@ -164,7 +176,7 @@ func formatValue(v any) string {
 		s := v.(string)
 		// Check if it looks like a function call - if so, output as-is without quotes
 		// To make it more robust, check that it starts with an uppercase letter as well.
-		// As the function shoud be exported only.
+		// As the function should be exported only.
 		if len(s) > 2 && s[len(s)-2:] == "()" && unicode.IsUpper(rune(s[0])) {
 			return s
 		}

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -48,6 +48,8 @@ type Param struct {
 	HideShorthand      bool                      `yaml:"hide-shorthand"`
 	Optimizations      *shared.OptimizationRules `yaml:"optimizations,omitempty"`
 	ProtoTag           int                       `yaml:"proto-tag"`
+	ProtoType          string                    `yaml:"-"`
+	ProtoFieldName     string                    `yaml:"-"`
 }
 
 // ParamsYAML mirrors the params.yaml file itself.
@@ -72,6 +74,9 @@ func parseParamsYAMLStr(paramsYAMLStr string) (paramsYAML ParamsYAML, err error)
 	if err = validateProtoTags(paramsYAML.Params, paramsYAML.RetiredParams); err != nil {
 		return ParamsYAML{}, err
 	}
+	if err = populateProtoMetadata(paramsYAML.Params); err != nil {
+		return ParamsYAML{}, err
+	}
 	return paramsYAML, nil
 }
 
@@ -82,6 +87,52 @@ var supportedDataTypes = []string{
 
 func isValidDataType(dt string) bool {
 	return slices.Contains(supportedDataTypes, dt)
+}
+
+var highRiskTextTypes = map[string]bool{
+	"string":       true,
+	"resolvedPath": true,
+	"[]string":     true,
+}
+
+func computeProtoMetadata(configPath string, paramType string) (protoType, protoFieldName string, err error) {
+	name := strings.ReplaceAll(strings.ReplaceAll(configPath, ".", "_"), "-", "_")
+	if highRiskTextTypes[paramType] {
+		return "bool", fmt.Sprintf("is_%s_set", name), nil
+	}
+	switch paramType {
+	case "bool":
+		return "bool", name, nil
+	case "int", "octal":
+		return "int32", name, nil
+	case "duration":
+		return "int64", name, nil // Mapped as nanoseconds
+	case "float64":
+		return "double", name, nil
+	case "protocol", "directPathStrategy", "logSeverity":
+		return "string", name, nil
+	case "[]int":
+		return "repeated int32", name, nil
+	default:
+		return "", "", fmt.Errorf("unknown configuration type [%s] declared for config-path [%s]", paramType, configPath)
+	}
+}
+
+// populateProtoMetadata maps YAML types to Flat Protobuf types, converting high-risk text strings to booleans for telemetry privacy.
+func populateProtoMetadata(params []Param) error {
+	for i := range params {
+		param := &params[i]
+		if param.ConfigPath == "" {
+			continue
+		}
+		pt, pn, err := computeProtoMetadata(param.ConfigPath, param.Type)
+		if err != nil {
+			return err
+		}
+		param.ProtoType = pt
+		param.ProtoFieldName = pn
+	}
+	return nil
 }
 
 func validateProtoTags(params []Param, retiredTags []int) error {
@@ -182,7 +233,14 @@ func validateParam(param Param) error {
 	}
 
 	// Validate the data type.
-	if !isValidDataType(param.Type) {
+	idx := slices.IndexFunc(
+		[]string{"int", "float64", "bool", "string", "duration", "octal", "[]int",
+			"[]string", "logSeverity", "protocol", "resolvedPath", "directPathStrategy"},
+		func(dt string) bool {
+			return dt == param.Type
+		},
+	)
+	if idx == -1 {
 		return fmt.Errorf("unsupported datatype: %s", param.Type)
 	}
 

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -326,10 +326,14 @@ params:
 		assert.Equal(t, expected, param.Optimizations)
 	})
 
-	t.Run("TestParamWithNoOptimizations", func(t *testing.T) {
+	t.Run("TestParamWithNoOptimizationsAndProtoMetadata", func(t *testing.T) {
 		param := parsedYAML.Params[0]
 		assert.Equal(t, "app-name", param.ConfigPath)
 		assert.Nil(t, param.Optimizations)
+		// Check proto metadata for a string field (privacy booleanization)
+		assert.Equal(t, "bool", param.ProtoType)
+		assert.Equal(t, "is_app_name_set", param.ProtoFieldName)
+		assert.Equal(t, 1, param.ProtoTag)
 	})
 
 	t.Run("testParamProtoTag", func(t *testing.T) {
@@ -603,18 +607,121 @@ params:
 `,
 			expectedErrorSubstring: "bucket-type list is empty",
 		},
+		{
+			name: "UnknownConfigurationType",
+			yamlContent: `
+params:
+  - config-path: "test-param"
+    proto-tag: 1
+    flag-name: "test-flag"
+    type: "unknownTypeForGoAndProto"
+    default: 500
+    usage: "Test flag for unknown type validation"
+`,
+			expectedErrorSubstring: "unsupported datatype: unknownTypeForGoAndProto",
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// ARRANGE
-
-			// ACT
 			_, err := parseParamsYAMLStr(tc.yamlContent)
-
-			// ASSERT
 			require.Error(t, err)
 			require.True(t, strings.Contains(err.Error(), tc.expectedErrorSubstring), "Expected error to contain %q, but got: %q", tc.expectedErrorSubstring, err.Error())
 		})
 	}
+}
+
+func TestPopulateProtoMetadataExhaustive(t *testing.T) {
+	yamlContent := `
+retired-params: [13, 14]
+params:
+  - config-path: "type-bool"
+    proto-tag: 1
+    flag-name: "type-bool"
+    type: "bool"
+    usage: "test"
+  - config-path: "type-direct-path-strategy"
+    proto-tag: 2
+    flag-name: "type-direct-path-strategy"
+    type: "directPathStrategy"
+    usage: "test"
+  - config-path: "type-duration"
+    proto-tag: 3
+    flag-name: "type-duration"
+    type: "duration"
+    usage: "test"
+  - config-path: "type-float"
+    proto-tag: 4
+    flag-name: "type-float"
+    type: "float64"
+    usage: "test"
+  - config-path: "type-int"
+    proto-tag: 5
+    flag-name: "type-int"
+    type: "int"
+    usage: "test"
+  - config-path: "type-log-severity"
+    proto-tag: 6
+    flag-name: "type-log-severity"
+    type: "logSeverity"
+    usage: "test"
+  - config-path: "type-octal"
+    proto-tag: 7
+    flag-name: "type-octal"
+    type: "octal"
+    usage: "test"
+  - config-path: "type-protocol"
+    proto-tag: 8
+    flag-name: "type-protocol"
+    type: "protocol"
+    usage: "test"
+  - config-path: "type-resolved-path"
+    proto-tag: 9
+    flag-name: "type-resolved-path"
+    type: "resolvedPath"
+    usage: "test"
+  - config-path: "type-slice-int"
+    proto-tag: 10
+    flag-name: "type-slice-int"
+    type: "[]int"
+    usage: "test"
+  - config-path: "type-slice-string"
+    proto-tag: 11
+    flag-name: "type-slice-string"
+    type: "[]string"
+    usage: "test"
+  - config-path: "type-string"
+    proto-tag: 12
+    flag-name: "type-string"
+    type: "string"
+    usage: "test"
+`
+	parsedYAML, err := parseParamsYAMLStr(yamlContent)
+	require.NoError(t, err)
+
+	expected := []struct {
+		protoType      string
+		protoFieldName string
+	}{
+		{"bool", "type_bool"},
+		{"string", "type_direct_path_strategy"},
+		{"int64", "type_duration"},
+		{"double", "type_float"},
+		{"int32", "type_int"},
+		{"string", "type_log_severity"},
+		{"int32", "type_octal"},
+		{"string", "type_protocol"},
+		{"bool", "is_type_resolved_path_set"},
+		{"repeated int32", "type_slice_int"},
+		{"bool", "is_type_slice_string_set"},
+		{"bool", "is_type_string_set"},
+	}
+
+	require.Len(t, parsedYAML.Params, len(expected))
+	for i, param := range parsedYAML.Params {
+		assert.Equal(t, expected[i].protoType, param.ProtoType, "Failed protoType for %s", param.FlagName)
+		assert.Equal(t, expected[i].protoFieldName, param.ProtoFieldName, "Failed protoFieldName for %s", param.FlagName)
+	}
+
+	assert.Equal(t, []int{13, 14}, parsedYAML.RetiredParams)
 }

--- a/tools/config-gen/templates/config_proto.tpl
+++ b/tools/config-gen/templates/config_proto.tpl
@@ -1,0 +1,30 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// GENERATED CODE - DO NOT EDIT MANUALLY.
+
+syntax = "proto3";
+
+package gcsfuse.cfg.v1;
+
+option go_package = "github.com/googlecloudplatform/gcsfuse/v3/cfg/pb";
+
+message Config {
+{{- if .ReservedTags}}
+  reserved {{.ReservedTags}};
+{{- end}}
+{{- range .ProtoFields}}
+  {{.ProtoType}} {{.ProtoFieldName}} = {{.ProtoTag}};
+{{- end}}
+}

--- a/tools/config-gen/type_template_data_gen.go
+++ b/tools/config-gen/type_template_data_gen.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"golang.org/x/text/cases"
@@ -43,6 +44,43 @@ type typeTemplateData struct {
 	TypeName string
 	// Fields that are to be included in the type.
 	Fields []fieldInfo
+}
+
+type protoFieldTemplateData struct {
+	ProtoType      string
+	ProtoFieldName string
+	ProtoTag       int
+}
+
+func computeProtoFields(params []Param) []protoFieldTemplateData {
+	var fields []protoFieldTemplateData
+	for _, p := range params {
+		if p.ConfigPath == "" || p.ProtoFieldName == "" || p.ProtoType == "" {
+			continue
+		}
+		fields = append(fields, protoFieldTemplateData{
+			ProtoType:      p.ProtoType,
+			ProtoFieldName: p.ProtoFieldName,
+			ProtoTag:       p.ProtoTag,
+		})
+	}
+	slices.SortFunc(fields, func(a, b protoFieldTemplateData) int {
+		return cmp.Compare(a.ProtoTag, b.ProtoTag)
+	})
+	return fields
+}
+
+func formatReservedTags(tags []int) string {
+	if len(tags) == 0 {
+		return ""
+	}
+	sorted := slices.Clone(tags)
+	slices.Sort(sorted)
+	var strTags []string
+	for _, t := range sorted {
+		strTags = append(strTags, strconv.Itoa(t))
+	}
+	return strings.Join(strTags, ", ")
 }
 
 func capitalizeIdentifier(name string) (string, error) {
@@ -84,7 +122,7 @@ func getGoDataType(dt string) string {
 }
 
 // Returns a flat list with one entry for each field that needs to be created and the corresponding type.
-// A config path of x.y.z for a param of type int would return the follow entries
+// A config path of x.y.z for a param of type int would return the following entries
 // 1. {TypeName: Config, FieldName: X, DataType: XConfig, ConfigPath: x}
 // 2. {TypeName: XConfig, FieldName: Y, DataType: YXConfig, ConfigPath: y}
 // 3. {TypeName: YXConfig, FieldName: Z, DataType: int, ConfigPath: z}
@@ -108,7 +146,6 @@ func computeFields(param Param) ([]fieldInfo, error) {
 			if err != nil {
 				return nil, err
 			}
-
 			dt = tn + typeName
 		}
 		fieldInfos = append(fieldInfos, fieldInfo{
@@ -150,11 +187,13 @@ func constructTypeTemplateData(paramsConfig []Param) ([]typeTemplateData, error)
 			return cmp.Compare(i.FieldName, j.FieldName)
 		})
 
+		// Remove duplicates.
+		compacted := slices.Compact(v)
+
 		ttd = append(ttd, typeTemplateData{
 			TypeName: k,
-			Fields:   slices.Compact(v),
-		},
-		)
+			Fields:   compacted,
+		})
 	}
 	// Sort type names for reliable ordering.
 	slices.SortFunc(ttd, func(i, j typeTemplateData) int {

--- a/tools/config-gen/type_template_data_gen_test.go
+++ b/tools/config-gen/type_template_data_gen_test.go
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestComputeProtoFields(t *testing.T) {
+	params := []Param{
+		{
+			FlagName:       "file-cache-max-size-mb",
+			ConfigPath:     "file-cache.max-size-mb",
+			ProtoType:      "int32",
+			ProtoFieldName: "file_cache_max_size_mb",
+			ProtoTag:       3,
+		},
+		{
+			FlagName:       "app-name",
+			ConfigPath:     "app-name",
+			ProtoType:      "bool",
+			ProtoFieldName: "is_app_name_set",
+			ProtoTag:       1,
+		},
+		{
+			FlagName:       "cache-dir",
+			ConfigPath:     "cache-dir",
+			ProtoType:      "bool",
+			ProtoFieldName: "is_cache_dir_set",
+			ProtoTag:       2,
+		},
+		{
+			FlagName:       "deprecated-cli-flag",
+			ConfigPath:     "",
+			ProtoType:      "bool",
+			ProtoFieldName: "is_deprecated_cli_flag_set",
+			ProtoTag:       0,
+		},
+	}
+
+	protoFields := computeProtoFields(params)
+
+	require.Len(t, protoFields, 3)
+	assert.Equal(t, "is_app_name_set", protoFields[0].ProtoFieldName)
+	assert.Equal(t, 1, protoFields[0].ProtoTag)
+	assert.Equal(t, "bool", protoFields[0].ProtoType)
+
+	assert.Equal(t, "is_cache_dir_set", protoFields[1].ProtoFieldName)
+	assert.Equal(t, 2, protoFields[1].ProtoTag)
+	assert.Equal(t, "bool", protoFields[1].ProtoType)
+
+	assert.Equal(t, "file_cache_max_size_mb", protoFields[2].ProtoFieldName)
+	assert.Equal(t, 3, protoFields[2].ProtoTag)
+	assert.Equal(t, "int32", protoFields[2].ProtoType)
+}
+
+func TestFormatReservedTags(t *testing.T) {
+	assert.Equal(t, "", formatReservedTags(nil))
+	assert.Equal(t, "", formatReservedTags([]int{}))
+	assert.Equal(t, "4", formatReservedTags([]int{4}))
+	assert.Equal(t, "4, 10, 28", formatReservedTags([]int{28, 4, 10}))
+}
+
+func TestConstructTypeTemplateData(t *testing.T) {
+	params := []Param{
+		{
+			FlagName:   "app-name",
+			ConfigPath: "app-name",
+			Type:       "string",
+		},
+		{
+			FlagName:   "file-cache-max-size-mb",
+			ConfigPath: "file-cache.max-size-mb",
+			Type:       "int",
+		},
+		{
+			FlagName:   "logging-severity",
+			ConfigPath: "logging.severity",
+			Type:       "logSeverity",
+		},
+	}
+
+	ttd, err := constructTypeTemplateData(params)
+	require.NoError(t, err)
+
+	var configMsg, fileCacheMsg, loggingMsg typeTemplateData
+	for _, msg := range ttd {
+		switch msg.TypeName {
+		case "Config":
+			configMsg = msg
+		case "FileCacheConfig":
+			fileCacheMsg = msg
+		case "LoggingConfig":
+			loggingMsg = msg
+		}
+	}
+
+	assert.Equal(t, "Config", configMsg.TypeName)
+	require.Len(t, configMsg.Fields, 3)
+	assert.Equal(t, "AppName", configMsg.Fields[0].FieldName)
+	assert.Equal(t, "FileCache", configMsg.Fields[1].FieldName)
+	assert.Equal(t, "Logging", configMsg.Fields[2].FieldName)
+
+	assert.Equal(t, "FileCacheConfig", fileCacheMsg.TypeName)
+	require.Len(t, fileCacheMsg.Fields, 1)
+	assert.Equal(t, "MaxSizeMb", fileCacheMsg.Fields[0].FieldName)
+
+	assert.Equal(t, "LoggingConfig", loggingMsg.TypeName)
+	require.Len(t, loggingMsg.Fields, 1)
+	assert.Equal(t, "Severity", loggingMsg.Fields[0].FieldName)
+}


### PR DESCRIPTION
### Description
- Update config-gen to generate flat Protobuf message Config from params.yaml.
- Implement privacy scrubber in parser.go converting high-risk text fields to boolean flags.
- Merge active and retired parameters in computeProtoFields sorted strictly by proto-tag.
- Render cfg/config.proto statelessly from config_proto.tpl.
- Add unit tests for proto metadata mapping and template generation.

### Link to the issue in case of a bug fix.

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
