### PR TITLE
feat(cfg): support flag conditions in bucket-type optimizations

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -226,11 +226,49 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{"file-system.
 			Value: int64(-1),
 		},
 	},
+}, "write.block-size-mb": {
+	BucketTypeOptimization: []shared.BucketTypeOptimization{
+		{
+			BucketTypes: shared.BucketTypeList{
+				"pirlo",
+			},
+			Conditions: map[string]any{
+				"write.enable-rapid-appends": false,
+				"write.enable-rapid-writes":  true,
+			},
+			Value: float64(1),
+		},
+	},
 }, "write.global-max-blocks": {
 	MachineBasedOptimization: []shared.MachineBasedOptimization{
 		{
 			Group: "high-performance",
 			Value: int64(1600),
+		},
+	},
+	BucketTypeOptimization: []shared.BucketTypeOptimization{
+		{
+			BucketTypes: shared.BucketTypeList{
+				"pirlo",
+			},
+			Conditions: map[string]any{
+				"write.enable-rapid-appends": false,
+				"write.enable-rapid-writes":  true,
+			},
+			Value: int64(16),
+		},
+	},
+}, "write.max-blocks-per-file": {
+	BucketTypeOptimization: []shared.BucketTypeOptimization{
+		{
+			BucketTypes: shared.BucketTypeList{
+				"pirlo",
+			},
+			Conditions: map[string]any{
+				"write.enable-rapid-appends": false,
+				"write.enable-rapid-writes":  true,
+			},
+			Value: int64(4),
 		},
 	},
 },
