### PR TITLE
test(perfmetrics): update continuous local tests and add gRPC HNS benchmarks

### DIFF
--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -135,19 +135,7 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
     UPLOAD_FLAGS="--upload_gs"
   fi
 
-  COMMON_MOUNT_FLAGS="--debug_fuse --debug_gcs --log-format \"text\""
-
-  run_load_test_and_fetch_metrics() {
-    local FIO_START=$SECONDS
-    local fio_flags="$1"
-    local bucket_name="$2"
-    local spreadsheet_id="$3"
-    local gcsfuse_flags="$COMMON_MOUNT_FLAGS $fio_flags"
-    
-    echo "Starting FIO Load Test on $bucket_name..."
-    ./run_load_test_and_fetch_metrics.sh "$gcsfuse_flags" "$UPLOAD_FLAGS" "$bucket_name" "$spreadsheet_id"
-    print_duration "FIO Load Test ($bucket_name)" "$FIO_START"
-  }
+  COMMON_MOUNT_FLAGS="--log-severity trace --log-format \"text\""
 
   run_ls_benchmark() {
     local LS_START=$SECONDS
@@ -167,15 +155,11 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   echo "Starting Flat Bucket Tests..."
   FLAT_START=$SECONDS
   
-  LOG_FILE_FIO_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-fio-flat.txt"
   LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat.txt"
-  GCSFUSE_FIO_FLAGS="--implicit-dirs --stackdriver-export-interval=30s --log-file $LOG_FILE_FIO_TESTS"
-  GCSFUSE_LS_FLAGS="--implicit-dirs --log-file $LOG_FILE_LS_TESTS"
-  BUCKET_NAME="periodic-perf-tests"
+  GCSFUSE_LS_FLAGS="--implicit-dirs --client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
   SPREADSHEET_ID='1kvHv1OBCzr9GnFxRu9RTJC7jjQjc9M4rAiDnhyak2Sg'
   LIST_CONFIG_FILE="config.json"
   
-  run_load_test_and_fetch_metrics "$GCSFUSE_FIO_FLAGS" "$BUCKET_NAME" "$SPREADSHEET_ID"
   run_ls_benchmark "$GCSFUSE_LS_FLAGS" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
   
   print_duration "Flat Bucket Benchmarks (Total)" "$FLAT_START"
@@ -184,16 +168,23 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   echo "Starting HNS Bucket Tests..."
   HNS_START=$SECONDS
   
-  LOG_FILE_FIO_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-fio-hns.txt"
-  LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns.txt"
-  GCSFUSE_FIO_FLAGS="--stackdriver-export-interval=30s --log-file $LOG_FILE_FIO_TESTS"
-  GCSFUSE_LS_FLAGS="--log-file $LOG_FILE_LS_TESTS"
-  BUCKET_NAME="periodic-perf-tests-hns"
   SPREADSHEET_ID='1wXRGYyAWvasU8U4KaP7NGPHEvgiOSgMd1sCLxsQUwf0'
   LIST_CONFIG_FILE="config-hns.json"
   
-  run_load_test_and_fetch_metrics "$GCSFUSE_FIO_FLAGS" "$BUCKET_NAME" "$SPREADSHEET_ID"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  # 1. HNS with HTTP/1.1
+  LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns.txt"
+  GCSFUSE_LS_FLAGS_HTTP1="--client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  
+  # 2. HNS with gRPC (default pool size)
+  LOG_FILE_LS_TESTS_GRPC="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns-grpc.txt"
+  GCSFUSE_LS_FLAGS_GRPC="--client-protocol grpc --log-file $LOG_FILE_LS_TESTS_GRPC"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  
+  # 3. HNS with gRPC (conn pool size 4)
+  LOG_FILE_LS_TESTS_GRPC_POOL4="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns-grpc-pool4.txt"
+  GCSFUSE_LS_FLAGS_GRPC_POOL4="--client-protocol grpc --experimental-grpc-conn-pool-size 4 --log-file $LOG_FILE_LS_TESTS_GRPC_POOL4"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC_POOL4" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
   
   print_duration "HNS Bucket Benchmarks (Total)" "$HNS_START"
 
@@ -203,6 +194,7 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   
   cd "./hns_rename_folders_metrics"
   ./run_rename_benchmark.sh $UPLOAD_FLAGS
+  cd "../"
   
   print_duration "Rename Benchmark" "$RENAME_START"
 
@@ -222,7 +214,3 @@ else
   echo "Unknown or unspecified BENCHMARK_TYPE: ${BENCHMARK_TYPE:-}"
   exit 1
 fi
-# TODO: Testing for hns bucket with client protocol set to grpc. To be done when
-#  includeFolderAsPrefixes is supported in grpc.
-# TODO: Testing for hns bucket with client protocol set to grpc with grpc-conn-pool-size
-# set to 4. To be done when includeFolderAsPrefixes is supported in grpc.

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -133,6 +133,7 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
      [ "${KOKORO_JOB_TYPE:-}" == "PRESUBMIT_GITHUB" ] || \
      [ "${KOKORO_JOB_TYPE:-}" == "SUB_JOB" ]; then
     UPLOAD_FLAGS="--upload_gs"
+    gcloud storage cp gs://periodic-perf-tests/creds.json ./gsheet/
   fi
 
   COMMON_MOUNT_FLAGS="--log-severity trace --log-format \"text\""
@@ -143,11 +144,12 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
     local spreadsheet_id="$2"
     local config_file="$3"
     local message="${4:-"Testing CT setup."}"
+    local clear_sheet_flag="${5:-}"
     local gcsfuse_flags="$COMMON_MOUNT_FLAGS $ls_flags"
     
     echo "Starting LS Benchmark ($message) with $config_file..."
     cd "./ls_metrics"
-    ./run_ls_benchmark.sh "$gcsfuse_flags" "$UPLOAD_FLAGS" "$spreadsheet_id" "$config_file" "$message"
+    ./run_ls_benchmark.sh "$gcsfuse_flags" "$UPLOAD_FLAGS" "$spreadsheet_id" "$config_file" "$message" "$clear_sheet_flag"
     cd "../"
     print_duration "LS Benchmark - $message ($config_file)" "$LS_START"
   }
