### PR TITLE
fix(storage): remove forced DP for rapid and standard buckets to allow fallback to CloudPath

### DIFF
--- a/internal/storage/storage_handle.go
+++ b/internal/storage/storage_handle.go
@@ -199,24 +199,11 @@ func createGRPCClientHandle(ctx context.Context, clientConfig *storageutil.Stora
 		return nil, fmt.Errorf("error in getting clientOpts for gRPC client: %w", err)
 	}
 
-	// For non-rapid buckets, add DirectPath enforcement - operations performed via the client will fail if DirectPath is not available.
-	if !isBucketRapid {
-		clientOpts = append(clientOpts, experimental.WithDirectConnectivityEnforced())
-	}
-
 	sc, err := storage.NewGRPCClient(ctx, clientOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("NewGRPCClient: %w", err)
 	}
 
-	// For regional buckets, perform the direct path verification.
-	if !isBucketRapid {
-		if verifyErr := verifyDirectPathConnectivity(ctx, clientConfig, bucketName, sc, billingProject); verifyErr != nil {
-			logger.Warnf("DirectPath verification failed with error: %v", verifyErr)
-			return nil, verifyErr
-		}
-		logger.Infof("DirectPath verification succeeded, continuing with DirectPath.")
-	}
 	setRetryConfig(ctx, sc, clientConfig)
 	return sc, nil
 }

--- a/internal/storage/storage_handle_test.go
+++ b/internal/storage/storage_handle_test.go
@@ -1213,35 +1213,3 @@ func (testSuite *StorageHandleTest) TestBucketHandle_NonHNS_AccessCheck_WithPref
 		testSuite.T().Fatal("Timeout waiting for request")
 	}
 }
-
-func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid() {
-	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
-	// This prevents storage.NewGRPCClient from failing in CI environments (like GitHub Actions)
-	// where Google credentials are not available.
-	testSuite.clientConfig.AnonymousAccess = true
-	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, true, false, "my-bucket", "")
-	defer func() {
-		if client != nil {
-			_ = client.Close()
-		}
-	}()
-
-	// If the bucket is rapid, the method for directpath check is not called, so err should be nil.
-	assert.Nil(testSuite.T(), err)
-	assert.NotNil(testSuite.T(), client)
-}
-
-func (testSuite *StorageHandleTest) TestCreateGRPCClientHandle_DirectPathVerificationForStandard() {
-	// Set AnonymousAccess to true to bypass environment credentials (like GCE ADC).
-	// This ensures the DirectPath verification strictly fails with PermissionDenied
-	// (instead of potentially authenticating and getting a NotFound error which is ignored).
-	// This guarantees test determinism across all execution environments.
-	testSuite.clientConfig.AnonymousAccess = true
-
-	client, err := createGRPCClientHandle(testSuite.ctx, testSuite.clientConfig, false, false, "my-bucket", "")
-
-	// If the bucket is non rapid, the method for directpath check is called, which fails in unit test environment.
-	assert.NotNil(testSuite.T(), err)
-	assert.ErrorContains(testSuite.T(), err, "DirectPath verification failed")
-	assert.Nil(testSuite.T(), client)
-}

--- a/tools/integration_tests/emulator_tests/configs/grpc_header_validation.yaml
+++ b/tools/integration_tests/emulator_tests/configs/grpc_header_validation.yaml
@@ -2,8 +2,5 @@ proxyType: grpc
 targetHost: "localhost:8888"
 headerValidation:
   - headerName: "x-goog-request-params"
-    expectedPattern: "force_direct_connectivity=ENFORCED"
-    failOnMismatch: true
-  - headerName: "x-goog-request-params"
     expectedPattern: "direct_connectivity_diagnostic"
     failOnMismatch: true

--- a/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
+++ b/tools/integration_tests/emulator_tests/grpc_header_validation/grpc_header_validation_test.go
@@ -68,7 +68,6 @@ func (g *grpcHeaderValidation) TestGRPCClientSendsExpectedHeaders() {
 	logStr := string(logContent)
 	assert.Contains(g.T(), logStr, "Metadata validation passed")
 	assert.Contains(g.T(), logStr, "x-goog-request-params")
-	assert.Contains(g.T(), logStr, "force_direct_connectivity=ENFORCED")
 	assert.Contains(g.T(), logStr, "direct_connectivity_diagnostic=no_auth")
 	assert.Contains(g.T(), logStr, "/google.storage.v2.Storage/GetObject")
 }
@@ -96,7 +95,6 @@ func (g *grpcHeaderValidation) TestGRPCHeadersInMultipleOperations() {
 	logStr := string(logContent)
 	validationCount := strings.Count(logStr, "Metadata validation passed")
 	assert.Greater(g.T(), validationCount, 0, "Expected at least one successful metadata validation")
-	assert.Contains(g.T(), logStr, "force_direct_connectivity=ENFORCED")
 	assert.Contains(g.T(), logStr, "direct_connectivity_diagnostic=no_auth")
 	assert.Equal(g.T(), 3, strings.Count(logStr, "/google.storage.v2.Storage/GetObject"), "Expected 3 GetObject calls (1 for each operation)")
 	assert.Equal(g.T(), 1, strings.Count(logStr, "/google.storage.v2.Storage/BidiWriteObject"), "Expected 1 BidiWriteObject call for writing the file")
@@ -107,9 +105,9 @@ func (g *grpcHeaderValidation) TestGRPCHeadersInMultipleOperations() {
 
 func TestGRPCHeaderValidation(t *testing.T) {
 	ts := &grpcHeaderValidation{}
-	// Test with gRPC protocol to validate that DirectPath metadata is sent.
-	// The Go Storage SDK automatically adds force_direct_connectivity=ENFORCED
-	// to x-goog-request-params when experimental.WithDirectConnectivityEnforced() is used.
+	// Test with gRPC protocol to validate that gRPC metadata is sent.
+	// The Go Storage SDK automatically adds diagnostic metadata
+	// to x-goog-request-params.
 	// The gRPC proxy intercepts and validates this metadata.
 	//
 	// NOTE: This test requires:


### PR DESCRIPTION
### Description
- Remove forced DirectPath enforcement (`force_direct_connectivity=ENFORCED`) and mount-time verification probe for rapid and standard buckets, allowing requests to safely fall back to CloudPath when DirectPath is unavailable.
- Remove obsolete DirectPath verification unit tests (`TestCreateGRPCClientHandle_SkipDirectPathVerificationForRapid` and `TestCreateGRPCClientHandle_DirectPathVerificationForStandard`) in `internal/storage/storage_handle_test.go`.
- Update `grpc_header_validation.yaml` and emulator integration test assertions to remove the `force_direct_connectivity=ENFORCED` requirement.

### Link to the issue in case of a bug fix.
b/556501068

### Testing details
1. Manual - NA
2. Unit tests - Passed `go test -v ./internal/storage -run TestStorageHandleTestSuite` (68/68 passed).
3. Integration tests - Verified via `make build` (`go vet`, `golangci-lint`, `go build ./...`).

### Any backward incompatible change? If so, please explain.
No