### PR TITLE
refactor(integration_tests): remove redundant sync and wait for size update during file writes

### DIFF
--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -174,6 +174,7 @@ func CloseFiles(t *testing.T, files []*os.File) {
 		err := file.Close()
 		assert.NoError(t, err)
 	}
+	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseZB)
 }
 
 // Deprecated: please use CloseFileShouldNotThrowError instead.
@@ -248,14 +249,6 @@ func WriteChunkOfRandomBytesToFiles(files []*os.File, chunkSize int, offset int6
 
 		if n != chunkSize {
 			return fmt.Errorf("incorrect number of bytes written in the file %s actual %d, expected %d", file.Name(), n, chunkSize)
-		}
-
-		if !setup.IsZonalBucketRun() {
-			err = file.Sync()
-			if err != nil {
-				return fmt.Errorf("error in syncing file: %v", err)
-			}
-			WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterFlushZB)
 		}
 	}
 

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -233,6 +233,8 @@ func ReadFileSequentially(file *os.File, chunkSize int64) (content []byte, err e
 	return
 }
 
+// WriteChunkOfRandomBytesToFiles writes a chunk of random bytes to multiple files at a given offset.
+// This function does not sync or close the files, the responsibility falls on the caller instead.
 func WriteChunkOfRandomBytesToFiles(files []*os.File, chunkSize int, offset int64) error {
 	// Generate random data of chunk size.
 	chunk, err := GenerateRandomData(int64(chunkSize))

--- a/tools/integration_tests/write_large_files/concurrent_write_to_same_file_test.go
+++ b/tools/integration_tests/write_large_files/concurrent_write_to_same_file_test.go
@@ -69,7 +69,4 @@ func writeToFileSequentially(t *testing.T, filePaths []string, startOffset int, 
 
 		startOffset = startOffset + chunkSize
 	}
-	if setup.IsZonalBucketRun() {
-		operations.SyncFiles(filesToWrite, t)
-	}
 }


### PR DESCRIPTION
### Description
This PR removes redundant intermediate `Sync()` and `WaitForSizeUpdate` calls during file write loops in integration test helpers, and updates `CloseFiles` to use `CloseFileShouldNotThrowError` to ensure file closures uniformly assert and handle size update delays.

**Key Changes:**
* **`tools/integration_tests/util/operations/file_operations.go`**:
  * Updated `CloseFiles` to call `CloseFileShouldNotThrowError(t, file)` for each file.
  * Removed unnecessary `file.Sync()` and `WaitForSizeUpdate` inside the chunk-writing loop in `WriteChunkOfRandomBytesToFiles` since outer caller functions already close all files at the end via `defer CloseFiles(...)`.
* **`tools/integration_tests/write_large_files/concurrent_write_to_same_file_test.go`**:
  * Removed redundant `operations.SyncFiles` call in `writeToFileSequentially` because `defer operations.CloseFiles(t, filesToWrite)` already closes the files.


### Testing details
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Passed Tests [Zonal and Regional](https://fusion2.corp.google.com/ci/kokoro/prod:gcsfuse%2Fgcp_ubuntu%2Fpresubmits%2Fperf_tests%2Fpresubmit/activity/5cc33166-463c-4c0d-a187-88f65878ae2f/log)

### Any backward incompatible change? If so, please explain.
No