@@ -159,10 +161,10 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   SPREADSHEET_ID='1kvHv1OBCzr9GnFxRu9RTJC7jjQjc9M4rAiDnhyak2Sg'
   LIST_CONFIG_FILE="config.json"
   
-  # 1. Flat with HTTP/1.1
+  # 1. Flat with HTTP/1.1 (clears previous day's results from sheet)
   LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat.txt"
   GCSFUSE_LS_FLAGS_HTTP1="--implicit-dirs --client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "Flat Bucket (HTTP/1.1)"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "Flat Bucket (HTTP/1.1)" "--clear_sheet"
   
   # 2. Flat with gRPC (default pool size)
   LOG_FILE_LS_TESTS_GRPC="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat-grpc.txt"
@@ -183,10 +185,10 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   SPREADSHEET_ID='1wXRGYyAWvasU8U4KaP7NGPHEvgiOSgMd1sCLxsQUwf0'
   LIST_CONFIG_FILE="config-hns.json"
   
-  # 1. HNS with HTTP/1.1
+  # 1. HNS with HTTP/1.1 (clears previous day's results from sheet)
   LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns.txt"
   GCSFUSE_LS_FLAGS_HTTP1="--client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "HNS (HTTP/1.1)"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "HNS (HTTP/1.1)" "--clear_sheet"
   
   # 2. HNS with gRPC (default pool size)
   LOG_FILE_LS_TESTS_GRPC="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns-grpc.txt"

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/build.sh
@@ -142,25 +142,37 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
     local ls_flags="$1"
     local spreadsheet_id="$2"
     local config_file="$3"
+    local message="${4:-"Testing CT setup."}"
     local gcsfuse_flags="$COMMON_MOUNT_FLAGS $ls_flags"
     
-    echo "Starting LS Benchmark with $config_file..."
+    echo "Starting LS Benchmark ($message) with $config_file..."
     cd "./ls_metrics"
-    ./run_ls_benchmark.sh "$gcsfuse_flags" "$UPLOAD_FLAGS" "$spreadsheet_id" "$config_file"
+    ./run_ls_benchmark.sh "$gcsfuse_flags" "$UPLOAD_FLAGS" "$spreadsheet_id" "$config_file" "$message"
     cd "../"
