### PR TITLE
fix(gcsx): prioritize context cancellation over concurrent operation results in multi-range downloader

### DIFF
--- a/internal/gcsx/mrd_instance.go
+++ b/internal/gcsx/mrd_instance.go
@@ -189,6 +189,9 @@ func (mi *MrdInstance) Read(ctx context.Context, p []byte, offset int64, metrics
 		case <-ctx.Done():
 			return 0, ctx.Err()
 		case res := <-done:
+			if ctx.Err() != nil {
+				return 0, ctx.Err()
+			}
 			if res.err != nil && res.err != io.EOF {
 				return res.bytesRead, fmt.Errorf("Error in Add call: %w", res.err)
 			}

--- a/internal/gcsx/multi_range_downloader_wrapper.go
+++ b/internal/gcsx/multi_range_downloader_wrapper.go
@@ -314,8 +314,12 @@ func (mrdWrapper *MultiRangeDownloaderWrapper) Read(ctx context.Context, buf []b
 		case <-ctx.Done():
 			err = ctx.Err()
 		case res := <-done:
-			bytesRead = res.bytesRead
-			err = res.err
+			if ctx.Err() != nil {
+				err = ctx.Err()
+			} else {
+				bytesRead = res.bytesRead
+				err = res.err
+			}
 		}
 	} else {
 		res := <-done

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -231,7 +231,7 @@ func (t *mrdWrapperTest) TestReadContextCancelledWithInterruptsDisabled() {
 			bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics(), tracing.NewNoopTracer(), false)
 
 			require.NoError(t.T(), err)
-			assert.Equal(t.T(), 100, bytesRead)
+			assert.Equal(t.T(), int(t.object.Size), bytesRead)
 		})
 	}
 }

--- a/internal/gcsx/multi_range_downloader_wrapper_test.go
+++ b/internal/gcsx/multi_range_downloader_wrapper_test.go
@@ -174,29 +174,66 @@ func (t *mrdWrapperTest) Test_Read_ShortRead() {
 }
 
 func (t *mrdWrapperTest) TestReadContextCancelledWithInterruptsEnabled() {
-	t.mrdWrapper.Wrapped = nil
-	t.mrdWrapper.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond), nil).Once()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	testCases := []struct {
+		name      string
+		sleepTime time.Duration
+	}{
+		{
+			name:      "ZeroSleep",
+			sleepTime: 0,
+		},
+		{
+			name:      "NonZeroSleep",
+			sleepTime: 10 * time.Millisecond,
+		},
+	}
 
-	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics(), tracing.NewNoopTracer(), false)
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.mrdWrapper.Wrapped = nil
+			t.mrdWrapper.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: false}}
+			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, tc.sleepTime), nil).Once()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-	require.Error(t.T(), err)
-	assert.ErrorContains(t.T(), err, "context canceled")
-	assert.Equal(t.T(), 0, bytesRead)
+			bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics(), tracing.NewNoopTracer(), false)
+
+			require.Error(t.T(), err)
+			assert.ErrorContains(t.T(), err, "context canceled")
+			assert.Equal(t.T(), 0, bytesRead)
+		})
+	}
 }
 
 func (t *mrdWrapperTest) TestReadContextCancelledWithInterruptsDisabled() {
-	t.mrdWrapper.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: true}}
-	t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, time.Microsecond), nil).Once()
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
+	testCases := []struct {
+		name      string
+		sleepTime time.Duration
+	}{
+		{
+			name:      "ZeroSleep",
+			sleepTime: 0,
+		},
+		{
+			name:      "NonZeroSleep",
+			sleepTime: 10 * time.Millisecond,
+		},
+	}
 
-	bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics(), tracing.NewNoopTracer(), false)
+	for _, tc := range testCases {
+		t.Run(tc.name, func() {
+			t.mrdWrapper.Wrapped = nil
+			t.mrdWrapper.config = &cfg.Config{FileSystem: cfg.FileSystemConfig{IgnoreInterrupts: true}}
+			t.mockBucket.On("NewMultiRangeDownloader", mock.Anything, mock.Anything).Return(fake.NewFakeMultiRangeDownloaderWithSleep(t.object, t.objectData, tc.sleepTime), nil).Once()
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
 
-	require.NoError(t.T(), err)
-	assert.Equal(t.T(), 100, bytesRead)
+			bytesRead, err := t.mrdWrapper.Read(ctx, make([]byte, t.object.Size), 0, int64(t.object.Size), metrics.NewNoopMetrics(), tracing.NewNoopTracer(), false)
+
+			require.NoError(t.T(), err)
+			assert.Equal(t.T(), 100, bytesRead)
+		})
+	}
 }
 
 func (t *mrdWrapperTest) Test_Read_EOF() {


### PR DESCRIPTION
### Description
When a read context is cancelled, Go's `select` statement between `<-ctx.Done()` and `<-done` chooses pseudo-randomly if both channels are ready simultaneously. In cases where the background download operation completes before or concurrently with cancellation evaluation, receiving from `done` would previously return the read result or EOF instead of respecting context cancellation when interrupts are enabled.

This change checks `ctx.Err()` when handling results from the `done` channel in `MrdInstance.Read` and `MultiRangeDownloaderWrapper.Read` to ensure context cancellation is prioritized when interrupts are enabled. It also updates the unit tests in `multi_range_downloader_wrapper_test.go` to test both zero and non-zero sleep cases.

### Link to the issue in case of a bug fix.
b/546318093

### Testing details
1. Unit tests - `go test -v -count=1 ./internal/gcsx -run TestMRDWrapperTestSuite`

### Any backward incompatible change? If so, please explain.
NA