### PR TITLE
test(storage): resolve timeout race condition in stalling client mock tests

### DIFF
--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -41,72 +41,52 @@ type stallingStorageControlClient struct {
 	stallDurationForFolderAPIs       *time.Duration
 }
 
+func (s *stallingStorageControlClient) stall(ctx context.Context, d *time.Duration) error {
+	if d == nil || *d <= 0 {
+		return nil
+	}
+	select {
+	case <-time.After(*d):
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
-	if s.stallDurationForGetStorageLayout != nil && *s.stallDurationForGetStorageLayout > 0 {
-		select {
-		case <-time.After(*s.stallDurationForGetStorageLayout):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+	if err := s.stall(ctx, s.stallDurationForGetStorageLayout); err != nil {
+		return nil, err
 	}
 	return s.wrapped.GetStorageLayout(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) DeleteFolder(ctx context.Context, req *controlpb.DeleteFolderRequest, opts ...gax.CallOption) error {
-	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return err
 	}
 	return s.wrapped.DeleteFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.GetFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
-	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.RenameFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
-		if err := ctx.Err(); err != nil {
-			return nil, err
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.CreateFolder(ctx, req, opts...)
 }

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -42,55 +42,70 @@ type stallingStorageControlClient struct {
 }
 
 func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
-	if s.stallDurationForGetStorageLayout != nil {
+	if s.stallDurationForGetStorageLayout != nil && *s.stallDurationForGetStorageLayout > 0 {
 		select {
 		case <-time.After(*s.stallDurationForGetStorageLayout):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.GetStorageLayout(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) DeleteFolder(ctx context.Context, req *controlpb.DeleteFolderRequest, opts ...gax.CallOption) error {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return err
 		}
 	}
 	return s.wrapped.DeleteFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.GetFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.RenameFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
+	if s.stallDurationForFolderAPIs != nil && *s.stallDurationForFolderAPIs > 0 {
 		select {
 		case <-time.After(*s.stallDurationForFolderAPIs):
 		case <-ctx.Done():
 			return nil, ctx.Err()
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
 	}
 	return s.wrapped.CreateFolder(ctx, req, opts...)


### PR DESCRIPTION
### Description
Fixes a race condition and non-deterministic behavior in `stallingStorageControlClient` timeout tests in `internal/storage/control_client_wrapper_test.go`.

**Problem & Root Cause:**
In `stallingStorageControlClient`, Go's `select` statement between `<-time.After()` and `<-ctx.Done()` caused flaky failures when both channels were ready simultaneously under heavy load or GC pauses. Because Go's select evaluates ready channels pseudo-randomly, the timer branch was sometimes chosen even though the context deadline had already expired, causing unintended fall-through to real unmocked control client methods. Additionally, zero/nil stall durations created unnecessary timer overhead.

**Solution / Fix Mechanism:**
- Added a guard checking `stallDuration != nil && *stallDuration > 0` before entering stall delay.
- Added explicit post-select context cancellation checks (`if err := ctx.Err(); err != nil { return nil, err }`) so that even if time.After(*d) unblocks at the exact same instant as ctx.Done(), the subsequent ctx.Err() check guarantees that an expired context is prioritized and returned immediately.

### Link to the issue in case of a bug fix.
b/553889914

### Testing details
1. Manual - Verified compilation and linting via `make build`.
2. Unit tests - Executed with race detector: `go test -v -race -run "TestControlClientWrapperTestSuite|TestControlClientGaxRetryWrapperTestSuite" ./internal/storage` (PASS — 0 race warnings, 0 failures).
3. Integration tests - N/A (Unit test mock fix).

### Any backward incompatible change? If so, please explain.
N/A