-    print_duration "LS Benchmark ($config_file)" "$LS_START"
+    print_duration "LS Benchmark - $message ($config_file)" "$LS_START"
   }
 
   # --- Flat Bucket Tests ---
   echo "Starting Flat Bucket Tests..."
   FLAT_START=$SECONDS
   
-  LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat.txt"
-  GCSFUSE_LS_FLAGS="--implicit-dirs --client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
   SPREADSHEET_ID='1kvHv1OBCzr9GnFxRu9RTJC7jjQjc9M4rAiDnhyak2Sg'
   LIST_CONFIG_FILE="config.json"
   
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  # 1. Flat with HTTP/1.1
+  LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat.txt"
+  GCSFUSE_LS_FLAGS_HTTP1="--implicit-dirs --client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "Flat Bucket (HTTP/1.1)"
+  
+  # 2. Flat with gRPC (default pool size)
+  LOG_FILE_LS_TESTS_GRPC="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat-grpc.txt"
+  GCSFUSE_LS_FLAGS_GRPC="--implicit-dirs --client-protocol grpc --log-file $LOG_FILE_LS_TESTS_GRPC"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "Flat Bucket (gRPC)"
+  
+  # 3. Flat with gRPC (conn pool size 4)
+  LOG_FILE_LS_TESTS_GRPC_POOL4="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-flat-grpc-pool4.txt"
+  GCSFUSE_LS_FLAGS_GRPC_POOL4="--implicit-dirs --client-protocol grpc --experimental-grpc-conn-pool-size 4 --log-file $LOG_FILE_LS_TESTS_GRPC_POOL4"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC_POOL4" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "Flat Bucket (gRPC Pool 4)"
   
   print_duration "Flat Bucket Benchmarks (Total)" "$FLAT_START"
 
@@ -174,17 +186,17 @@ elif [ "${BENCHMARK_TYPE:-}" == "local_tests" ]; then
   # 1. HNS with HTTP/1.1
   LOG_FILE_LS_TESTS="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns.txt"
   GCSFUSE_LS_FLAGS_HTTP1="--client-protocol http1 --log-file $LOG_FILE_LS_TESTS"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_HTTP1" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "HNS (HTTP/1.1)"
   
   # 2. HNS with gRPC (default pool size)
   LOG_FILE_LS_TESTS_GRPC="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns-grpc.txt"
   GCSFUSE_LS_FLAGS_GRPC="--client-protocol grpc --log-file $LOG_FILE_LS_TESTS_GRPC"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "HNS (gRPC)"
   
   # 3. HNS with gRPC (conn pool size 4)
   LOG_FILE_LS_TESTS_GRPC_POOL4="${KOKORO_ARTIFACTS_DIR}/gcsfuse-logs-ls-hns-grpc-pool4.txt"
   GCSFUSE_LS_FLAGS_GRPC_POOL4="--client-protocol grpc --experimental-grpc-conn-pool-size 4 --log-file $LOG_FILE_LS_TESTS_GRPC_POOL4"
