### PR TITLE
fix(internal/fs): destroy unsynced temp files on handle release to prevent disk leak

### DIFF
--- a/internal/fs/handle/file.go
+++ b/internal/fs/handle/file.go
@@ -135,7 +135,8 @@ func NewFileHandle(
 // LOCK_FUNCTION(fh.inode.mu)
 // UNLOCK_FUNCTION(fh.inode.mu)
 func (fh *FileHandle) Destroy() {
-	// Deregister the fileHandle with the inode.
+	// Deregister the fileHandle with the inode. If this is the last write
+	// handle for the inode, any unsynced staging temporary file is destroyed.
 	fh.inode.Lock()
 	fh.inode.DeRegisterFileHandle(fh.openMode.AccessMode() == util.ReadOnly)
 	fh.inode.Unlock()

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -555,21 +555,48 @@ func (f *FileInode) DeRegisterFileHandle(readOnly bool) {
 
 	f.writeHandleCount--
 
-	// All write fileHandles are closed.
-	if f.writeHandleCount == 0 {
-		if f.bwh != nil {
-			err := f.bwh.Destroy()
-			if err != nil {
-				logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
-			}
-			f.bwh = nil
-		}
-		// If there is an unsynced/abandoned temp file, destroy it to reclaim disk space.
-		if !f.localFileCache && f.content != nil {
-			f.content.Destroy()
-			f.content = nil
-		}
+	if f.writeHandleCount != 0 {
+		return
 	}
+
+	// All write fileHandles are closed.
+	if f.bwh != nil {
+		err := f.bwh.Destroy()
+		if err != nil {
+			logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
+		}
+		f.bwh = nil
+	}
+
+	f.cleanupContentOnLastHandleRelease()
+}
+
+// cleanupContentOnLastHandleRelease ensures that the on-disk staging temporary
+// file (used for staged writes and random-write fallback) is destroyed once the
+// last write handle for the inode is released.
+//
+// This serves as a backstop for cases where FUSE_FLUSH is not invoked:
+//  1. When writeback cache is enabled and a write error occurs, the Linux FUSE
+//     kernel module marks AS_EIO on the mapping and skips FUSE_FLUSH on close().
+//  2. When an unsynced file handle is closed without an explicit flush.
+//
+// Under these conditions, relying on ForgetInode for cleanup causes disk space to
+// be leaked indefinitely until dentry cache eviction.
+//
+// This intentionally does not attempt to sync content to GCS. FUSE_RELEASE cannot
+// return errors to the application, and any unsynced content at this stage reflects
+// a failed or aborted write. Mirroring the discard contract of bwh.Destroy(), the
+// uncommitted temporary file is discarded.
+//
+// LOCKS_REQUIRED(f.mu)
+func (f *FileInode) cleanupContentOnLastHandleRelease() {
+	// localFileCache content is managed by ContentCache, so do not destroy it here.
+	if f.localFileCache || f.content == nil {
+		return
+	}
+
+	f.content.Destroy()
+	f.content = nil
 }
 
 // LOCKS_REQUIRED(f.mu)

--- a/internal/fs/inode/file.go
+++ b/internal/fs/inode/file.go
@@ -555,13 +555,20 @@ func (f *FileInode) DeRegisterFileHandle(readOnly bool) {
 
 	f.writeHandleCount--
 
-	// All write fileHandles associated with bwh are closed. So safe to set bwh to nil.
-	if f.writeHandleCount == 0 && f.bwh != nil {
-		err := f.bwh.Destroy()
-		if err != nil {
-			logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
+	// All write fileHandles are closed.
+	if f.writeHandleCount == 0 {
+		if f.bwh != nil {
+			err := f.bwh.Destroy()
+			if err != nil {
+				logger.Warnf("Error while destroying the bufferedWritesHandler: %v", err)
+			}
+			f.bwh = nil
 		}
-		f.bwh = nil
+		// If there is an unsynced/abandoned temp file, destroy it to reclaim disk space.
+		if !f.localFileCache && f.content != nil {
+			f.content.Destroy()
+			f.content = nil
+		}
 	}
 }
 

--- a/internal/fs/inode/file_mock_bucket_test.go
+++ b/internal/fs/inode/file_mock_bucket_test.go
@@ -199,6 +199,22 @@ func (t *FileMockBucketTest) TestFlushSyncedFileForceFetchObjectFromGCS() {
 	t.bucket.AssertExpectations(t.T())
 }
 
+func (t *FileMockBucketTest) TestDeRegisterFileHandle_DestroysContentOnLastHandleWithoutSyncing() {
+	// Local inode created by createLockedInode already has a non-nil f.content
+	// (CreateEmptyTempFile) backed by an on-disk staging file.
+	require.NotNil(t.T(), t.in.content)
+	// Dirty the file.
+	_, err := t.in.Write(t.ctx, []byte("data"), 0, util.NewOpenMode(util.WriteOnly, 0), getWriteContext())
+	require.NoError(t.T(), err)
+	t.in.writeHandleCount = 1
+
+	t.in.DeRegisterFileHandle(false)
+
+	// The staging TempFile must be destroyed immediately on release without
+	// attempting an upload/sync to GCS (no CreateObject or SyncObject calls).
+	assert.Nil(t.T(), t.in.content)
+}
+
 func (t *FileMockBucketTest) TestSync_RemoteAppendClobber() {
 	// Expect CreateObject from createLockedInode
 	t.bucket.On("CreateObject", t.ctx, mock.AnythingOfType("*gcs.CreateObjectRequest")).

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -2180,6 +2180,96 @@ func (t *FileTest) TestDeRegisterFileHandle() {
 	}
 }
 
+func (t *FileTest) TestTempFileCleanup_StreamingWritesEnabled_RandomWriteFallback() {
+	t.createInodeWithEmptyObject()
+	t.writeCtx.Config = &cfg.Config{Write: *getWriteConfig()}
+	t.createBufferedWriteHandler(true, WriteMode)
+
+	// Step 1: Open write handle.
+	t.in.RegisterFileHandle(false)
+	require.Equal(t.T(), int32(1), t.in.writeHandleCount)
+
+	// Step 2: Perform sequential write (handled by bwh).
+	gcsSynced, err := t.in.Write(t.ctx, []byte("hello"), 0, WriteMode, t.writeCtx)
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+	assert.NotNil(t.T(), t.in.bwh)
+	assert.Nil(t.T(), t.in.content)
+
+	// Step 3: Perform out-of-order/random write at offset 1024 (triggers fallback to temp file).
+	gcsSynced, err = t.in.Write(t.ctx, []byte("world"), 1024, WriteMode, t.writeCtx)
+	require.NoError(t.T(), err)
+	assert.True(t.T(), gcsSynced)
+	assert.Nil(t.T(), t.in.bwh)
+	assert.NotNil(t.T(), t.in.content) // Temp file on disk is active
+
+	// Step 4: Application closes write handle without a successful flush (e.g. error on close or skipped flush).
+	t.in.DeRegisterFileHandle(false)
+
+	// Step 5: Verify all resources (both bwh and temp file on disk) are destroyed immediately.
+	assert.Equal(t.T(), int32(0), t.in.writeHandleCount)
+	assert.Nil(t.T(), t.in.bwh)
+	assert.Nil(t.T(), t.in.content)
+}
+
+func (t *FileTest) TestTempFileCleanup_StreamingWritesDisabled_StagedWrites() {
+	t.createInodeWithEmptyObject()
+	// Disable streaming writes (pure staged writes / writeback cache mode).
+	t.writeCtx.Config = &cfg.Config{Write: cfg.WriteConfig{EnableStreamingWrites: false}}
+
+	// Step 1: Open write handle.
+	t.in.RegisterFileHandle(false)
+	require.Equal(t.T(), int32(1), t.in.writeHandleCount)
+
+	// Step 2: Perform random/staged write (goes directly to local temp file).
+	gcsSynced, err := t.in.Write(t.ctx, []byte("staged data"), 0, WriteMode, t.writeCtx)
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+	assert.Nil(t.T(), t.in.bwh)
+	assert.NotNil(t.T(), t.in.content) // Local disk temp file is holding space
+
+	// Step 3: Perform second write at offset 4096.
+	gcsSynced, err = t.in.Write(t.ctx, []byte("random chunk"), 4096, WriteMode, t.writeCtx)
+	require.NoError(t.T(), err)
+	assert.False(t.T(), gcsSynced)
+	assert.NotNil(t.T(), t.in.content)
+
+	// Step 4: Write/flush fails and application closes the handle.
+	t.in.DeRegisterFileHandle(false)
+
+	// Step 5: Verify temp file on disk is immediately destroyed, reclaiming disk blocks.
+	assert.Equal(t.T(), int32(0), t.in.writeHandleCount)
+	assert.Nil(t.T(), t.in.content)
+}
+
+func (t *FileTest) TestTempFileCleanup_MultipleWriteHandles() {
+	t.createInodeWithEmptyObject()
+	t.writeCtx.Config = &cfg.Config{Write: *getWriteConfig()}
+	t.createBufferedWriteHandler(true, WriteMode)
+
+	// Step 1: Open two write handles (concurrent writers on same inode).
+	t.in.RegisterFileHandle(false)
+	t.in.RegisterFileHandle(false)
+	require.Equal(t.T(), int32(2), t.in.writeHandleCount)
+
+	// Step 2: Trigger fallback to temp file via out-of-order write.
+	_, err := t.in.Write(t.ctx, []byte("random"), 500, WriteMode, t.writeCtx)
+	require.NoError(t.T(), err)
+	assert.NotNil(t.T(), t.in.content)
+
+	// Step 3: First writer closes its handle.
+	t.in.DeRegisterFileHandle(false)
+	assert.Equal(t.T(), int32(1), t.in.writeHandleCount)
+	// Temp file must NOT be destroyed yet because second writer is still active!
+	assert.NotNil(t.T(), t.in.content)
+
+	// Step 4: Second writer closes its handle.
+	t.in.DeRegisterFileHandle(false)
+	assert.Equal(t.T(), int32(0), t.in.writeHandleCount)
+	// Now temp file is cleanly destroyed.
+	assert.Nil(t.T(), t.in.content)
+}
+
 func getWriteConfig() *cfg.WriteConfig {
 	return &cfg.WriteConfig{
 		MaxBlocksPerFile:      10,

--- a/internal/fs/inode/file_test.go
+++ b/internal/fs/inode/file_test.go
@@ -2100,6 +2100,86 @@ func (t *FileTest) TestRegisterFileHandle() {
 	}
 }
 
+func (t *FileTest) TestDeRegisterFileHandle() {
+	tbl := []struct {
+		name             string
+		readonly         bool
+		currentVal       int32
+		expectedVal      int32
+		hasContent       bool
+		localFileCache   bool
+		expectContentNil bool
+	}{
+		{
+			name:             "ReadOnlyHandle",
+			readonly:         true,
+			currentVal:       10,
+			expectedVal:      10,
+			hasContent:       true,
+			localFileCache:   false,
+			expectContentNil: false,
+		},
+		{
+			name:             "NonZeroCurrentValueForWriteHandle",
+			readonly:         false,
+			currentVal:       10,
+			expectedVal:      9,
+			hasContent:       true,
+			localFileCache:   false,
+			expectContentNil: false,
+		},
+		{
+			name:             "LastWriteHandleToDeregister_DestroysContent",
+			readonly:         false,
+			currentVal:       1,
+			expectedVal:      0,
+			hasContent:       true,
+			localFileCache:   false,
+			expectContentNil: true,
+		},
+		{
+			name:             "LastWriteHandleToDeregister_LocalFileCache_PreservesContent",
+			readonly:         false,
+			currentVal:       1,
+			expectedVal:      0,
+			hasContent:       true,
+			localFileCache:   true,
+			expectContentNil: false,
+		},
+		{
+			name:             "LastWriteHandleToDeregister_NoContent",
+			readonly:         false,
+			currentVal:       1,
+			expectedVal:      0,
+			hasContent:       false,
+			localFileCache:   false,
+			expectContentNil: true,
+		},
+	}
+	for _, tc := range tbl {
+		t.Run(tc.name, func() {
+			t.in.writeHandleCount = tc.currentVal
+			t.in.localFileCache = tc.localFileCache
+			if tc.hasContent {
+				err := t.in.CreateEmptyTempFile(t.ctx)
+				require.NoError(t.T(), err)
+				require.NotNil(t.T(), t.in.content)
+			} else {
+				t.in.content = nil
+			}
+
+			t.in.DeRegisterFileHandle(tc.readonly)
+
+			assert.Equal(t.T(), tc.expectedVal, t.in.writeHandleCount)
+			if tc.expectContentNil {
+				assert.Nil(t.T(), t.in.content)
+			} else {
+				assert.NotNil(t.T(), t.in.content)
+			}
+		})
+	}
+}
+
 func getWriteConfig() *cfg.WriteConfig {
 	return &cfg.WriteConfig{
 		MaxBlocksPerFile:      10,


### PR DESCRIPTION
### Description
When writeback cache is enabled (`-o writeback_cache`, e.g. with `--enable-streaming-writes=false`) or when streaming writes falls back to staged temp files during out-of-order/random writes, an I/O error or quota failure during write causes the Linux FUSE kernel driver to flag `AS_EIO` on the address space mapping. On `close()`, the kernel's `fuse_flush()` detects this via `filemap_check_errors()` and returns early without sending `FUSE_FLUSH` to userspace.

Previously, GCSFuse only cleaned up `f.content` (the staging temporary file) in `updateInodeStateAfterSync()` (successful sync) or `FileInode.Destroy()` (upon receiving `ForgetInodeOp`). Because `FUSE_FLUSH` was bypassed and `ForgetInode` relies on unpredictable dentry cache eviction, the open staging file remained on disk in `--temp-dir`, causing an indefinite disk space leak.

### Link to the issue in case of a bug fix.
Fixes #4896

### Testing details
1. Manual - NA
2. Unit tests 
   - Added table-driven and scenario tests in `internal/fs/inode/file_test.go`:
     - `TestDeRegisterFileHandle`
     - `TestTempFileCleanup_StreamingWritesEnabled_RandomWriteFallback`
     - `TestTempFileCleanup_StreamingWritesDisabled_StagedWrites`
     - `TestTempFileCleanup_MultipleWriteHandles`
   - Added mock bucket test in `internal/fs/inode/file_mock_bucket_test.go`:
     - `TestDeRegisterFileHandle_DestroysContentOnLastHandleWithoutSyncing`
   - Executed full unit test suite with race detector:
     `go test -race ./internal/fs/inode/...` (passed)
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A
