### PR TITLE
test(cache): fix race condition in parallel download mock expectation

### DIFF
--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -15,13 +15,13 @@
 package downloader
 
 import (
+	"bytes"
+	"context"
 	"io"
 	"os"
 	"strings"
 	"sync"
 	"testing"
-
-	"context"
 
 	"github.com/googlecloudplatform/gcsfuse/v3/cfg"
 	"github.com/googlecloudplatform/gcsfuse/v3/internal/cache/data"
@@ -156,6 +156,78 @@ func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_New
 	assert.Equal(t.T(), nil, err)
 	jobStatus, ok := <-notificationC
 	assert.Equal(t.T(), true, ok)
+	// Check the notification is sent after subscribed offset
+	assert.GreaterOrEqual(t.T(), jobStatus.Offset, subscribedOffset)
+	t.job.mu.Lock()
+	defer t.job.mu.Unlock()
+	// Verify file is downloaded
+	verifyCompleteFile(t.T(), t.fileSpec, objectContent)
+	// Verify fileInfoCache update
+	verifyFileInfoEntry(t.T(), t.mockBucket, t.object, t.cache, uint64(objectSize))
+}
+
+func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_ReadHandleReused() {
+	objectName := "path/in/gcs/foo.txt"
+	objectSize := 9 * util.MiB
+	chunkSize := 3 * util.MiB
+	objectContent := testutil.GenerateRandomBytes(objectSize)
+
+	// Set ParallelDownloadsPerFile = 1 to guarantee sequential chunk execution
+	// by a single worker, allowing deterministic validation of ReadHandle reuse across chunks.
+	t.defaultFileCacheConfig.ParallelDownloadsPerFile = 1
+	t.defaultFileCacheConfig.DownloadChunkSizeMb = 3
+
+	t.initReadCacheTestifyTest(objectName, objectContent, DefaultSequentialReadSizeMb, uint64(2*objectSize), func() {})
+	t.job.cancelCtx, t.job.cancelFunc = context.WithCancel(context.Background())
+	defer t.job.cancelFunc()
+
+	// Add subscriber
+	subscribedOffset := int64(1 * util.MiB)
+	notificationC := t.job.subscribe(subscribedOffset)
+	file, err := util.CreateFile(data.FileSpec{Path: t.job.fileSpec.Path,
+		FilePerm: os.FileMode(0600), DirPerm: os.FileMode(0700)}, os.O_TRUNC|os.O_RDWR)
+	assert.NoError(t.T(), err)
+	defer func() {
+		_ = file.Close()
+	}()
+
+	handle1 := []byte("opaque-handle-1")
+	handle2 := []byte("opaque-handle-2")
+	handle3 := []byte("opaque-handle-3")
+
+	rangeR1 := &gcs.ByteRange{Start: uint64(0 * chunkSize), Limit: uint64(1 * chunkSize)}
+	rangeR2 := &gcs.ByteRange{Start: uint64(1 * chunkSize), Limit: uint64(2 * chunkSize)}
+	rangeR3 := &gcs.ByteRange{Start: uint64(2 * chunkSize), Limit: uint64(3 * chunkSize)}
+
+	readerR1 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[0*chunkSize : 1*chunkSize]))), Handle: handle1}
+	readerR2 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[1*chunkSize : 2*chunkSize]))), Handle: handle2}
+	readerR3 := &fake.FakeReader{ReadCloser: io.NopCloser(strings.NewReader(string(objectContent[2*chunkSize : 3*chunkSize]))), Handle: handle3}
+
+	t.mockBucket.On("Name").Return(storage.TestBucketName)
+
+	// Chunk 1 (R1): Must have ReadHandle: nil and returns handle1
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR1.Start && req.Range.Limit == rangeR1.Limit && req.ReadHandle == nil
+	})).Return(readerR1, nil).Once()
+
+	// Chunk 2 (R2): Must have ReadHandle equal to handle1 returned by Chunk 1
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR2.Start && req.Range.Limit == rangeR2.Limit && bytes.Equal(req.ReadHandle, handle1)
+	})).Return(readerR2, nil).Once()
+
+	// Chunk 3 (R3): Must have ReadHandle equal to handle2 returned by Chunk 2
+	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
+		return req.Range.Start == rangeR3.Start && req.Range.Limit == rangeR3.Limit && bytes.Equal(req.ReadHandle, handle2)
+	})).Return(readerR3, nil).Once()
+
+	// Start download
+	err = t.job.parallelDownloadObjectToFile(file)
+
+	assert.NoError(t.T(), err, "parallelDownloadObjectToFile should not return an error")
+	t.mockBucket.AssertExpectations(t.T())
+
+	jobStatus, ok := <-notificationC
+	assert.True(t.T(), ok)
 	// Check the notification is sent after subscribed offset
 	assert.GreaterOrEqual(t.T(), jobStatus.Offset, subscribedOffset)
 	t.job.mu.Lock()

--- a/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
+++ b/internal/cache/file/downloader/parallel_downloads_job_testify_test.go
@@ -128,9 +128,9 @@ func (t *ParallelDownloaderJobTestifyTest) Test_ParallelDownloadObjectToFile_New
 		return req.Range.Start == rangeR3.Start && req.Range.Limit == rangeR3.Limit
 	})).Run(incrementCounters).Return(readerR3, nil).Once()
 
-	// Chunk 4 (R4): ReadHandle should not be nil
+	// Chunk 4 (R4): ReadHandle can be nil or propagated depending on which worker picks it up. Match primarily on range.
 	t.mockBucket.On("NewReaderWithReadHandle", mock.Anything, mock.MatchedBy(func(req *gcs.ReadObjectRequest) bool {
-		return req.Range.Start == rangeR4.Start && req.Range.Limit == rangeR4.Limit && req.ReadHandle != nil
+		return req.Range.Start == rangeR4.Start && req.Range.Limit == rangeR4.Limit
 	})).Run(incrementCounters).Return(readerR4, nil).Once()
 
 	// Start download


### PR DESCRIPTION
### Description
The mock expectation for chunk 4 explicitly mandated `req.ReadHandle != nil`. Because worker goroutines race concurrently to acquire chunks from the job queue, any worker (including one that has not yet opened a read handle) may pick up chunk 4. Under heavy scheduler contention or race detector instrumentation, this non-deterministic worker execution led to intermittent mock expectation mismatches.

**Solution / Fix Mechanism:**
- Relaxed the chunk 4 mock expectation to accept either nil or non-nil ReadHandle.

### Link to the issue in case of a bug fix.
b/553889964

### Testing details
1. Manual - Verified compilation and formatting via `make build`.
2. Unit tests - Executed with race detector: `go test -v -race ./internal/cache/file/downloader/...` (PASS — 0 race warnings, 0 failures).
3. Integration tests - N/A (Unit test mock fix).

### Any backward incompatible change? If so, please explain.
N/A