### PR TITLE
test(unit): resolve race conditions and timeout flakes in mock unit test suites

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -740,23 +740,22 @@ func (cht *cacheHandleTest) Test_Read_FileInfoRemoved() {
 	dst := make([]byte, ReadContentSize)
 	cht.cacheHandle.isSequential.Store(true)
 	cht.cacheHandle.cacheFileForRangeRead = true
-	// First let the cache populated (we are doing this so that we can externally
-	// modify file info cache for this unit test without hampering download job).
-	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	// First let the cache be fully populated (we are doing this so that we can externally
+	// modify file info cache for this unit test without ongoing background download updates).
+	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(context.Background(), int64(cht.object.Size), true)
 	assert.Nil(cht.T(), err)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	assert.GreaterOrEqual(cht.T(), jobStatus.Offset, int64(ReadContentSize))
+	assert.Equal(cht.T(), int64(cht.object.Size), jobStatus.Offset)
+
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
 	}
 	fileInfoKeyName, err := fileInfoKey.Key()
 	assert.Nil(cht.T(), err)
-	assert.False(cht.T(), cacheHit)
 
 	// Delete the file info entry and again perform read
 	_ = cht.cache.Erase(fileInfoKeyName)
-	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
 	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))
@@ -767,13 +766,12 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	dst := make([]byte, ReadContentSize)
 	cht.cacheHandle.isSequential.Store(true)
 	cht.cacheHandle.cacheFileForRangeRead = true
-	// First let the cache populated (we are doing this so that we can externally
-	// modify file info cache for this unit test without hampering download job).
-	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	// First let the cache be fully populated (we are doing this so that we can externally
+	// modify file info cache for this unit test without ongoing background download updates).
+	jobStatus, err := cht.cacheHandle.fileDownloadJob.Download(context.Background(), int64(cht.object.Size), true)
 	assert.Nil(cht.T(), err)
-	assert.False(cht.T(), cacheHit)
-	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
-	assert.GreaterOrEqual(cht.T(), jobStatus.Offset, int64(ReadContentSize))
+	assert.Equal(cht.T(), int64(cht.object.Size), jobStatus.Offset)
+
 	fileInfoKey := data.FileInfoKey{
 		BucketName: cht.bucket.Name(),
 		ObjectName: cht.object.Name,
@@ -787,7 +785,7 @@ func (cht *cacheHandleTest) Test_Read_FileInfoGenerationChanged() {
 	fileInfoData.ObjectGeneration = 1
 	err = cht.cache.UpdateWithoutChangingOrder(fileInfoKeyName, fileInfoData)
 	assert.Nil(cht.T(), err)
-	_, cacheHit, err = cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
+	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, 0, dst)
 
 	assert.NotNil(cht.T(), err)
 	assert.True(cht.T(), errors.Is(err, util.ErrInvalidFileInfoCache))

--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -128,9 +128,9 @@ func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_New
 		return req.Range.Start == rangeR3.Start && req.Range.Limit == rangeR3.Limit
 	})).Run(incrementCounters).Return(readerR3, nil).Once()
 
-	// Chunk 4 (R4): ReadHandle should not be nil
+	// Chunk 4 (R4): ReadHandle can be nil or propagated depending on which worker picks it up. Match primarily on range.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
-		return req.Range.Start == rangeR4.Start && req.Range.Limit == rangeR4.Limit && req.ReadHandle != nil
+		return req.Range.Start == rangeR4.Start && req.Range.Limit == rangeR4.Limit
 	})).Run(incrementCounters).Return(readerR4, nil).Once()
 
 	// Start download

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -42,55 +42,70 @@ type stallingStorageControlClient struct {
 }
 
 func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
-	if s.stallDurationForGetStorageLayout != nil {
+	if s.stallDurationForGetStorageLayout != nil && *s.stallDurationForGetStorageLayout > 0 {
 		select {
 		case <-time.After(*s.stallDurationForGetStorageLayout):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.GetStorageLayout(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) DeleteFolder(ctx context.Context, req *controlpb.DeleteFolderRequest, opts ...gax.CallOption) error {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 	}
 	return s.wrapped.DeleteFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.GetFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.RenameFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.CreateFolder(ctx, req, opts...)


### PR DESCRIPTION
### Description
This PR resolves flaky test race conditions across multiple unit test suites:

1. **`internal/storage` (`control_client_wrapper_test.go`)**:
   - Fixed timeout race condition in `stallingStorageControlClient` mock methods (`GetStorageLayout`, `DeleteFolder`, `GetFolder`, `RenameFolder`, `CreateFolder`) by ensuring that when a stall completes, context cancellation/deadline expiration is checked before delegating calls to the wrapped client.

2. **`internal/cache/file/downloader` (`parallel_downloads_job_testify_test.go`)**:
   - Fixed mock expectation race condition in `Test_ParallelDownloadObjectToFile_NewReaderWithReadHandle`. When worker goroutines process queued chunks concurrently, Chunk 4 can be picked up as a worker's initial chunk with `ReadHandle == nil`. The mock expectation was updated to match on byte range (matching Chunks 2 & 3), while handle reuse is validated via `nilHandleCallCount`.

3. **`internal/cache/file` (`cache_handle_test.go`)**:
   - Fixed race conditions in `Test_Read_FileInfoGenerationChanged` and `Test_Read_FileInfoRemoved` where ongoing background asynchronous download workers overwrote `fileInfoCache` after the test had modified it. The tests now explicitly ensure full object download completion before mutating `fileInfoCache`.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Ran `make build` and repeated deflake test passes.
2. Unit tests - 
   - `go test -v -race -count=50 ./internal/storage`
   - `go test -v -race -count=50 ./internal/cache/file/downloader`
   - `go test -v -count=50 ./internal/cache/file`
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A