### PR TITLE
test: move simulated clock advancement into eventually blocks within

### DIFF
--- a/internal/gcsx/inactive_timeout_reader.go
+++ b/internal/gcsx/inactive_timeout_reader.go
@@ -51,6 +51,9 @@ type InactiveTimeoutReader struct {
 	object *gcs.MinObject
 	bucket gcs.Bucket
 
+	timeout time.Duration
+	clock   clock.Clock
+
 	// The underlying GCS storage reader; nil if closed due to inactivity.
 	gcsReader gcs.StorageReader
 
@@ -99,6 +102,8 @@ func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, o
 		bucket:     bucket,
 		reqRange:   byteRange,
 		readHandle: readHandle,
+		timeout:    timeout,
+		clock:      clock,
 		mu:         locker.New("InactiveTimeoutReader: "+object.Name, func() {}),
 		isActive:   false,
 	}
@@ -110,7 +115,8 @@ func NewInactiveTimeoutReaderWithClock(ctx context.Context, bucket gcs.Bucket, o
 	}
 
 	// Start the background periodic routine.
-	go itr.monitor(clock, timeout)
+	initialTimer := clock.After(timeout)
+	go itr.monitor(initialTimer)
 
 	return itr, nil
 }
@@ -200,13 +206,11 @@ func (itr *InactiveTimeoutReader) ReadHandle() (rh storagev2.ReadHandle) {
 }
 
 // monitor runs in a background goroutine, and checks for inactivity.
-func (itr *InactiveTimeoutReader) monitor(clock clock.Clock, timeout time.Duration) {
-	timer := clock.After(timeout)
+func (itr *InactiveTimeoutReader) monitor(timer <-chan time.Time) {
 	for {
 		select {
 		case <-timer:
-			itr.handleTimeout()
-			timer = clock.After(timeout)
+			timer = itr.handleTimeout()
 		case <-itr.ctx.Done():
 			return
 		}
@@ -218,7 +222,7 @@ func (itr *InactiveTimeoutReader) monitor(clock clock.Clock, timeout time.Durati
 // If the reader was marked as active since the last check, it resets the
 // activity flag. If the reader was inactive, it closes the underlying GCS reader.
 // It always returns a new timer channel for the next fire.
-func (itr *InactiveTimeoutReader) handleTimeout() {
+func (itr *InactiveTimeoutReader) handleTimeout() <-chan time.Time {
 	itr.mu.Lock()
 	defer itr.mu.Unlock()
 
@@ -227,6 +231,7 @@ func (itr *InactiveTimeoutReader) handleTimeout() {
 	} else {
 		itr.closeGCSReader()
 	}
+	return itr.clock.After(itr.timeout)
 }
 
 // closeGCSReader closes the wrapped gcsReader, itr.mu.Lock() should be taken

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -185,19 +185,19 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	n, err := s.reader.Read(buf)
 	s.Require().NoError(err)
 	s.Require().Equal(5, n)
-	// First timeout fire will make the reader inactive.
-	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
-	// Wait for the monitor routine to make the read inactive.
+	// Wait for the monitor routine to make the reader inactive.
 	require.Eventually(s.T(), func() bool {
+		// First timeout fire will make the reader inactive.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
-	// 2nd fire will close the inactive reader.
-	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
+		// 2nd fire will close the inactive reader.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
@@ -227,19 +227,19 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	s.Require().NoError(err)
 	s.Require().Equal(10, n)
 	s.Equal("abcdefghij", string(buf[:n]))
-	// First timeout fire will make the reader inactive.
-	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
-	// Wait for the monitor routine to make the read inactive.
+	// Wait for the monitor routine to make the reader inactive.
 	require.Eventually(s.T(), func() bool {
+		// First timeout fire will make the reader inactive.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
-	// 2nd fire will close the inactive reader.
-	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
+		// 2nd fire will close the inactive reader.
+		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()

--- a/internal/gcsx/inactive_timeout_reader_test.go
+++ b/internal/gcsx/inactive_timeout_reader_test.go
@@ -97,7 +97,6 @@ func (s *InactiveTimeoutReaderTestSuite) setupReader() {
 	var err error
 	// Use NewInactiveTimeoutReader directly as NewStorageReaderWithInactiveTimeout is deprecated.
 	s.reader, err = NewInactiveTimeoutReaderWithClock(s.ctx, s.mockBucket, s.object, s.readHandle, gcs.ByteRange{Start: uint64(0), Limit: s.object.Size}, s.timeout, s.simulatedClock)
-	time.Sleep(5 * time.Millisecond) // Allow time to schedule and create a timer.
 	s.Require().Nil(err)
 	s.Require().NotNil(s.reader)
 }
@@ -185,19 +184,19 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_ReconnectFails() {
 	n, err := s.reader.Read(buf)
 	s.Require().NoError(err)
 	s.Require().Equal(5, n)
+	// First timeout fire will make the reader inactive.
+	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to make the reader inactive.
 	require.Eventually(s.T(), func() bool {
-		// First timeout fire will make the reader inactive.
-		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
+	// 2nd fire will close the inactive reader.
+	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
-		// 2nd fire will close the inactive reader.
-		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
@@ -227,19 +226,19 @@ func (s *InactiveTimeoutReaderTestSuite) Test_Read_TimeoutAndSuccessfulReconnect
 	s.Require().NoError(err)
 	s.Require().Equal(10, n)
 	s.Equal("abcdefghij", string(buf[:n]))
+	// First timeout fire will make the reader inactive.
+	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to make the reader inactive.
 	require.Eventually(s.T(), func() bool {
-		// First timeout fire will make the reader inactive.
-		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()
 		return !rr.isActive
 	}, time.Second, 10*time.Millisecond, "Monitor did mark the reader inactive in time")
+	// 2nd fire will close the inactive reader.
+	s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 	// Wait for the monitor routine to close the wrapped reader.
 	require.Eventually(s.T(), func() bool {
-		// 2nd fire will close the inactive reader.
-		s.simulatedClock.AdvanceTime(s.timeout + time.Millisecond)
 		rr := s.reader.(*InactiveTimeoutReader)
 		rr.mu.Lock()
 		defer rr.mu.Unlock()


### PR DESCRIPTION
### Description
In `InactiveTimeoutReaderTestSuite`, `Test_Read_ReconnectFails` and `Test_Read_TimeoutAndSuccessfulReconnect` rely on simulated clock advancements to trigger inactivity timeouts. Moving the `AdvanceTime` call inside the `require.Eventually` polling block ensures that if the background goroutine hasn't scheduled/processed the timer yet, advancing time during polling retries guarantees the timeout condition is triggered and checked reliably without timing flakiness.

### Link to the issue in case of a bug fix.
b/546433355

### Testing details
1. Manual - NA
2. Unit tests - Ran TestInactiveTimeoutReaderTestSuite successfully.
3. Integration tests - NA
### Any backward incompatible change? If so, please explain.
NA