-  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC_POOL4" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE"
+  run_ls_benchmark "$GCSFUSE_LS_FLAGS_GRPC_POOL4" "$SPREADSHEET_ID" "$LIST_CONFIG_FILE" "HNS (gRPC Pool 4)"
   
   print_duration "HNS Bucket Benchmarks (Total)" "$HNS_START"
 

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -18,6 +18,8 @@ action {
     regex: "gcsfuse-logs-ls-hns-grpc.txt"
     regex: "gcsfuse-logs-ls-hns-grpc-pool4.txt"
     regex: "gcsfuse-logs-ls-flat.txt"
+    regex: "gcsfuse-logs-ls-flat-grpc.txt"
+    regex: "gcsfuse-logs-ls-flat-grpc-pool4.txt"
     regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/continuous.cfg
@@ -14,11 +14,10 @@
 
 action {
   define_artifacts {
-    regex: "gcsfuse-logs-fio-hns.txt"
     regex: "gcsfuse-logs-ls-hns.txt"
-    regex: "gcsfuse-logs-fio-flat.txt"
+    regex: "gcsfuse-logs-ls-hns-grpc.txt"
+    regex: "gcsfuse-logs-ls-hns-grpc-pool4.txt"
     regex: "gcsfuse-logs-ls-flat.txt"
-    regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
     regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
@@ -18,6 +18,8 @@ action {
     regex: "gcsfuse-logs-ls-hns-grpc.txt"
     regex: "gcsfuse-logs-ls-hns-grpc-pool4.txt"
     regex: "gcsfuse-logs-ls-flat.txt"
+    regex: "gcsfuse-logs-ls-flat-grpc.txt"
+    regex: "gcsfuse-logs-ls-flat-grpc-pool4.txt"
     regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }

--- a/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
+++ b/perfmetrics/scripts/continuous_test/gcp_ubuntu/local_tests.cfg
@@ -14,11 +14,10 @@
 
 action {
   define_artifacts {
-    regex: "gcsfuse-logs-fio-hns.txt"
     regex: "gcsfuse-logs-ls-hns.txt"
-    regex: "gcsfuse-logs-fio-flat.txt"
+    regex: "gcsfuse-logs-ls-hns-grpc.txt"
+    regex: "gcsfuse-logs-ls-hns-grpc-pool4.txt"
     regex: "gcsfuse-logs-ls-flat.txt"
-    regex: "github/gcsfuse/perfmetrics/scripts/fio-output.json"
     regex: "**/*sponge_log.*"
     strip_prefix: "github/gcsfuse/perfmetrics/scripts"
   }

--- a/perfmetrics/scripts/generate_files.py
+++ b/perfmetrics/scripts/generate_files.py
@@ -94,9 +94,11 @@ def generate_files_and_upload_to_gcs_bucket(destination_blob_name, num_of_files,
     # Deleting batch files from temporary folder:
     subprocess.call('rm -rf {}/*'.format(TEMPORARY_DIRECTORY), shell=True)
 
-    # Writing number of files uploaded to output file after every batch uploads:
-    logmessage('{}/{} files uploaded to {}\n'.format(file_num, num_of_files,
-                                                     destination_blob_name))
+    # Writing number of files uploaded to output file every 5% of progress or upon completion:
+    log_step = max(BATCH_SIZE, (num_of_files // 20) // BATCH_SIZE * BATCH_SIZE)
+    if file_num % log_step == 0 or file_num == num_of_files:
+      logmessage('{}/{} files ({:.0f}%) uploaded to {}\n'.format(
+          file_num, num_of_files, (file_num / num_of_files) * 100, destination_blob_name))
 
   return 0
 

--- a/perfmetrics/scripts/gsheet/gsheet.py
+++ b/perfmetrics/scripts/gsheet/gsheet.py
@@ -29,12 +29,14 @@ def _get_sheets_service_client():
 
 
 def write_to_google_sheet(worksheet: str, data,
-    spreadsheet_id=SPREADSHEET_ID) -> None:
+    spreadsheet_id=SPREADSHEET_ID, clear_sheet: bool = False) -> None:
   """Calls the API to update the values of a sheet.
 
   Args:
     worksheet: string, name of the worksheet to be edited appended by a "!"
     data: list of tuples/lists, data to be added to the worksheet
+    spreadsheet_id: string, spreadsheet ID
+    clear_sheet: bool, whether to clear rows from A2 downwards before writing
 
   Raises:
     HttpError: For any Google Sheets API call related errors
@@ -45,15 +47,19 @@ def write_to_google_sheet(worksheet: str, data,
   spreadsheet_response = sheets_client.spreadsheets().values().get(
       spreadsheetId=spreadsheet_id,
       range='{}!A1:A'.format(worksheet)).execute()
-  entries = len(spreadsheet_response['values'])
+  entries = len(spreadsheet_response.get('values', []))
 
-  # Clearing the occupied rows
-  request = sheets_client.spreadsheets().values().clear(
-      spreadsheetId=spreadsheet_id,
-      range='{}!A2:{}'.format(worksheet, entries + 1),
-      body={}).execute()
+  if clear_sheet:
+    if entries > 1:
+      sheets_client.spreadsheets().values().clear(
+          spreadsheetId=spreadsheet_id,
+          range='{}!A2:{}'.format(worksheet, entries + 1),
+          body={}).execute()
+    target_row = 2
+  else:
+    target_row = max(2, entries + 1)
 
-  # Appending new rows
+  # Writing rows starting at target_row
   sheets_client.spreadsheets().values().update(
       spreadsheetId=spreadsheet_id,
       valueInputOption='USER_ENTERED',
@@ -61,4 +67,4 @@ def write_to_google_sheet(worksheet: str, data,
           'majorDimension': 'ROWS',
           'values': data
       },
-      range='{}!A2'.format(worksheet)).execute()
+      range='{}!A{}'.format(worksheet, target_row)).execute()

--- a/perfmetrics/scripts/gsheet/gsheet_test.py
+++ b/perfmetrics/scripts/gsheet/gsheet_test.py
@@ -41,23 +41,16 @@ class GsheetTest(unittest.TestCase):
     sheets_client = gsheet._get_sheets_service_client()
     self.assertIsInstance(sheets_client, Resource)
 
-  def test_write_to_google_sheet(self):
+  def test_write_to_google_sheet_append(self):
     get_response = {
         'range': '{}!A1:A'.format(WORKSHEET_NAME),
         'majorDimension': 'ROWS',
         'values': [['read'], ['read'],['read'],['read'],['write'],['write']]
     }
-    last_row = len(get_response['values'])+1
-    update_response_clear = {
-        'spreadsheetId': SPREADSHEET_ID,
-        'updatedRange': '{0}!A2:{1}'.format(WORKSHEET_NAME, last_row),
-        'updatedRows': 1,
-        'updatedColumns': 10,
-        'updatedCells': 10
-    }
+    target_row = len(get_response['values']) + 1
     update_response_write = {
         'spreadsheetId': SPREADSHEET_ID,
-        'updatedRange': '{0}!A2'.format(WORKSHEET_NAME),
+        'updatedRange': '{0}!A{1}'.format(WORKSHEET_NAME, target_row),
         'updatedRows': 1,
         'updatedColumns': 10,
         'updatedCells': 10
@@ -65,10 +58,48 @@ class GsheetTest(unittest.TestCase):
     sheets_service_mock = mock.MagicMock()
     sheets_service_mock.spreadsheets().values().get(
     ).execute.return_value = get_response
-    sheets_service_mock.spreadsheets().values().clear(
-    ).execute.return_value = update_response_clear
     sheets_service_mock.spreadsheets().values().update(
     ).execute.return_value = update_response_write
+    metrics_to_be_added = [
+        ('read', 50000, 40, 1653027155, 1653027215, 1, 2, 3, 4, 5)
+    ]
+    calls = [
+        mock.call.spreadsheets().values().get(
+            spreadsheetId=SPREADSHEET_ID,
+            range='{}!A1:A'.format(WORKSHEET_NAME)),
+        mock.call.spreadsheets().values().update(
+            spreadsheetId=SPREADSHEET_ID,
+            valueInputOption='USER_ENTERED',
+            body={
+                'majorDimension': 'ROWS',
+                'values': [(
+                    'read', 50000, 40, 1653027155, 1653027215, 1, 2, 3, 4, 5
+                    )]
+            },
+            range='{}!A{}'.format(WORKSHEET_NAME, target_row))
+    ]
+
+    with mock.patch.object(gsheet, '_get_sheets_service_client'
+                           ) as get_sheets_service_client_mock:
+      get_sheets_service_client_mock.return_value = sheets_service_mock
+      gsheet.write_to_google_sheet(WORKSHEET_NAME, metrics_to_be_added, clear_sheet=False)
+
+    sheets_service_mock.assert_has_calls(calls, any_order=True)
+
+  def test_write_to_google_sheet_clear(self):
+    get_response = {
+        'range': '{}!A1:A'.format(WORKSHEET_NAME),
+        'majorDimension': 'ROWS',
+        'values': [['read'], ['read'],['read'],['read'],['write'],['write']]
+    }
+    last_row = len(get_response['values']) + 1
+    sheets_service_mock = mock.MagicMock()
+    sheets_service_mock.spreadsheets().values().get(
+    ).execute.return_value = get_response
+    sheets_service_mock.spreadsheets().values().clear(
+    ).execute.return_value = {'spreadsheetId': SPREADSHEET_ID}
+    sheets_service_mock.spreadsheets().values().update(
+    ).execute.return_value = {'spreadsheetId': SPREADSHEET_ID}
     metrics_to_be_added = [
         ('read', 50000, 40, 1653027155, 1653027215, 1, 2, 3, 4, 5)
     ]
@@ -95,7 +126,7 @@ class GsheetTest(unittest.TestCase):
     with mock.patch.object(gsheet, '_get_sheets_service_client'
                            ) as get_sheets_service_client_mock:
       get_sheets_service_client_mock.return_value = sheets_service_mock
-      gsheet.write_to_google_sheet(WORKSHEET_NAME, metrics_to_be_added)
+      gsheet.write_to_google_sheet(WORKSHEET_NAME, metrics_to_be_added, clear_sheet=True)
 
     sheets_service_mock.assert_has_calls(calls, any_order=True)
 

--- a/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark.py
@@ -344,12 +344,12 @@ def _perform_testing(dir, test_type, num_samples):
     # Creating config file for mounting with hns enabled.
     with open("/tmp/config.yml",'w') as mount_config:
       mount_config.write("enable-hns: true")
-    mount_flags="--config-file=/tmp/config.yml --stackdriver-export-interval=30s"
+    mount_flags="--config-file=/tmp/config.yml --cloud-metrics-export-interval-secs=30 --client-protocol=http1"
   else :
     # Creating config file for mounting with hns disabled.
     with open("/tmp/config.yml",'w') as mount_config:
       mount_config.write("enable-hns: false")
-    mount_flags = "--config-file=/tmp/config.yml  --implicit-dirs --rename-dir-limit=1000000 --stackdriver-export-interval=30s"
+    mount_flags = "--config-file=/tmp/config.yml --implicit-dirs --rename-dir-limit=1000000 --cloud-metrics-export-interval-secs=30 --client-protocol=http1"
 
   # Mounting the gcs bucket.
   bucket_name = mount_gcs_bucket(dir["name"], mount_flags, log)

--- a/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark_test.py
+++ b/perfmetrics/scripts/hns_rename_folders_metrics/renaming_benchmark_test.py
@@ -133,7 +133,7 @@ class TestRenamingBenchmark(unittest.TestCase):
     test_type = "flat"
     num_samples = 4
     results = {}
-    mount_flags = "--config-file=/tmp/config.yml  --implicit-dirs --rename-dir-limit=1000000 --stackdriver-export-interval=30s"
+    mount_flags = "--config-file=/tmp/config.yml --implicit-dirs --rename-dir-limit=1000000 --cloud-metrics-export-interval-secs=30 --client-protocol=http1"
     mock_mount_gcs_bucket.return_value="flat_bucket"
     mock_record_time_of_operation.return_value = [{"test_folder": [0.1, 0.2, 0.3, 0.4]},[[0.1,0.4]]]
     expected_results = {"test_folder": [0.1, 0.2, 0.3, 0.4]}
@@ -170,7 +170,7 @@ class TestRenamingBenchmark(unittest.TestCase):
     test_type = "hns"
     num_samples = 4
     results = {}
-    mount_flags = "--config-file=/tmp/config.yml --stackdriver-export-interval=30s"
+    mount_flags = "--config-file=/tmp/config.yml --cloud-metrics-export-interval-secs=30 --client-protocol=http1"
     mock_mount_gcs_bucket.return_value="hns_bucket"
     mock_record_time_of_operation.return_value = [{"test_folder": [0.1, 0.2, 0.3, 0.4]},[[0.1,0.4]]]
     expected_results = {"test_folder": [0.1, 0.2, 0.3, 0.4]}

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -464,7 +464,7 @@ def _parse_arguments(argv):
   )
   parser.add_argument(
       '--gcsfuse_flags',
-      help='Gcsfuse flags for mounting the list tests bucket. Example set of flags - "--implicit-dirs --max-conns-per-host 100 --debug_fuse --debug_gcs --log-file gcsfuse-list-logs.txt --log-format \"text\" --stackdriver-export-interval=30s"',
+      help='Gcsfuse flags for mounting the list tests bucket. Example set of flags - "--implicit-dirs --max-conns-per-host 100 --client-protocol http1 --log-severity trace --log-file gcsfuse-list-logs.txt --log-format \"text\" --cloud-metrics-export-interval-secs=30"',
       action='store',
       nargs=1,
       required=True,

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark.py
@@ -484,23 +484,32 @@ def _parse_arguments(argv):
       default=False,
       required=False,
   )
+  parser.add_argument(
+      '--clear_sheet',
+      help='Clear the worksheet prior to writing results? [True/False]',
+      action='store_true',
+      default=False,
+      required=False,
+  )
   # Ignoring the first parameter, as it is the path of this python
   # script itself.
   return parser.parse_args(argv[1:])
 
 
-def _export_to_gsheet(worksheet, ls_data, spreadsheet_id=""):
+def _export_to_gsheet(worksheet, ls_data, spreadsheet_id="", clear_sheet=False):
   """Writes list results to Google Spreadsheets
   Args:
     worksheet (str): Google sheet name to which results will be uploaded
     ls_data (list): List results to be uploaded
+    spreadsheet_id (str): Google spreadsheet ID
+    clear_sheet (bool): Whether to clear rows A2:end before writing
   """
   # Changing directory to comply with "cred.json" path in "gsheet.py".
   os.chdir('..')
   if spreadsheet_id != "":
-    gsheet.write_to_google_sheet(worksheet, ls_data, spreadsheet_id)
+    gsheet.write_to_google_sheet(worksheet, ls_data, spreadsheet_id, clear_sheet)
   else:
-    gsheet.write_to_google_sheet(worksheet, ls_data)
+    gsheet.write_to_google_sheet(worksheet, ls_data, clear_sheet=clear_sheet)
   os.chdir('./ls_metrics')  # Changing the directory back to current directory.
   return
 
@@ -600,8 +609,9 @@ if __name__ == '__main__':
   if args.upload_gs:
     log.info('Uploading files to the Google Sheet.\n')
     _export_to_gsheet(WORKSHEET_NAME_GCS, upload_values_gcs,
-                      args.spreadsheet_id)
-    _export_to_gsheet(WORKSHEET_NAME_PD, upload_values_pd, args.spreadsheet_id)
+                      args.spreadsheet_id, clear_sheet=args.clear_sheet)
+    _export_to_gsheet(WORKSHEET_NAME_PD, upload_values_pd,
+                      args.spreadsheet_id, clear_sheet=args.clear_sheet)
 
   if args.upload_bq:
     if not args.config_id or not args.start_time_build:

--- a/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
+++ b/perfmetrics/scripts/ls_metrics/listing_benchmark_test.py
@@ -275,7 +275,7 @@ class ListingBenchmarkTest(unittest.TestCase):
     listing_benchmark._export_to_gsheet(
         WORKSHEET_NAME, DIRECTORY_STRUCTURE_2_VALUES)
     self.assertEqual(mock_sheet.call_args_list, [
-        call('ls_metrics_gcsfuse', DIRECTORY_STRUCTURE_2_VALUES)
+        call('ls_metrics_gcsfuse', DIRECTORY_STRUCTURE_2_VALUES, clear_sheet=False)
     ])
 
   def test_parse_results_double_level_dir(self):

--- a/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
+++ b/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
@@ -27,4 +27,5 @@ UPLOAD_FLAGS=$2
 SPREADSHEET_ID=$3
 CONFIG_FILE=$4
 MESSAGE=${5:-"Testing CT setup."}
-python3 listing_benchmark.py $CONFIG_FILE --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 30 --message "$MESSAGE" --spreadsheet_id=$SPREADSHEET_ID
+CLEAR_SHEET_FLAG=$6
+python3 listing_benchmark.py $CONFIG_FILE --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 30 --message "$MESSAGE" --spreadsheet_id=$SPREADSHEET_ID $CLEAR_SHEET_FLAG

--- a/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
+++ b/perfmetrics/scripts/ls_metrics/run_ls_benchmark.sh
@@ -26,4 +26,5 @@ GCSFUSE_FLAGS=$1
 UPLOAD_FLAGS=$2
 SPREADSHEET_ID=$3
 CONFIG_FILE=$4
-python3 listing_benchmark.py $CONFIG_FILE --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 30 --message "Testing CT setup." --spreadsheet_id=$SPREADSHEET_ID
+MESSAGE=${5:-"Testing CT setup."}
+python3 listing_benchmark.py $CONFIG_FILE --gcsfuse_flags "$GCSFUSE_FLAGS" $UPLOAD_FLAGS --command "ls -R" --num_samples 30 --message "$MESSAGE" --spreadsheet_id=$SPREADSHEET_ID

--- a/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
+++ b/perfmetrics/scripts/read_cache/mount_gcsfuse.sh
@@ -87,12 +87,12 @@ export STAT_CACHE_MAX_SIZE_MB="${stat_cache_max_size_mb}"
 
 debug_flags=""
 if [ $enable_log -eq 1 ]; then
-  debug_flags="--debug_fuse --debug_gcs"
+  debug_flags="--log-severity trace"
 fi
 
 # Mount gcsfuse
 echo "Mounting gcsfuse..."
-gcsfuse --stackdriver-export-interval 30s \
+gcsfuse --cloud-metrics-export-interval-secs 30 \
         $debug_flags \
         --log-file $WORKING_DIR/gcsfuse_logs.txt \
         --log-format text \


### PR DESCRIPTION
### Description
This change modernizes the continuous testing suite for `local_tests`, adds gRPC listing benchmark variations for Flat and HNS buckets, improves Google Sheet metrics export, and rate-limits file generation logging:

1. **Remove Deprecated FIO Read/Write Tests**: Removed synthetic FIO load tests from `continuous_test/gcp_ubuntu/build.sh` and updated Kokoro artifact definitions in `local_tests.cfg` and `continuous.cfg`.
2. **Add gRPC Listing Benchmarks (Flat & HNS)**:
   - Added directory listing benchmark runs for both Flat and HNS buckets using `--client-protocol grpc` (default pool size) and `--client-protocol grpc --experimental-grpc-conn-pool-size 4` alongside existing HTTP/1.1 (`--client-protocol http1`).
   - Passed distinct test descriptions to `--message` for clear identification in Google Sheets and BigQuery.
3. **Google Sheet Export Append & Clear Modes**:
   - Updated `write_to_google_sheet` in `perfmetrics/scripts/gsheet/gsheet.py` to support `clear_sheet` and append modes.
   - Configured `build.sh` to clear previous test data on the first run (`HTTP/1.1`) and cleanly append subsequent runs (`gRPC`, `gRPC Pool 4`), preventing intra-build data overwrites while keeping the sheet as a clean snapshot of the latest build.
   - Added corresponding unit tests in `gsheet_test.py` and `listing_benchmark_test.py`.
4. **Rate-Limited Progress Logging in File Generation**:
   - Updated `perfmetrics/scripts/generate_files.py` to log progress at 5% intervals instead of every batch, significantly reducing log noise during large directory creation (100k / 200k files).
5. **Flag Modernization & Protocol Pinning**:
   - Replaced deprecated `--debug_fuse` and `--debug_gcs` with `--log-severity trace`.
   - Replaced deprecated `--stackdriver-export-interval` with `--cloud-metrics-export-interval-secs`.
   - Removed obsolete `--enable-storage-client-library` references in BigQuery test fixtures.

### Link to the issue in case of a bug fix.
N/A

### Testing details
1. Manual - Verified shell script syntax (`bash -n`) across all modified shell scripts and JSON validation with Python `json.tool`. Tested `listing_benchmark.py` and `generate_files.py` execution locally.
2. Unit tests - Verified all Python unit tests pass:
   - `python -m unittest perfmetrics/scripts/gsheet/gsheet_test.py` (4/4 tests pass)
   - `python -m unittest perfmetrics/scripts/ls_metrics/listing_benchmark_test.py` (25/25 tests pass)
3. Integration tests - `go build -mod=mod ./...` executed with zero errors.

### Any backward incompatible change? If so, please explain.
N/A