### PR TITLE
fix(integration_tests): add --experimental-enable-pirlo flag in TestCacheFileForExcludeRegexTest

### DIFF
--- a/tools/integration_tests/read_cache/cache_file_for_exclude_regex_test.go
+++ b/tools/integration_tests/read_cache/cache_file_for_exclude_regex_test.go
@@ -98,10 +98,24 @@ func TestCacheFileForExcludeRegexTest(t *testing.T) {
 	// Run tests for GCE environment otherwise.
 	flagsSet := setup.BuildFlagSets(*testEnv.cfg, testEnv.bucketType, t.Name())
 	if setup.OnlyDirMounted() != "" {
-		flagsSet = append(flagsSet,
-			[]string{fmt.Sprintf("--file-cache-exclude-regex=^%s/%s/", setup.TestBucket(), onlyDirMounted), "--file-cache-max-size-mb=50", "--file-cache-cache-file-for-range-read=true", "--file-cache-enable-parallel-downloads=false", "--file-cache-enable-o-direct=false", fmt.Sprintf("--cache-dir=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest", setup.TestDir()), fmt.Sprintf("--log-file=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log", setup.TestDir()), "--log-severity=TRACE", "--enable-kernel-reader=false"},
-			[]string{fmt.Sprintf("--file-cache-exclude-regex=^%s/%s/", setup.TestBucket(), onlyDirMounted), "--file-cache-max-size-mb=50", "--file-cache-cache-file-for-range-read=true", "--file-cache-enable-parallel-downloads=false", "--file-cache-enable-o-direct=false", fmt.Sprintf("--cache-dir=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest", setup.TestDir()), fmt.Sprintf("--log-file=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log", setup.TestDir()), "--log-severity=TRACE", "--client-protocol=grpc", "--enable-kernel-reader=false"},
-		)
+		baseFlags := []string{
+			fmt.Sprintf("--file-cache-exclude-regex=^%s/%s/", setup.TestBucket(), onlyDirMounted),
+			"--file-cache-max-size-mb=50",
+			"--file-cache-cache-file-for-range-read=true",
+			"--file-cache-enable-parallel-downloads=false",
+			"--file-cache-enable-o-direct=false",
+			fmt.Sprintf("--cache-dir=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest", setup.TestDir()),
+			fmt.Sprintf("--log-file=%s/gcsfuse-tmp/TestCacheFileForExcludeRegexTest.log", setup.TestDir()),
+			"--log-severity=TRACE",
+			"--enable-kernel-reader=false",
+		}
+		if setup.IsPirloBucketRun() {
+			f1 := append([]string{"--experimental-enable-pirlo"}, baseFlags...)
+			flagsSet = append(flagsSet, f1)
+		} else {
+			f2 := append([]string{"--client-protocol=grpc"}, baseFlags...)
+			flagsSet = append(flagsSet, baseFlags, f2)
+		}
 	}
 	for _, ts.flags = range flagsSet {
 		log.Printf("Running tests with flags: %s", ts.flags)


### PR DESCRIPTION
### **Description**
When running `TestCacheFileForExcludeRegexTest` with `--only-dir` mounted (`setup.OnlyDirMounted() != ""`), the test appends hardcoded flagsets directly rather than reading them from `test_config.yaml`.

For Pirlo bucket runs (`setup.IsPirloBucketRun()`), we need to prepend `--experimental-enable-pirlo` so that mounting succeeds, and omit the duplicate flagset with `--client-protocol=grpc` (as Pirlo does not use `--client-protocol`).

### **Testing details**
1. Manual - Done
2. Unit tests - NA
3. Integration tests - Automated

### **Any backward incompatible change? If so, please explain.**
NA