### PR TITLE
feat(grpc): bypass DirectPath connectivity check for rapid buckets (#…

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -215,24 +215,24 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// Add DirectPath enforcement - client creation will fail if DirectPath is not available
-	clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	// For non-rapid buckets, add DirectPath enforcement - operations performed via the client will fail if DirectPath is not available.
+	if !isbucketZonal {
+		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
+	}
 
 	if sc, err = storage.NewGRPCClient(ctx, clientOpts...); err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
-	setRetryConfig(ctx, sc, clientConfig)
 
-	// Direct-path verification is fatal for regional. Todo(b/503624405): Make it fatal for all after making the dummy-stat reliable.
-	if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc); verifyErr != nil {
-		logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
-		if !isbucketZonal {
+	// For regional buckets, perform the direct path verification.
+	if !isbucketZonal {
+		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc); verifyErr != nil {
+			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
 			return nil, verifyErr
 		}
-	} else {
 		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
 	}
-
+	setRetryConfig(ctx, sc, clientConfig)
 	return sc, nil
 }
 
@@ -258,6 +258,10 @@ func verifyDirectPathConnectivity(ctx context.Context, clientConfig *storageutil
 	// We should get a notFound error and not any error when the object doesn't exist.
 	// Any error other than notFound is treated as dp connection failure.
 	if statErr != nil && !errors.As(gcs.GetGCSError(statErr), &notFoundError) {
+		// The client is unusable, close it to prevent connection leaks.
+		if err := sc.Close(); err != nil {
+			logger.Errorf("Failed to close unusable gRPC client: %v", err)
+		}
 		return fmt.Errorf("DirectPath verification failed for bucket %q: %w", bucketName, statErr)
 	}
 

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1079,3 +1079,35 @@ func (testSuite *StorageHandleTest) TestControlClientForBucketHandle_NonZonalBuc
 	assert.True(testSuite.T(), controlClientWithRetry.enableRetriesOnStorageLayoutAPI, "Retries should be enabled for storage layout API on zonal buckets")
 	assert.Same(testSuite.T(), mockRawControlClientWithoutRetries, controlClientWithRetry.raw)
 }
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid() {
+	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
+	// This prevents storage.NewGRPCClient from failing in CI environments (like GitHub Actions)
+	// where Google credentials are not available.
+	testSuite.clientConfig.AnonymousAccess = true
+	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, true, false, "my-bucket")
+	defer func() {
+		if client != nil {
+			_ = client.Close()
+		}
+	}()
+
+	// If the bucket is rapid, the method for directpath check is not called, so err should be nil.
+	assert.Nil(testSuite.T(), err)
+	assert.NotNil(testSuite.T(), client)
+}
+
+func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_DirectPathVerificationForStandard() {
+	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
+	// This ensures the DirectPath verification strictly fails with PermissionDenied
+	// (instead of potentially authenticating and getting a NotFound error which is ignored).
+	// This guarantees test determinism across all execution environments.
+	testSuite.clientConfig.AnonymousAccess = true
+
+	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, false, false, "my-bucket")
+
+	// If the bucket is non rapid, the method for directpath check is called, which fails in unit test environment.
+	assert.NotNil(testSuite.T(), err)
+	assert.ErrorContains(testSuite.T(), err, "DirectPath verification failed")
+	assert.Nil(testSuite.T(), client)
+}


### PR DESCRIPTION
### Description
Backport the Rapid Bucket Startup Optimization (#5027) onto the `3.8.x` branch (`v3.8.4`) to resolve DirectPath verification timeouts during mount for rapid (zonal) buckets.

Key changes:
- Bypass `verifyDirectPathConnectivity` during gRPC client creation when the bucket is a rapid/zonal bucket.
- Enforce `experimental.WithDirectConnectivityEnforced()` client option only for non-rapid buckets.
- Close unusable gRPC clients upon verification failure to prevent connection leaks.
- Add unit tests verifying DirectPath verification is bypassed for rapid buckets and executed for standard buckets.

### Link to the issue in case of a bug fix.
Fixes b/553732236
Fixes b/555318851

### Testing details
1. Manual - NA
2. Unit tests - Passed `go test -race -count=1 ./internal/storage`
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
None.