### PR TITLE
fix(csi): update gcloud addon flag for managed CSI driver

### DIFF
--- a/tools/scripts/csi/install_managed.sh
+++ b/tools/scripts/csi/install_managed.sh
@@ -74,6 +74,6 @@ echo "Installing GKE managed Cloud Storage FUSE CSI driver..."
 gcloud container clusters update "${CLUSTER_NAME}" \
   --location="${CLUSTER_LOCATION}" \
   --project="${CLUSTER_PROJECT}" \
-  --enable-gcs-fuse-csi-driver
+  --update-addons=GcsFuseCsiDriver=ENABLED
 
 echo "GKE Managed Cloud Storage FUSE CSI driver successfully installed."

--- a/tools/scripts/csi/uninstall_managed.sh
+++ b/tools/scripts/csi/uninstall_managed.sh
@@ -68,6 +68,6 @@ echo "Uninstalling GKE managed Cloud Storage FUSE CSI driver..."
 gcloud container clusters update "${CLUSTER_NAME}" \
   --location="${CLUSTER_LOCATION}" \
   --project="${CLUSTER_PROJECT}" \
-  --no-enable-gcs-fuse-csi-driver
+  --update-addons=GcsFuseCsiDriver=DISABLED
 
 echo "GKE Managed Cloud Storage FUSE CSI driver successfully uninstalled."


### PR DESCRIPTION
### Description
Updates `gcloud container clusters update` flags in the CSI management scripts:
- Replaces `--enable-gcs-fuse-csi-driver` with `--update-addons=GcsFuseCsiDriver=ENABLED` in `tools/scripts/csi/install_managed.sh`.
- Replaces `--no-enable-gcs-fuse-csi-driver` with `--update-addons=GcsFuseCsiDriver=DISABLED` in `tools/scripts/csi/uninstall_managed.sh`.

### Link to the issue in case of a bug fix.
NA

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
No