### PR TITLE
fix(perfmetrics): update gke-gcloud-auth-plugin apt package name

### DIFF
--- a/perfmetrics/scripts/continuous_test/gke/common/utils.py
+++ b/perfmetrics/scripts/continuous_test/gke/common/utils.py
@@ -171,7 +171,7 @@ async def check_prerequisites():
               "apt",
               "install",
               "-y",
-              "google-cloud-sdk-gke-gcloud-auth-plugin",
+              "google-cloud-cli-gke-gcloud-auth-plugin",
           ])
         except (FileNotFoundError, subprocess.CalledProcessError) as e:
           print(


### PR DESCRIPTION
### Description
Updated the APT package name for installing `gke-gcloud-auth-plugin` from `google-cloud-sdk-gke-gcloud-auth-plugin` to `google-cloud-cli-gke-gcloud-auth-plugin` in GKE continuous test utilities.

### Link to the issue in case of a bug fix.
Fixes b/554022361

### Testing details
1. Manual - Executed `make build` and verified formatting/linting checks pass cleanly.
2. Unit tests - NA
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A