### PR TITLE
refactor(integration_tests): generalize WaitForSizeUpdate and rename wait constants to rapid

### DIFF
--- a/tools/integration_tests/rapid_operations/reads_after_appends_test.go
+++ b/tools/integration_tests/rapid_operations/reads_after_appends_test.go
@@ -41,7 +41,7 @@ func (t *SingleMountReadsTestSuite) runAppendAndReadTest(verifyFunc readAndVerif
 	for i := range numAppends {
 		// Wait for a minute for stat to return the correct file size, which is needed by appendToFile.
 		if i > 0 {
-			time.Sleep(operations.WaitDurationAfterFlushZB)
+			operations.WaitForSizeUpdate(setup.IsZonalBucketRun() || setup.IsPirloBucketRun(), operations.WaitDurationAfterFlushRapid)
 		}
 
 		t.appendToFile(appendFileHandle, setup.GenerateRandomString(appendSize))
@@ -89,7 +89,7 @@ func (t *DualMountReadsTestSuite) runAppendAndReadTest(verifyFunc readAndVerifyF
 			// Wait for metadata cache to expire to fetch the latest size for the next read.
 			// Metadata update for appends in current iteration itself takes a minute, so the
 			// cached size will expire in ttl-60 secs from now, so wait accordingly.
-			time.Sleep(time.Duration(metadataCacheTTLSecs*time.Second - operations.WaitDurationAfterFlushZB))
+			time.Sleep(metadataCacheTTLSecs*time.Second - operations.WaitDurationAfterFlushRapid)
 			// Expect read up to the latest file size which is the size after the append.
 			verifyFunc(t.T(), readPath, []byte(t.fileContent[:sizeAfterAppend]))
 		}

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -140,7 +140,7 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 	_, err := w.Write(content)
 	s.Require().NoError(err)
 	s.Require().NoError(w.Close())
-	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
+	operations.WaitForSizeUpdate(w.Append && !w.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/symlink_handling/symlink_suites_test.go
+++ b/tools/integration_tests/symlink_handling/symlink_suites_test.go
@@ -140,7 +140,8 @@ func (s *BaseSymlinkSuite) createGCSSymlinkObject(linkName, target string) {
 	_, err := w.Write(content)
 	s.Require().NoError(err)
 	s.Require().NoError(w.Close())
-	operations.WaitForSizeUpdate(w.Append && !w.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
+	isUnfinalizedObject := w.Append && !w.FinalizeOnClose
+	operations.WaitForSizeUpdate(isUnfinalizedObject, operations.WaitDurationAfterCloseRapid)
 }
 
 ////////////////////////////////////////////////////////////////////////

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -292,7 +292,7 @@ func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object
 	if err := wc.Close(); err != nil {
 		return fmt.Errorf("wc.Close failed for object %q: %w", object, err)
 	}
-	operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
+	operations.WaitForSizeUpdate(wc.Append && !wc.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
 	return nil
 }
 
@@ -406,7 +406,7 @@ func UploadGcsObjectWithPreconditions(ctx context.Context, client *storage.Clien
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)
 		}
-		operations.WaitForSizeUpdate(setup.IsZonalBucketRun(), operations.WaitDurationAfterCloseZB)
+		operations.WaitForSizeUpdate(w.Append && !w.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
 	}()
 
 	filePathToUpload := localPath

--- a/tools/integration_tests/util/client/storage_client.go
+++ b/tools/integration_tests/util/client/storage_client.go
@@ -292,7 +292,8 @@ func CreateObjectWithOptions(ctx context.Context, client *storage.Client, object
 	if err := wc.Close(); err != nil {
 		return fmt.Errorf("wc.Close failed for object %q: %w", object, err)
 	}
-	operations.WaitForSizeUpdate(wc.Append && !wc.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
+	isUnfinalizedObject := wc.Append && !wc.FinalizeOnClose
+	operations.WaitForSizeUpdate(isUnfinalizedObject, operations.WaitDurationAfterCloseRapid)
 	return nil
 }
 
@@ -406,7 +407,8 @@ func UploadGcsObjectWithPreconditions(ctx context.Context, client *storage.Clien
 		if err := w.Close(); err != nil {
 			log.Printf("Failed to close GCS object gs://%s/%s: %v", bucketName, objectName, err)
 		}
-		operations.WaitForSizeUpdate(w.Append && !w.FinalizeOnClose, operations.WaitDurationAfterCloseRapid)
+		isUnfinalizedObject := w.Append && !w.FinalizeOnClose
+		operations.WaitForSizeUpdate(isUnfinalizedObject, operations.WaitDurationAfterCloseRapid)
 	}()
 
 	filePathToUpload := localPath

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -53,9 +53,9 @@ const (
 	TimeSlop = 25 * time.Millisecond
 	// TmpDirectory specifies the directory where temporary files will be created.
 	// In this case, we are using the system's default temporary directory.
-	TmpDirectory             = "/tmp"
-	WaitDurationAfterFlushZB = time.Minute
-	WaitDurationAfterCloseZB = time.Second
+	TmpDirectory                = "/tmp"
+	WaitDurationAfterFlushRapid = time.Minute
+	WaitDurationAfterCloseRapid = time.Second
 )
 
 func copyFile(srcFileName, dstFileName string, allowOverwrite bool) (err error) {
@@ -174,7 +174,7 @@ func CloseFiles(t *testing.T, files []*os.File) {
 		err := file.Close()
 		assert.NoError(t, err)
 	}
-	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseZB)
+	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
 // Deprecated: please use CloseFileShouldNotThrowError instead.
@@ -182,7 +182,7 @@ func CloseFile(file *os.File) {
 	if err := file.Close(); err != nil {
 		log.Fatalf("error in closing: %v", err)
 	}
-	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseZB)
+	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
 func RemoveFile(filePath string) {
@@ -581,7 +581,7 @@ func WriteAt(content string, offset int64, fh *os.File, t testing.TB) {
 func CloseFileShouldNotThrowError(t testing.TB, file *os.File) {
 	err := file.Close()
 	assert.NoError(t, err)
-	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseZB)
+	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
 func CloseFileShouldThrowError(t *testing.T, file *os.File) {
@@ -598,7 +598,7 @@ func SyncFile(fh *os.File, t *testing.T) {
 	if err != nil {
 		t.Fatalf("%s.Sync(): %v", fh.Name(), err)
 	}
-	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterFlushZB)
+	WaitForSizeUpdate(setup.IsZonalBucketRun() || setup.IsPirloBucketRun(), WaitDurationAfterFlushRapid)
 }
 
 func SyncFiles(files []*os.File, t *testing.T) {

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -175,7 +175,8 @@ func CloseFiles(t *testing.T, files []*os.File) {
 		assert.NoError(t, err)
 	}
 	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close, and this method is not used for creating unfinalized objects explicitly.
+	// on close. Update it to check for Pirlo if in the future this method is
+	// used for creating unfinalized objects in Pirlo.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -185,7 +186,8 @@ func CloseFile(file *os.File) {
 		log.Fatalf("error in closing: %v", err)
 	}
 	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close, and this method is not used for creating unfinalized objects explicitly.
+	// on close. Update it to check for Pirlo if in the future this method is
+	// used for creating unfinalized objects in Pirlo.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -586,7 +588,8 @@ func CloseFileShouldNotThrowError(t testing.TB, file *os.File) {
 	err := file.Close()
 	assert.NoError(t, err)
 	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close, and this method is not used for creating unfinalized objects explicitly.
+	// on close. Update it to check for Pirlo if in the future this method is
+	// used for creating unfinalized objects in Pirlo.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -174,6 +174,8 @@ func CloseFiles(t *testing.T, files []*os.File) {
 		err := file.Close()
 		assert.NoError(t, err)
 	}
+	// We don't wait for Pirlo since by default Pirlo creates finalized objects
+	// on close, and this method is not used for creating unfinalized objects explicitly.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -182,6 +184,8 @@ func CloseFile(file *os.File) {
 	if err := file.Close(); err != nil {
 		log.Fatalf("error in closing: %v", err)
 	}
+	// We don't wait for Pirlo since by default Pirlo creates finalized objects
+	// on close, and this method is not used for creating unfinalized objects explicitly.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -581,6 +585,8 @@ func WriteAt(content string, offset int64, fh *os.File, t testing.TB) {
 func CloseFileShouldNotThrowError(t testing.TB, file *os.File) {
 	err := file.Close()
 	assert.NoError(t, err)
+	// We don't wait for Pirlo since by default Pirlo creates finalized objects
+	// on close, and this method is not used for creating unfinalized objects explicitly.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 

--- a/tools/integration_tests/util/operations/file_operations.go
+++ b/tools/integration_tests/util/operations/file_operations.go
@@ -174,9 +174,8 @@ func CloseFiles(t *testing.T, files []*os.File) {
 		err := file.Close()
 		assert.NoError(t, err)
 	}
-	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close. Update it to check for Pirlo if in the future this method is
-	// used for creating unfinalized objects in Pirlo.
+	// Pirlo creates finalized objects on close by default, so we don't wait for it here.
+	// Update this condition if this method is used to create unfinalized Pirlo objects in the future.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -185,9 +184,8 @@ func CloseFile(file *os.File) {
 	if err := file.Close(); err != nil {
 		log.Fatalf("error in closing: %v", err)
 	}
-	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close. Update it to check for Pirlo if in the future this method is
-	// used for creating unfinalized objects in Pirlo.
+	// Pirlo creates finalized objects on close by default, so we don't wait for it here.
+	// Update this condition if this method is used to create unfinalized Pirlo objects in the future.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 
@@ -587,9 +585,8 @@ func WriteAt(content string, offset int64, fh *os.File, t testing.TB) {
 func CloseFileShouldNotThrowError(t testing.TB, file *os.File) {
 	err := file.Close()
 	assert.NoError(t, err)
-	// We don't wait for Pirlo since by default Pirlo creates finalized objects
-	// on close. Update it to check for Pirlo if in the future this method is
-	// used for creating unfinalized objects in Pirlo.
+	// Pirlo creates finalized objects on close by default, so we don't wait for it here.
+	// Update this condition if this method is used to create unfinalized Pirlo objects in the future.
 	WaitForSizeUpdate(setup.IsZonalBucketRun(), WaitDurationAfterCloseRapid)
 }
 

--- a/tools/integration_tests/util/operations/operations.go
+++ b/tools/integration_tests/util/operations/operations.go
@@ -81,8 +81,8 @@ func ExecuteGcloudCommand(command string) ([]byte, error) {
 
 // WaitForSizeUpdate waits for a specified time duration to ensure that stat()
 // call returns correct size for unfinalized object.
-func WaitForSizeUpdate(isZonal bool, duration time.Duration) {
-	if isZonal {
+func WaitForSizeUpdate(isUnfinalized bool, duration time.Duration) {
+	if isUnfinalized {
 		time.Sleep(duration)
 	}
 }


### PR DESCRIPTION
### **Description**
1. Generalized [`WaitForSizeUpdate`](file:///usr/local/google/home/vipinydv/gcsfuse/tools/integration_tests/util/operations/operations.go#L83) parameter name from `isZonal bool` to `isUnfinalized bool` to represent unfinalized objects for both Zonal and Pirlo runs.
2. Renamed wait duration constants `WaitDurationAfterFlushZB` $\rightarrow$ `WaitDurationAfterFlushRapid` and `WaitDurationAfterCloseZB` $\rightarrow$ `WaitDurationAfterCloseRapid` in [`file_operations.go`](file:///usr/local/google/home/vipinydv/gcsfuse/tools/integration_tests/util/operations/file_operations.go#L56).
3. In `file_operations.go`, updated `CloseFiles`, `CloseFile`, and `CloseFileShouldNotThrowError` to pass `setup.IsZonalBucketRun()` since only Zonal leaves files unfinalized on close (Pirlo finalizes on close by default and does not need to sleep 1s).
4. In `storage_client.go` and `symlink_suites_test.go`, passed `wc.Append && !wc.FinalizeOnClose` to dynamically wait only when an unfinalized appendable object was actually created.
5. Updated `SyncFile` in `file_operations.go` and `reads_after_appends_test.go` to pass `setup.IsZonalBucketRun() || setup.IsPirloBucketRun()` for unfinalized flushes/appends.

### **Testing details**
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### **Any backward incompatible change? If so, please explain.**
NA