@@ -285,7 +323,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	// Apply optimizations for each flag that has rules defined.
 	if !v.IsSet("file-system.congestion-threshold") {
 		rules := AllFlagOptimizationRules["file-system.congestion-threshold"]
-		result := getOptimizedValue(&rules, c.FileSystem.CongestionThreshold, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.CongestionThreshold, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.CongestionThreshold != val {
@@ -297,7 +335,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.enable-kernel-reader") {
 		rules := AllFlagOptimizationRules["file-system.enable-kernel-reader"]
-		result := getOptimizedValue(&rules, c.FileSystem.EnableKernelReader, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.EnableKernelReader, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(bool); ok {
 				if c.FileSystem.EnableKernelReader != val {
@@ -309,7 +347,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-cache.cache-file-for-range-read") {
 		rules := AllFlagOptimizationRules["file-cache.cache-file-for-range-read"]
-		result := getOptimizedValue(&rules, c.FileCache.CacheFileForRangeRead, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileCache.CacheFileForRangeRead, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(bool); ok {
 				if c.FileCache.CacheFileForRangeRead != val {
@@ -321,7 +359,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("write.finalize-file-for-rapid") {
 		rules := AllFlagOptimizationRules["write.finalize-file-for-rapid"]
-		result := getOptimizedValue(&rules, c.Write.FinalizeFileForRapid, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.Write.FinalizeFileForRapid, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(bool); ok {
 				if c.Write.FinalizeFileForRapid != val {
@@ -333,7 +371,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.fuse-max-request-size-kb") {
 		rules := AllFlagOptimizationRules["file-system.fuse-max-request-size-kb"]
-		result := getOptimizedValue(&rules, c.FileSystem.FuseMaxRequestSizeKb, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.FuseMaxRequestSizeKb, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.FuseMaxRequestSizeKb != val {
@@ -345,7 +383,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("implicit-dirs") {
 		rules := AllFlagOptimizationRules["implicit-dirs"]
-		result := getOptimizedValue(&rules, c.ImplicitDirs, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.ImplicitDirs, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(bool); ok {
 				if c.ImplicitDirs != val {
@@ -357,7 +395,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.kernel-list-cache-ttl-secs") {
 		rules := AllFlagOptimizationRules["file-system.kernel-list-cache-ttl-secs"]
-		result := getOptimizedValue(&rules, c.FileSystem.KernelListCacheTtlSecs, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.KernelListCacheTtlSecs, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.KernelListCacheTtlSecs != val {
@@ -369,7 +407,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.max-background") {
 		rules := AllFlagOptimizationRules["file-system.max-background"]
-		result := getOptimizedValue(&rules, c.FileSystem.MaxBackground, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.MaxBackground, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.MaxBackground != val {
@@ -381,7 +419,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.max-read-ahead-kb") {
 		rules := AllFlagOptimizationRules["file-system.max-read-ahead-kb"]
-		result := getOptimizedValue(&rules, c.FileSystem.MaxReadAheadKb, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.MaxReadAheadKb, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.MaxReadAheadKb != val {
@@ -393,7 +431,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("metadata-cache.negative-ttl-secs") {
 		rules := AllFlagOptimizationRules["metadata-cache.negative-ttl-secs"]
-		result := getOptimizedValue(&rules, c.MetadataCache.NegativeTtlSecs, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.MetadataCache.NegativeTtlSecs, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.MetadataCache.NegativeTtlSecs != val {
@@ -405,7 +443,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("metadata-cache.ttl-secs") {
 		rules := AllFlagOptimizationRules["metadata-cache.ttl-secs"]
-		result := getOptimizedValue(&rules, c.MetadataCache.TtlSecs, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.MetadataCache.TtlSecs, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.MetadataCache.TtlSecs != val {
@@ -417,7 +455,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("file-system.rename-dir-limit") {
 		rules := AllFlagOptimizationRules["file-system.rename-dir-limit"]
-		result := getOptimizedValue(&rules, c.FileSystem.RenameDirLimit, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.FileSystem.RenameDirLimit, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.FileSystem.RenameDirLimit != val {
@@ -429,7 +467,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 	}
 	if !v.IsSet("metadata-cache.stat-cache-max-size-mb") {
 		rules := AllFlagOptimizationRules["metadata-cache.stat-cache-max-size-mb"]
-		result := getOptimizedValue(&rules, c.MetadataCache.StatCacheMaxSizeMb, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.MetadataCache.StatCacheMaxSizeMb, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.MetadataCache.StatCacheMaxSizeMb != val {
@@ -439,14 +477,38 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 			}
 		}
 	}
+	if !v.IsSet("write.block-size-mb") {
+		rules := AllFlagOptimizationRules["write.block-size-mb"]
+		result := getOptimizedValue(&rules, c.Write.BlockSizeMb, profileName, machineType, input, machineTypeToGroupMap, c)
+		if result.Optimized {
+			if val, ok := result.FinalValue.(float64); ok {
+				if c.Write.BlockSizeMb != val {
+					c.Write.BlockSizeMb = val
+					optimizedFlags["write.block-size-mb"] = result
+				}
+			}
+		}
+	}
 	if !v.IsSet("write.global-max-blocks") {
 		rules := AllFlagOptimizationRules["write.global-max-blocks"]
-		result := getOptimizedValue(&rules, c.Write.GlobalMaxBlocks, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.Write.GlobalMaxBlocks, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.(int64); ok {
 				if c.Write.GlobalMaxBlocks != val {
 					c.Write.GlobalMaxBlocks = val
 					optimizedFlags["write.global-max-blocks"] = result
+				}
+			}
+		}
+	}
+	if !v.IsSet("write.max-blocks-per-file") {
+		rules := AllFlagOptimizationRules["write.max-blocks-per-file"]
+		result := getOptimizedValue(&rules, c.Write.MaxBlocksPerFile, profileName, machineType, input, machineTypeToGroupMap, c)
+		if result.Optimized {
+			if val, ok := result.FinalValue.(int64); ok {
+				if c.Write.MaxBlocksPerFile != val {
+					c.Write.MaxBlocksPerFile = val
+					optimizedFlags["write.max-blocks-per-file"] = result
 				}
 			}
 		}

--- a/cfg/config_test.go
+++ b/cfg/config_test.go
@@ -29,6 +29,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -93,6 +94,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.CongestionThreshold = tc.expectedValue.(int64)
@@ -122,6 +126,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -170,6 +175,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.EnableKernelReader = tc.expectedValue.(bool)
@@ -199,6 +207,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -249,6 +258,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileCache.CacheFileForRangeRead = tc.expectedValue.(bool)
@@ -278,6 +290,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -326,6 +339,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.Write.FinalizeFileForRapid = tc.expectedValue.(bool)
@@ -355,6 +371,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -403,6 +420,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.FuseMaxRequestSizeKb = tc.expectedValue.(int64)
@@ -432,6 +452,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -519,6 +540,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.ImplicitDirs = tc.expectedValue.(bool)
@@ -548,6 +572,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -590,6 +615,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.KernelListCacheTtlSecs = tc.expectedValue.(int64)
@@ -619,6 +647,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -683,6 +712,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.MaxBackground = tc.expectedValue.(int64)
@@ -712,6 +744,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -776,6 +809,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.MaxReadAheadKb = tc.expectedValue.(int64)
@@ -805,6 +841,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -892,6 +929,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.MetadataCache.NegativeTtlSecs = tc.expectedValue.(int64)
@@ -921,6 +961,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -1008,6 +1049,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.MetadataCache.TtlSecs = tc.expectedValue.(int64)
@@ -1037,6 +1081,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -1117,6 +1162,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.FileSystem.RenameDirLimit = tc.expectedValue.(int64)
@@ -1146,6 +1194,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -1233,6 +1282,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.MetadataCache.StatCacheMaxSizeMb = tc.expectedValue.(int64)
@@ -1257,11 +1309,93 @@ func TestApplyOptimizations(t *testing.T) {
 			})
 		}
 	})
+	// Tests for write.block-size-mb
+	t.Run("write.block-size-mb", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			config          Config
+			conditions      map[string]any
+			userSetFlags    map[string]any
+			input           *OptimizationInput
+			expectOptimized bool
+			expectedValue   any
+		}{
+			{
+				name:   "user_set",
+				config: Config{},
+				userSetFlags: map[string]any{
+					"write.block-size-mb": 32 + 1.23,
+					"machine-type":        "a2-megagpu-16g",
+				},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: false,
+				expectedValue:   32 + 1.23,
+			},
+			{
+				name:   "no_optimization",
+				config: Config{Profile: "non_existent_profile"},
+				userSetFlags: map[string]any{
+					"machine-type": "low-end-machine",
+				},
+				input:           nil,
+				expectOptimized: false,
+				expectedValue:   32,
+			},
+			{
+				name:   "bucket_type_pirlo",
+				config: Config{Profile: ""},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   1,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// We need a copy of the config for each test case.
+				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
+				// Set the default or non-default value on the config object.
+				if tc.name == "user_set" {
+					c.Write.BlockSizeMb = tc.expectedValue.(float64)
+				} else {
+					c.Write.BlockSizeMb = float64(32)
+				}
+
+				v := viper.New()
+				for key, val := range tc.userSetFlags {
+					v.Set(key, val)
+				}
+
+				optimizedFlags := c.ApplyOptimizations(v, tc.input)
+
+				if tc.expectOptimized {
+					assert.Contains(t, optimizedFlags, "write.block-size-mb")
+				} else {
+					assert.NotContains(t, optimizedFlags, "write.block-size-mb")
+				}
+				// Use EqualValues to handle the int vs int64 type mismatch for default values.
+				assert.EqualValues(t, tc.expectedValue, c.Write.BlockSizeMb)
+			})
+		}
+	})
 	// Tests for write.global-max-blocks
 	t.Run("write.global-max-blocks", func(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -1274,7 +1408,11 @@ func TestApplyOptimizations(t *testing.T) {
 					"write.global-max-blocks": 98765,
 					"machine-type":            "a2-megagpu-16g",
 				},
-				input:           nil,
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
 				expectOptimized: false,
 				expectedValue:   int64(98765),
 			},
@@ -1295,6 +1433,32 @@ func TestApplyOptimizations(t *testing.T) {
 					"machine-type": "a2-megagpu-16g",
 				},
 				input:           nil,
+				expectOptimized: true,
+				expectedValue:   1600,
+			},
+			{
+				name:   "bucket_type_pirlo",
+				config: Config{Profile: ""},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   16,
+			},
+			{
+				name:   "machine_type_overrides_bucket_type",
+				config: Config{Profile: ""},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				userSetFlags: map[string]any{
+					"machine-type": "a2-megagpu-16g",
+				},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
 				expectOptimized: true,
 				expectedValue:   1600,
 			}, {
@@ -1322,6 +1486,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.Write.GlobalMaxBlocks = tc.expectedValue.(int64)
@@ -1343,6 +1510,87 @@ func TestApplyOptimizations(t *testing.T) {
 				}
 				// Use EqualValues to handle the int vs int64 type mismatch for default values.
 				assert.EqualValues(t, tc.expectedValue, c.Write.GlobalMaxBlocks)
+			})
+		}
+	})
+	// Tests for write.max-blocks-per-file
+	t.Run("write.max-blocks-per-file", func(t *testing.T) {
+		testCases := []struct {
+			name            string
+			config          Config
+			conditions      map[string]any
+			userSetFlags    map[string]any
+			input           *OptimizationInput
+			expectOptimized bool
+			expectedValue   any
+		}{
+			{
+				name:   "user_set",
+				config: Config{},
+				userSetFlags: map[string]any{
+					"write.max-blocks-per-file": 98765,
+					"machine-type":              "a2-megagpu-16g",
+				},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: false,
+				expectedValue:   int64(98765),
+			},
+			{
+				name:   "no_optimization",
+				config: Config{Profile: "non_existent_profile"},
+				userSetFlags: map[string]any{
+					"machine-type": "low-end-machine",
+				},
+				input:           nil,
+				expectOptimized: false,
+				expectedValue:   1,
+			},
+			{
+				name:   "bucket_type_pirlo",
+				config: Config{Profile: ""},
+				conditions: map[string]any{
+					"write.enable-rapid-appends": false,
+					"write.enable-rapid-writes":  true,
+				},
+				userSetFlags:    map[string]any{},
+				input:           &OptimizationInput{BucketType: BucketTypePirlo},
+				expectOptimized: true,
+				expectedValue:   4,
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				// We need a copy of the config for each test case.
+				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
+				// Set the default or non-default value on the config object.
+				if tc.name == "user_set" {
+					c.Write.MaxBlocksPerFile = tc.expectedValue.(int64)
+				} else {
+					c.Write.MaxBlocksPerFile = int64(1)
+				}
+
+				v := viper.New()
+				for key, val := range tc.userSetFlags {
+					v.Set(key, val)
+				}
+
+				optimizedFlags := c.ApplyOptimizations(v, tc.input)
+
+				if tc.expectOptimized {
+					assert.Contains(t, optimizedFlags, "write.max-blocks-per-file")
+				} else {
+					assert.NotContains(t, optimizedFlags, "write.max-blocks-per-file")
+				}
+				// Use EqualValues to handle the int vs int64 type mismatch for default values.
+				assert.EqualValues(t, tc.expectedValue, c.Write.MaxBlocksPerFile)
 			})
 		}
 	})

--- a/cfg/optimize.go
+++ b/cfg/optimize.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"reflect"
 	"slices"
 	"strings"
 	"time"
@@ -131,6 +132,7 @@ func getOptimizedValue(
 	machineType string,
 	input *OptimizationInput,
 	machineTypeToGroupMap map[string]string,
+	c *Config,
 ) OptimizationResult {
 	// Precedence: Profile -> Machine-type -> Bucket-type -> Default
 	// Assuming Machine and Bucket optimizations are applied on mutually exclusive flags, so
@@ -164,10 +166,14 @@ func getOptimizedValue(
 	if input != nil && input.BucketType.IsValid() {
 		for _, bto := range rules.BucketTypeOptimization {
 			for _, bt := range bto.BucketTypes {
-				if BucketType(bt) == input.BucketType {
+				if BucketType(bt) == input.BucketType && matchesConditions(c, bto.Conditions) {
+					reason := fmt.Sprintf("bucket-type %q", input.BucketType)
+					if len(bto.Conditions) > 0 {
+						reason = fmt.Sprintf("bucket-type %q with matching conditions", input.BucketType)
+					}
 					return OptimizationResult{
 						FinalValue:         bto.Value,
-						OptimizationReason: fmt.Sprintf("bucket-type %q", input.BucketType),
+						OptimizationReason: reason,
 						Optimized:          true,
 					}
 				}
@@ -180,6 +186,188 @@ func getOptimizedValue(
 		FinalValue: currentValue,
 		Optimized:  false,
 	}
+}
+
+// matchesConditions checks if the current config satisfies all the given conditions.
+// If conditions is empty or nil, it returns true.
+func matchesConditions(c *Config, conditions map[string]any) bool {
+	if len(conditions) == 0 {
+		return true
+	}
+	if c == nil {
+		return false
+	}
+	for path, expectedVal := range conditions {
+		actualVal, ok := getConfigValueByPath(c, path)
+		if !ok || !valuesMatch(actualVal, expectedVal) {
+			return false
+		}
+	}
+	return true
+}
+
+// getConfigValueByPath traverses a struct by yaml tags corresponding to the dot-separated path.
+func getConfigValueByPath(config any, path string) (any, bool) {
+	if config == nil || path == "" {
+		return nil, false
+	}
+	parts := strings.Split(path, ".")
+	curr := reflect.ValueOf(config)
+	for curr.Kind() == reflect.Pointer || curr.Kind() == reflect.Interface {
+		if curr.IsNil() {
+			return nil, false
+		}
+		curr = curr.Elem()
+	}
+
+	for _, part := range parts {
+		if curr.Kind() != reflect.Struct {
+			return nil, false
+		}
+		found := false
+		currType := curr.Type()
+		for i := 0; i < curr.NumField(); i++ {
+			field := currType.Field(i)
+			tag := field.Tag.Get("yaml")
+			tagName := strings.Split(tag, ",")[0]
+			if tagName == part {
+				curr = curr.Field(i)
+				for curr.Kind() == reflect.Pointer || curr.Kind() == reflect.Interface {
+					if curr.IsNil() {
+						return nil, false
+					}
+					curr = curr.Elem()
+				}
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, false
+		}
+	}
+	if !curr.CanInterface() {
+		return nil, false
+	}
+	return curr.Interface(), true
+}
+
+// setConfigValueByPath sets a field on a struct pointer by traversing yaml tags.
+func setConfigValueByPath(config any, path string, val any) error {
+	if config == nil || path == "" {
+		return fmt.Errorf("invalid config or path")
+	}
+	curr := reflect.ValueOf(config)
+	if curr.Kind() != reflect.Pointer || curr.IsNil() {
+		return fmt.Errorf("config must be a non-nil pointer")
+	}
+	curr = curr.Elem()
+
+	parts := strings.Split(path, ".")
+	for i, part := range parts {
+		for curr.Kind() == reflect.Pointer || curr.Kind() == reflect.Interface {
+			if curr.IsNil() {
+				return fmt.Errorf("nil pointer at %s", part)
+			}
+			curr = curr.Elem()
+		}
+		if curr.Kind() != reflect.Struct {
+			return fmt.Errorf("expected struct at %s", part)
+		}
+		found := false
+		currType := curr.Type()
+		for j := 0; j < curr.NumField(); j++ {
+			field := currType.Field(j)
+			tag := field.Tag.Get("yaml")
+			tagName := strings.Split(tag, ",")[0]
+			if tagName == part {
+				fieldVal := curr.Field(j)
+				if i == len(parts)-1 {
+					if !fieldVal.CanSet() {
+						return fmt.Errorf("cannot set field %s", field.Name)
+					}
+					valToSet := reflect.ValueOf(val)
+					if !valToSet.IsValid() {
+						return fmt.Errorf("invalid value to set")
+					}
+					if valToSet.Type().ConvertibleTo(fieldVal.Type()) {
+						fieldVal.Set(valToSet.Convert(fieldVal.Type()))
+					} else {
+						fieldVal.Set(valToSet)
+					}
+					return nil
+				}
+				curr = fieldVal
+				found = true
+				break
+			}
+		}
+		if !found {
+			return fmt.Errorf("field %s not found in path %s", part, path)
+		}
+	}
+	return nil
+}
+
+func isIntKind(k reflect.Kind) bool {
+	return k >= reflect.Int && k <= reflect.Int64
+}
+
+func isUintKind(k reflect.Kind) bool {
+	return k >= reflect.Uint && k <= reflect.Uint64
+}
+
+func isFloatKind(k reflect.Kind) bool {
+	return k == reflect.Float32 || k == reflect.Float64
+}
+
+// valuesMatch compares two values, allowing for type flexibility between integers and floats.
+func valuesMatch(actual, expected any) bool {
+	if reflect.DeepEqual(actual, expected) {
+		return true
+	}
+	actualVal := reflect.ValueOf(actual)
+	expectedVal := reflect.ValueOf(expected)
+	if !actualVal.IsValid() || !expectedVal.IsValid() {
+		return false
+	}
+
+	if actualVal.Kind() == reflect.Bool && expectedVal.Kind() == reflect.Bool {
+		return actualVal.Bool() == expectedVal.Bool()
+	}
+	if actualVal.Kind() == reflect.String && expectedVal.Kind() == reflect.String {
+		return actualVal.String() == expectedVal.String()
+	}
+
+	if isIntKind(actualVal.Kind()) && isIntKind(expectedVal.Kind()) {
+		return actualVal.Int() == expectedVal.Int()
+	}
+	if isUintKind(actualVal.Kind()) && isUintKind(expectedVal.Kind()) {
+		return actualVal.Uint() == expectedVal.Uint()
+	}
+	if isFloatKind(actualVal.Kind()) && isFloatKind(expectedVal.Kind()) {
+		return actualVal.Float() == expectedVal.Float()
+	}
+	if isIntKind(actualVal.Kind()) && isUintKind(expectedVal.Kind()) {
+		return actualVal.Int() >= 0 && uint64(actualVal.Int()) == expectedVal.Uint()
+	}
+	if isUintKind(actualVal.Kind()) && isIntKind(expectedVal.Kind()) {
+		return expectedVal.Int() >= 0 && actualVal.Uint() == uint64(expectedVal.Int())
+	}
+	if isIntKind(actualVal.Kind()) && isFloatKind(expectedVal.Kind()) {
+		return float64(actualVal.Int()) == expectedVal.Float()
+	}
+	if isFloatKind(actualVal.Kind()) && isIntKind(expectedVal.Kind()) {
+		return actualVal.Float() == float64(expectedVal.Int())
+	}
+	if isUintKind(actualVal.Kind()) && isFloatKind(expectedVal.Kind()) {
+		return float64(actualVal.Uint()) == expectedVal.Float()
+	}
+	if isFloatKind(actualVal.Kind()) && isUintKind(expectedVal.Kind()) {
+		return actualVal.Float() == float64(expectedVal.Uint())
+	}
+
+	return false
 }
 
 // CreateHierarchicalOptimizedFlags converts a flat map with dot-separated keys

--- a/cfg/optimize_test.go
+++ b/cfg/optimize_test.go
@@ -287,6 +287,198 @@ func TestApplyOptimizations_Success(t *testing.T) {
 	assert.EqualValues(t, 200000, cfg.FileSystem.RenameDirLimit)
 }
 
+func TestApplyOptimizations_ConditionalBucketType_PirloWithConditions(t *testing.T) {
+	t.Run("Conditions_Met_Optimizes_Write_Params", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		assert.Contains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 1.0, cfg.Write.BlockSizeMb)
+		assert.Equal(t, `bucket-type "pirlo" with matching conditions`, optimizedFlags["write.block-size-mb"].OptimizationReason)
+
+		assert.Contains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 4, cfg.Write.MaxBlocksPerFile)
+		assert.Equal(t, `bucket-type "pirlo" with matching conditions`, optimizedFlags["write.max-blocks-per-file"].OptimizationReason)
+
+		assert.Contains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 16, cfg.Write.GlobalMaxBlocks)
+		assert.Equal(t, `bucket-type "pirlo" with matching conditions`, optimizedFlags["write.global-max-blocks"].OptimizationReason)
+	})
+
+	t.Run("Conditions_Not_Met_RapidWrites_False", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = false
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		assert.NotContains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 32, cfg.Write.BlockSizeMb)
+		assert.NotContains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 1, cfg.Write.MaxBlocksPerFile)
+		assert.NotContains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 4, cfg.Write.GlobalMaxBlocks)
+	})
+
+	t.Run("Conditions_Not_Met_RapidAppends_True", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = true
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		assert.NotContains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 32, cfg.Write.BlockSizeMb)
+		assert.NotContains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 1, cfg.Write.MaxBlocksPerFile)
+		assert.NotContains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 4, cfg.Write.GlobalMaxBlocks)
+	})
+
+	t.Run("Non_Pirlo_Bucket_No_Optimization", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypeZonal})
+
+		assert.NotContains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 32, cfg.Write.BlockSizeMb)
+		assert.NotContains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 1, cfg.Write.MaxBlocksPerFile)
+		assert.NotContains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 4, cfg.Write.GlobalMaxBlocks)
+	})
+
+	t.Run("User_Set_Flag_Takes_Precedence", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 8.0
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		v.Set("write.block-size-mb", 8.0)
+
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		assert.NotContains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 8.0, cfg.Write.BlockSizeMb)
+		// Other flags should still be optimized
+		assert.Contains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 4, cfg.Write.MaxBlocksPerFile)
+		assert.Contains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 16, cfg.Write.GlobalMaxBlocks)
+	})
+
+	t.Run("DisableAutoconfig_Skips_Optimization", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.DisableAutoconfig = true
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		assert.Empty(t, optimizedFlags)
+		assert.EqualValues(t, 32, cfg.Write.BlockSizeMb)
+		assert.EqualValues(t, 1, cfg.Write.MaxBlocksPerFile)
+		assert.EqualValues(t, 4, cfg.Write.GlobalMaxBlocks)
+	})
+
+	t.Run("High_Performance_Machine_Precedence_For_GlobalMaxBlocks", func(t *testing.T) {
+		cfg := defaultConfig()
+		cfg.Write.EnableRapidWrites = true
+		cfg.Write.EnableRapidAppends = false
+		cfg.Write.BlockSizeMb = 32
+		cfg.Write.MaxBlocksPerFile = 1
+		cfg.Write.GlobalMaxBlocks = 4
+
+		v := viper.New()
+		v.Set("machine-type", "a3-highgpu-8g")
+
+		optimizedFlags := cfg.ApplyOptimizations(v, &OptimizationInput{BucketType: BucketTypePirlo})
+
+		// Machine-type optimization takes precedence for global-max-blocks: 1600 instead of 16
+		assert.Contains(t, optimizedFlags, "write.global-max-blocks")
+		assert.EqualValues(t, 1600, cfg.Write.GlobalMaxBlocks)
+		assert.Equal(t, `machine-type group "high-performance"`, optimizedFlags["write.global-max-blocks"].OptimizationReason)
+
+		// Bucket-type optimizations still apply to the other write parameters
+		assert.Contains(t, optimizedFlags, "write.block-size-mb")
+		assert.EqualValues(t, 1.0, cfg.Write.BlockSizeMb)
+		assert.Contains(t, optimizedFlags, "write.max-blocks-per-file")
+		assert.EqualValues(t, 4, cfg.Write.MaxBlocksPerFile)
+	})
+}
+
+func TestGetAndSetConfigValueByPath(t *testing.T) {
+	cfg := defaultConfig()
+
+	// Test getConfigValueByPath
+	val, ok := getConfigValueByPath(&cfg, "write.enable-streaming-writes")
+	assert.True(t, ok)
+	assert.Equal(t, true, val)
+
+	val, ok = getConfigValueByPath(&cfg, "non.existent.path")
+	assert.False(t, ok)
+	assert.Nil(t, val)
+
+	// Test setConfigValueByPath
+	err := setConfigValueByPath(&cfg, "write.block-size-mb", 64.0)
+	assert.NoError(t, err)
+	assert.Equal(t, 64.0, cfg.Write.BlockSizeMb)
+
+	err = setConfigValueByPath(&cfg, "write.global-max-blocks", int64(100))
+	assert.NoError(t, err)
+	assert.EqualValues(t, 100, cfg.Write.GlobalMaxBlocks)
+
+	err = setConfigValueByPath(&cfg, "non.existent.path", true)
+	assert.Error(t, err)
+}
+
+func TestValuesMatch(t *testing.T) {
+	assert.True(t, valuesMatch(true, true))
+	assert.True(t, valuesMatch(false, false))
+	assert.False(t, valuesMatch(true, false))
+
+	assert.True(t, valuesMatch("hello", "hello"))
+	assert.False(t, valuesMatch("hello", "world"))
+
+	// Cross-type numeric comparisons
+	assert.True(t, valuesMatch(int(10), int64(10)))
+	assert.True(t, valuesMatch(int64(10), int(10)))
+	assert.True(t, valuesMatch(float64(1.0), int(1)))
+	assert.True(t, valuesMatch(int(1), float64(1.0)))
+	assert.True(t, valuesMatch(uint(5), int64(5)))
+	assert.True(t, valuesMatch(int64(5), uint(5)))
+	assert.False(t, valuesMatch(int(-5), uint(5)))
+	assert.False(t, valuesMatch(int(10), int(20)))
+}
+
 func TestCreateHierarchicalOptimizedFlags_Positive(t *testing.T) {
 	testCases := []struct {
 		name     string

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -1509,6 +1509,13 @@ params:
       requirements.
     default: 32
     hide-flag: true
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: "pirlo"
+          conditions:
+            write.enable-rapid-writes: true
+            write.enable-rapid-appends: false
+          value: 1.0
 
   - config-path: "write.create-empty-file"
     proto-tag: 152
@@ -1566,6 +1573,12 @@ params:
       machine-based-optimization:
         - group: "high-performance"
           value: 1600
+      bucket-type-optimization:
+        - bucket-type: "pirlo"
+          conditions:
+            write.enable-rapid-writes: true
+            write.enable-rapid-appends: false
+          value: 16
 
   - config-path: "write.max-blocks-per-file"
     proto-tag: 158
@@ -1576,6 +1589,13 @@ params:
       streaming writes. The value should be >= 1 or -1 (for infinite blocks).
     default: 1
     hide-flag: true
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: "pirlo"
+          conditions:
+            write.enable-rapid-writes: true
+            write.enable-rapid-appends: false
+          value: 4
 
   - flag-name: "debug_fs"
     type: "bool"

--- a/cfg/shared/types.go
+++ b/cfg/shared/types.go
@@ -55,6 +55,7 @@ type MachineBasedOptimization struct {
 // BucketTypeOptimization defines a bucket-type-based optimization.
 type BucketTypeOptimization struct {
 	BucketTypes BucketTypeList `yaml:"bucket-type"`
+	Conditions  map[string]any `yaml:"conditions,omitempty"`
 	Value       any            `yaml:"value"`
 }
 

--- a/cfg/shared/types_test.go
+++ b/cfg/shared/types_test.go
@@ -82,3 +82,22 @@ func TestBucketTypeListUnmarshalYAMLErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestBucketTypeOptimizationWithConditionsUnmarshalYAML(t *testing.T) {
+	yamlStr := `
+bucket-type: "pirlo"
+conditions:
+  write.enable-rapid-writes: true
+  write.enable-rapid-appends: false
+value: 1.0
+`
+	var bto BucketTypeOptimization
+	err := yaml.Unmarshal([]byte(yamlStr), &bto)
+	require.NoError(t, err)
+	assert.Equal(t, BucketTypeList{"pirlo"}, bto.BucketTypes)
+	assert.Equal(t, map[string]any{
+		"write.enable-rapid-writes":  true,
+		"write.enable-rapid-appends": false,
+	}, bto.Conditions)
+	assert.Equal(t, 1.0, bto.Value)
+}

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -282,6 +282,7 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 				if err := cfg.Rationalize(serverCfg.ViperConfig, serverCfg.NewConfig, optimizedFlagNames); err != nil {
 					logger.Warnf("GCSFuse Config: error in rationalize after applying bucket-type optimizations: %v", err)
 				}
+				fs.globalMaxWriteBlocksSem = semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks)
 			}
 		} else {
 			logger.Warnf("Cannot apply bucket-type optimizations as ViperConfig is nil")

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -282,6 +282,9 @@ func NewFileSystem(ctx context.Context, serverCfg *ServerConfig) (fuseutil.FileS
 				if err := cfg.Rationalize(serverCfg.ViperConfig, serverCfg.NewConfig, optimizedFlagNames); err != nil {
 					logger.Warnf("GCSFuse Config: error in rationalize after applying bucket-type optimizations: %v", err)
 				}
+				// Re-initialize the write blocks semaphore since ApplyOptimizations/Rationalize
+				// may have updated Write.GlobalMaxBlocks (e.g. for Pirlo bucket optimizations),
+				// overriding the initial value assigned during fileSystem struct initialization.
 				fs.globalMaxWriteBlocksSem = semaphore.NewWeighted(serverCfg.NewConfig.Write.GlobalMaxBlocks)
 			}
 		} else {

--- a/tools/config-gen/main.go
+++ b/tools/config-gen/main.go
@@ -77,8 +77,9 @@ func write(dataObj any, outputFile, templateFile string) (err error) {
 	}()
 	// Define the custom function map.
 	funcMap := template.FuncMap{
-		"formatValue": formatValue,
-		"title":       cases.Title(language.English).String,
+		"formatValue":   formatValue,
+		"sortedMapKeys": sortedMapKeys,
+		"title":         cases.Title(language.English).String,
 	}
 
 	file := path.Base(templateFile)
@@ -174,4 +175,17 @@ func formatValue(v any) string {
 		// Use %v for other types like int, bool, etc.
 		return fmt.Sprintf("%v", v)
 	}
+}
+
+// sortedMapKeys returns the keys of a map sorted alphabetically for deterministic code generation.
+func sortedMapKeys(m map[string]any) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	return keys
 }

--- a/tools/config-gen/parser.go
+++ b/tools/config-gen/parser.go
@@ -199,10 +199,24 @@ func validateParam(param Param) error {
 					return fmt.Errorf("invalid bucket-type %q for flag %s; must be one of: %v",
 						bt, param.FlagName, validBucketTypes)
 				}
-				if seenBucketTypes[bt] {
-					return fmt.Errorf("duplicate bucket-type %q for flag %s", bt, param.FlagName)
+				ruleKey := bt
+				if len(bto.Conditions) > 0 {
+					var condKeys []string
+					for k := range bto.Conditions {
+						condKeys = append(condKeys, k)
+					}
+					slices.Sort(condKeys)
+					var b strings.Builder
+					b.WriteString(bt)
+					for _, k := range condKeys {
+						fmt.Fprintf(&b, ";%s=%v", k, bto.Conditions[k])
+					}
+					ruleKey = b.String()
 				}
-				seenBucketTypes[bt] = true
+				if seenBucketTypes[ruleKey] {
+					return fmt.Errorf("duplicate bucket-type %q for flag %s", ruleKey, param.FlagName)
+				}
+				seenBucketTypes[ruleKey] = true
 			}
 		}
 	}
@@ -235,10 +249,25 @@ func validateParams(params []Param) error {
 	if err := validateForDuplicates(params, func(param Param) string { return param.ConfigPath }); err != nil {
 		return fmt.Errorf("duplicate config-paths found: %w", err)
 	}
+	knownConfigPaths := make(map[string]bool, len(params))
+	for _, p := range params {
+		if p.ConfigPath != "" {
+			knownConfigPaths[p.ConfigPath] = true
+		}
+	}
 	for _, param := range params {
 		err := validateParam(param)
 		if err != nil {
 			return err
+		}
+		if param.Optimizations != nil {
+			for _, bto := range param.Optimizations.BucketTypeOptimization {
+				for k := range bto.Conditions {
+					if !knownConfigPaths[k] {
+						return fmt.Errorf("unknown condition config-path %q in optimization for flag %s", k, param.FlagName)
+					}
+				}
+			}
 		}
 	}
 	return nil

--- a/tools/config-gen/parser_test.go
+++ b/tools/config-gen/parser_test.go
@@ -603,6 +603,48 @@ params:
 `,
 			expectedErrorSubstring: "bucket-type list is empty",
 		},
+		{
+			name: "UnknownConditionConfigPath",
+			yamlContent: `
+params:
+  - config-path: "test-param"
+    proto-tag: 1
+    flag-name: "test-flag"
+    type: "bool"
+    default: false
+    usage: "Test flag"
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: "pirlo"
+          conditions:
+            unknown.config.path: true
+          value: true
+`,
+			expectedErrorSubstring: "unknown condition config-path \"unknown.config.path\"",
+		},
+		{
+			name: "DuplicateBucketTypeWithSameConditions",
+			yamlContent: `
+params:
+  - config-path: "test-param"
+    proto-tag: 1
+    flag-name: "test-flag"
+    type: "bool"
+    default: false
+    usage: "Test flag"
+    optimizations:
+      bucket-type-optimization:
+        - bucket-type: "pirlo"
+          conditions:
+            test-param: true
+          value: true
+        - bucket-type: "pirlo"
+          conditions:
+            test-param: true
+          value: false
+`,
+			expectedErrorSubstring: "duplicate bucket-type \"pirlo;test-param=true\"",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/tools/config-gen/templates/config.tpl
+++ b/tools/config-gen/templates/config.tpl
@@ -42,14 +42,21 @@ var AllFlagOptimizationRules = map[string]shared.OptimizationRules{
 		{{- end }}
 		{{- if .Optimizations.BucketTypeOptimization }}
 		BucketTypeOptimization: []shared.BucketTypeOptimization{
-			{{- range .Optimizations.BucketTypeOptimization }}
+			{{- range $bto := .Optimizations.BucketTypeOptimization }}
 			{
 				BucketTypes: shared.BucketTypeList{
-					{{- range .BucketTypes }}
+					{{- range $bto.BucketTypes }}
 					"{{ . }}",
 					{{- end }}
 				},
-				Value:      {{$goType}}({{ formatValue .Value }}),
+				{{- if $bto.Conditions }}
+				Conditions: map[string]any{
+					{{- range $k := sortedMapKeys $bto.Conditions }}
+					"{{ $k }}": {{ formatValue (index $bto.Conditions $k) }},
+					{{- end }}
+				},
+				{{- end }}
+				Value:      {{$goType}}({{ formatValue $bto.Value }}),
 			},
 			{{- end }}
 		},
@@ -99,7 +106,7 @@ func (c *Config) ApplyOptimizations(v *viper.Viper, input *OptimizationInput) ma
 {{- if .Optimizations }}
 	if !v.IsSet("{{ .ConfigPath }}") {
 		rules := AllFlagOptimizationRules["{{ .ConfigPath }}"]
-		result := getOptimizedValue(&rules, c.{{ .GoPath }}, profileName, machineType, input, machineTypeToGroupMap)
+		result := getOptimizedValue(&rules, c.{{ .GoPath }}, profileName, machineType, input, machineTypeToGroupMap, c)
 		if result.Optimized {
 			if val, ok := result.FinalValue.({{ .GoType }}); ok {
 				if c.{{ .GoPath }} != val {

--- a/tools/config-gen/templates/config_test.tpl
+++ b/tools/config-gen/templates/config_test.tpl
@@ -32,6 +32,7 @@ func TestApplyOptimizations(t *testing.T) {
 		testCases := []struct {
 			name            string
 			config          Config
+			conditions      map[string]any
 			userSetFlags    map[string]any
 			input           *OptimizationInput
 			expectOptimized bool
@@ -63,6 +64,13 @@ func TestApplyOptimizations(t *testing.T) {
 				{{- if .Optimizations.BucketTypeOptimization }}
 				{{- $bto := index .Optimizations.BucketTypeOptimization 0 }}
 				{{- $bt := index $bto.BucketTypes 0 }}
+				{{- if $bto.Conditions }}
+				conditions: map[string]any{
+					{{- range $k := sortedMapKeys $bto.Conditions }}
+					"{{ $k }}": {{ formatValue (index $bto.Conditions $k) }},
+					{{- end }}
+				},
+				{{- end }}
 				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				{{- else }}
 				input:           nil,
@@ -117,6 +125,13 @@ func TestApplyOptimizations(t *testing.T) {
 			{
 				name:   "bucket_type_{{$bt}}",
 				config: Config{Profile: ""},
+				{{- if $bto.Conditions }}
+				conditions: map[string]any{
+					{{- range $k := sortedMapKeys $bto.Conditions }}
+					"{{ $k }}": {{ formatValue (index $bto.Conditions $k) }},
+					{{- end }}
+				},
+				{{- end }}
 				userSetFlags: map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				expectOptimized: {{if ne (printf "%v" $bto.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
@@ -146,6 +161,13 @@ func TestApplyOptimizations(t *testing.T) {
 			{
 				name:   "profile_overrides_bucket_type",
 				config: Config{Profile: "{{$profile.Name}}"},
+				{{- if $bto.Conditions }}
+				conditions: map[string]any{
+					{{- range $k := sortedMapKeys $bto.Conditions }}
+					"{{ $k }}": {{ formatValue (index $bto.Conditions $k) }},
+					{{- end }}
+				},
+				{{- end }}
 				userSetFlags: map[string]any{},
 				input:           &OptimizationInput{BucketType: BucketType{{ $bt | title }}},
 				expectOptimized: {{if ne (printf "%v" $profile.Value) (printf "%v" $flag.DefaultValue)}}true{{else}}false{{end}},
@@ -160,6 +182,13 @@ func TestApplyOptimizations(t *testing.T) {
 			{
 				name:   "machine_type_overrides_bucket_type",
 				config: Config{Profile: ""},
+				{{- if $bto.Conditions }}
+				conditions: map[string]any{
+					{{- range $k := sortedMapKeys $bto.Conditions }}
+					"{{ $k }}": {{ formatValue (index $bto.Conditions $k) }},
+					{{- end }}
+				},
+				{{- end }}
 				userSetFlags: map[string]any{
 					"machine-type": "{{$machineType}}",
 				},
@@ -207,6 +236,9 @@ func TestApplyOptimizations(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				// We need a copy of the config for each test case.
 				c := tc.config
+				for k, v := range tc.conditions {
+					_ = setConfigValueByPath(&c, k, v)
+				}
 				// Set the default or non-default value on the config object.
 				if tc.name == "user_set" {
 					c.{{$flag.GoPath}} = tc.expectedValue.({{$flag.GoType}})


### PR DESCRIPTION
### Summary
This PR adds support for specifying prerequisite configuration flag conditions under `bucket-type-optimization` rules in `cfg/params.yaml`.

### Motivation & Background
Certain performance optimizations for specific storage/bucket types (such as Pirlo) should only be applied when specific feature flags are enabled or disabled. For example, write buffer optimizations for Pirlo buckets should only apply when rapid writes are enabled (`write.enable-rapid-writes: true`) and rapid appends are disabled (`write.enable-rapid-appends: false`).

### Changes
1. **Schema & Types (`cfg/shared/types.go`):**
   - Added `Conditions map[string]any yaml:"conditions,omitempty"` to `BucketTypeOptimization`.
2. **Config Generator (`tools/config-gen/`):**
   - Validated that condition keys correspond to known `config-path`s.
   - Allowed multiple bucket-type rules on the same flag as long as their condition sets differ.
   - Updated `config.tpl` to output deterministic, sorted condition maps and pass the active `*Config` struct `c` to `getOptimizedValue`.
   - Updated `config_test.tpl` to apply condition prerequisites when testing bucket-type optimization rules.
3. **Condition Matching (`cfg/optimize.go`):**
   - Updated `getOptimizedValue` to check conditions via `matchesConditions(c, bto.Conditions)`.
   - Implemented reflection-based path traversal (`getConfigValueByPath`, `setConfigValueByPath`) and flexible numeric/boolean comparison (`valuesMatch`).
4. **Parameter Optimizations (`cfg/params.yaml`):**
   - Added conditional Pirlo optimizations for:
     - `write.block-size-mb`: `1.0`
     - `write.max-blocks-per-file`: `4`
     - `write.global-max-blocks`: `16`
   - Precedence is maintained:
     - User flags take highest precedence (`v.IsSet`).
     - Machine-type optimizations (`high-performance` -> `1600` for `write.global-max-blocks`) take precedence over bucket-type optimizations.
     - `--disable-autoconfig` skips all optimizations.
5. **Semaphore Re-initialization (`internal/fs/fs.go`):**
   - Re-initialized `fs.globalMaxWriteBlocksSem` after `ApplyOptimizations` updates `serverCfg.NewConfig.Write.GlobalMaxBlocks`.
6. **Tests (`cfg/optimize_test.go`, `cfg/shared/types_test.go`, `tools/config-gen/parser_test.go`):**
   - Added unit tests verifying conditions met, conditions not met, machine-type precedence, user-override precedence, autoconfig disabled, and YAML unmarshaling/validation.