### PR TITLE
fix(cfg): auto-adjust max-read-ahead-kb to match fuse-max-request-size-kb when kernel reader is enabled

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -1324,7 +1324,7 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 
 	flagSet.IntP("max-idle-conns-per-host", "", 100, "The number of maximum idle connections allowed per server.")
 
-	flagSet.IntP("max-read-ahead-kb", "", 0, "Sets max kernel-read-ahead for the mount in KiB. 0 means system default. Requires sudo permission to set this value, otherwise the value will be ignored and system default will be used.")
+	flagSet.IntP("max-read-ahead-kb", "", 0, "Sets max kernel-read-ahead for the mount in KiB. 0 means system default. Requires sudo permission to set this value, otherwise the value will be ignored and system default will be used. When enable-kernel-reader is enabled and this flag is not explicitly set, max-read-ahead-kb is automatically adjusted to match fuse-max-request-size-kb if fuse-max-request-size-kb is larger.")
 
 	if err := flagSet.MarkHidden("max-read-ahead-kb"); err != nil {
 		return err

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -621,7 +621,9 @@ params:
     usage: >-
       Sets max kernel-read-ahead for the mount in KiB. 0 means system default.
       Requires sudo permission to set this value, otherwise the value will be ignored
-      and system default will be used.
+      and system default will be used. When enable-kernel-reader is enabled and this
+      flag is not explicitly set, max-read-ahead-kb is automatically adjusted to
+      match fuse-max-request-size-kb if fuse-max-request-size-kb is larger.
     default: "0"
     hide-flag: true
     optimizations:

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -176,6 +176,18 @@ func resolveOnlyDir(c *Config) {
 	}
 }
 
+// resolveKernelReadAhead auto-adjusts max-read-ahead-kb to match fuse-max-request-size-kb
+// when kernel reader is enabled, unless the user explicitly configured max-read-ahead-kb.
+func resolveKernelReadAhead(v *viper.Viper, c *Config) {
+	if !c.FileSystem.EnableKernelReader {
+		return
+	}
+	if v != nil && v.IsSet("file-system.max-read-ahead-kb") {
+		return
+	}
+	c.FileSystem.MaxReadAheadKb = max(c.FileSystem.MaxReadAheadKb, c.FileSystem.FuseMaxRequestSizeKb)
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	var err error
@@ -198,6 +210,7 @@ func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	resolveFileCacheAndBufferedReadConflict(v, c)
 	resolveGCSRetriesConfig(&c.GcsRetries)
 	resolveOnlyDir(c)
+	resolveKernelReadAhead(v, c)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -930,7 +930,7 @@ func TestResolveOnlyDir(t *testing.T) {
 	}
 }
 
-func Test_resolve_kernel_read_ahead(t *testing.T) {
+func TestResolveKernelReadAhead(t *testing.T) {
 	testCases := []struct {
 		name                string
 		userSetFlags        map[string]any
@@ -1077,7 +1077,6 @@ func Test_resolve_kernel_read_ahead(t *testing.T) {
 					v.Set(key, val)
 				}
 			}
-
 			c := &Config{
 				FileSystem: FileSystemConfig{
 					EnableKernelReader:   tc.enableKernelReader,
@@ -1085,7 +1084,6 @@ func Test_resolve_kernel_read_ahead(t *testing.T) {
 					FuseMaxRequestSizeKb: tc.requestSizeKb,
 				},
 			}
-
 			resolveKernelReadAhead(v, c)
 
 			assert.Equal(t, tc.expectedReadAheadKb, c.FileSystem.MaxReadAheadKb)
@@ -1093,7 +1091,7 @@ func Test_resolve_kernel_read_ahead(t *testing.T) {
 	}
 }
 
-func Test_rationalize_kernel_read_ahead(t *testing.T) {
+func TestRationalizeKernelReadAhead(t *testing.T) {
 	testCases := []struct {
 		name                string
 		userSetFlags        map[string]any
@@ -1146,7 +1144,6 @@ func Test_rationalize_kernel_read_ahead(t *testing.T) {
 			for key, val := range tc.userSetFlags {
 				v.Set(key, val)
 			}
-
 			c := &Config{
 				FileSystem: FileSystemConfig{
 					EnableKernelReader:   tc.enableKernelReader,
@@ -1154,7 +1151,6 @@ func Test_rationalize_kernel_read_ahead(t *testing.T) {
 					FuseMaxRequestSizeKb: tc.requestSizeKb,
 				},
 			}
-
 			err := Rationalize(v, c, []string{})
 
 			require.NoError(t, err)
@@ -1163,7 +1159,7 @@ func Test_rationalize_kernel_read_ahead(t *testing.T) {
 	}
 }
 
-func Test_rationalize_with_bucket_optimization(t *testing.T) {
+func TestRationalizeWithBucketOptimization(t *testing.T) {
 	testCases := []struct {
 		name                string
 		bucketType          BucketType
@@ -1251,7 +1247,6 @@ func Test_rationalize_with_bucket_optimization(t *testing.T) {
 			for key, val := range tc.userSetFlags {
 				v.Set(key, val)
 			}
-
 			c := &Config{}
 			tc.setupConfig(c)
 

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -941,28 +941,28 @@ func TestResolveKernelReadAhead(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name:                "enabled_unset_large_request_size",
+			name:                "kr_enabled_unset_large_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072, // 128 MiB (regional default)
 			requestSizeKb:       261120, // 255 MiB
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "enabled_startup_zero_adjusted",
+			name:                "kr_enabled_startup_zero_adjusted",
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "enabled_startup_default_request_size",
+			name:                "kr_enabled_startup_default_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
 			requestSizeKb:       1024,
 			expectedReadAheadKb: 1024,
 		},
 		{
-			name:                "enabled_explicit_read_ahead_lower",
+			name:                "kr_enabled_explicit_read_ahead_lower",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 1024},
 			enableKernelReader:  true,
 			initialReadAheadKb:  1024,
@@ -970,7 +970,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 1024,
 		},
 		{
-			name:                "enabled_explicit_zero_preserved",
+			name:                "kr_enabled_explicit_zero_preserved",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 0},
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
@@ -978,7 +978,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "enabled_explicit_read_ahead_higher",
+			name:                "kr_enabled_explicit_read_ahead_higher",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 524288},
 			enableKernelReader:  true,
 			initialReadAheadKb:  524288,
@@ -986,42 +986,42 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 524288,
 		},
 		{
-			name:                "enabled_request_size_equal_read_ahead",
+			name:                "kr_enabled_request_size_equal_read_ahead",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       131072,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "enabled_request_size_smaller_read_ahead",
+			name:                "kr_enabled_request_size_smaller_read_ahead",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072, // 128 MiB
 			requestSizeKb:       16384,  // 16 MiB
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "enabled_explicit_small_request_size",
+			name:                "kr_enabled_explicit_small_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       8192,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "enabled_request_size_zero",
+			name:                "kr_enabled_request_size_zero",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       0,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "disabled_large_request_size",
+			name:                "kr_disabled_large_request_size",
 			enableKernelReader:  false,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "disabled_startup_zero",
+			name:                "kr_disabled_startup_zero",
 			enableKernelReader:  false,
 			initialReadAheadKb:  0,
 			requestSizeKb:       261120,

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -930,7 +930,7 @@ func TestResolveOnlyDir(t *testing.T) {
 	}
 }
 
-func TestResolveKernelReadAhead(t *testing.T) {
+func Test_resolve_kernel_read_ahead(t *testing.T) {
 	testCases := []struct {
 		name                string
 		userSetFlags        map[string]any
@@ -941,28 +941,28 @@ func TestResolveKernelReadAhead(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name:                "AC1: kernel reader enabled, read-ahead unset, request size larger than default",
+			name:                "enabled_unset_large_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072, // 128 MiB (regional default)
 			requestSizeKb:       261120, // 255 MiB
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "AC1: kernel reader enabled, read-ahead unset, unoptimized startup (0) adjusted to request size",
+			name:                "enabled_startup_zero_adjusted",
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "AC1: kernel reader enabled, read-ahead unset, startup default request size (1024)",
+			name:                "enabled_startup_default_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
 			requestSizeKb:       1024,
 			expectedReadAheadKb: 1024,
 		},
 		{
-			name:                "AC2: kernel reader enabled, read-ahead explicitly set lower than request size",
+			name:                "enabled_explicit_read_ahead_lower",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 1024},
 			enableKernelReader:  true,
 			initialReadAheadKb:  1024,
@@ -970,7 +970,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 1024,
 		},
 		{
-			name:                "AC2: kernel reader enabled, read-ahead explicitly set to 0",
+			name:                "enabled_explicit_zero_preserved",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 0},
 			enableKernelReader:  true,
 			initialReadAheadKb:  0,
@@ -978,7 +978,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "AC2: kernel reader enabled, read-ahead explicitly set higher than request size",
+			name:                "enabled_explicit_read_ahead_higher",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 524288},
 			enableKernelReader:  true,
 			initialReadAheadKb:  524288,
@@ -986,56 +986,56 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 524288,
 		},
 		{
-			name:                "AC3: kernel reader enabled, request size equal to default read-ahead",
+			name:                "enabled_request_size_equal_read_ahead",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       131072,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "AC3: kernel reader enabled, request size smaller than default read-ahead (16 MiB default)",
+			name:                "enabled_request_size_smaller_read_ahead",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072, // 128 MiB
 			requestSizeKb:       16384,  // 16 MiB
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "AC3: kernel reader enabled, request size explicitly small (8 MiB)",
+			name:                "enabled_explicit_small_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       8192,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "AC3: kernel reader enabled, request size unset / 0",
+			name:                "enabled_request_size_zero",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       0,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "AC4: kernel reader disabled, request size larger than default read-ahead",
+			name:                "disabled_large_request_size",
 			enableKernelReader:  false,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "AC4: kernel reader disabled, startup initial read-ahead 0",
+			name:                "disabled_startup_zero",
 			enableKernelReader:  false,
 			initialReadAheadKb:  0,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "Rapid: rapid defaults preserved (16 MiB read-ahead, 1 MiB request size)",
+			name:                "rapid_defaults_preserved",
 			enableKernelReader:  true,
 			initialReadAheadKb:  16384, // 16 MiB rapid default
 			requestSizeKb:       1024,  // 1 MiB rapid default
 			expectedReadAheadKb: 16384,
 		},
 		{
-			name:                "Rapid: explicit read-ahead preserved on rapid bucket",
+			name:                "rapid_explicit_read_ahead_preserved",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 4096},
 			enableKernelReader:  true,
 			initialReadAheadKb:  4096,
@@ -1043,7 +1043,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 4096,
 		},
 		{
-			name:                "Rapid: explicit read-ahead lower than request size preserved on rapid bucket",
+			name:                "rapid_explicit_lower_preserved",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 512},
 			enableKernelReader:  true,
 			initialReadAheadKb:  512,
@@ -1051,7 +1051,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 512,
 		},
 		{
-			name:                "Rapid: explicit read-ahead higher than default preserved on rapid bucket",
+			name:                "rapid_explicit_higher_preserved",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 32768},
 			enableKernelReader:  true,
 			initialReadAheadKb:  32768,
@@ -1059,7 +1059,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 32768,
 		},
 		{
-			name:                "Edge Case: nil viper does not panic and applies auto-adjustment",
+			name:                "nil_viper_auto_adjustment",
 			nilViper:            true,
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
@@ -1093,7 +1093,7 @@ func TestResolveKernelReadAhead(t *testing.T) {
 	}
 }
 
-func TestRationalize_KernelReadAhead(t *testing.T) {
+func Test_rationalize_kernel_read_ahead(t *testing.T) {
 	testCases := []struct {
 		name                string
 		userSetFlags        map[string]any
@@ -1103,14 +1103,14 @@ func TestRationalize_KernelReadAhead(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name:                "Rationalize adjusts read-ahead when kernel reader enabled and request size > default",
+			name:                "adjusts_large_request_size",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "Rationalize preserves explicit read-ahead even if lower than request size",
+			name:                "preserves_explicit_read_ahead",
 			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 2048},
 			enableKernelReader:  true,
 			initialReadAheadKb:  2048,
@@ -1118,21 +1118,21 @@ func TestRationalize_KernelReadAhead(t *testing.T) {
 			expectedReadAheadKb: 2048,
 		},
 		{
-			name:                "Rationalize preserves default read-ahead when request size <= default",
+			name:                "preserves_default_read_ahead",
 			enableKernelReader:  true,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       16384,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "Rationalize does not override read-ahead when kernel reader is disabled",
+			name:                "disabled_reader_preserves_read_ahead",
 			enableKernelReader:  false,
 			initialReadAheadKb:  131072,
 			requestSizeKb:       261120,
 			expectedReadAheadKb: 131072,
 		},
 		{
-			name:                "Rationalize preserves rapid bucket defaults",
+			name:                "preserves_rapid_defaults",
 			enableKernelReader:  true,
 			initialReadAheadKb:  16384,
 			requestSizeKb:       1024,
@@ -1163,7 +1163,7 @@ func TestRationalize_KernelReadAhead(t *testing.T) {
 	}
 }
 
-func TestRationalize_WithBucketOptimization(t *testing.T) {
+func Test_rationalize_with_bucket_optimization(t *testing.T) {
 	testCases := []struct {
 		name                string
 		bucketType          BucketType
@@ -1174,7 +1174,7 @@ func TestRationalize_WithBucketOptimization(t *testing.T) {
 		expectedKernelRd    bool
 	}{
 		{
-			name:       "Standard bucket with kernel reader and large request size (255 MiB) auto-adjusts read-ahead",
+			name:       "flat_bucket_large_request_size",
 			bucketType: BucketTypeFlat,
 			userSetFlags: map[string]any{
 				"file-system.enable-kernel-reader":     true,
@@ -1189,7 +1189,7 @@ func TestRationalize_WithBucketOptimization(t *testing.T) {
 			expectedKernelRd:    true,
 		},
 		{
-			name:       "Standard bucket with kernel reader and default request size preserves 128 MiB default read-ahead",
+			name:       "flat_bucket_default_request_size",
 			bucketType: BucketTypeFlat,
 			userSetFlags: map[string]any{
 				"file-system.enable-kernel-reader": true,
@@ -1202,7 +1202,7 @@ func TestRationalize_WithBucketOptimization(t *testing.T) {
 			expectedKernelRd:    true,
 		},
 		{
-			name:       "Standard bucket with explicit read-ahead preserves user value despite large request size",
+			name:       "flat_bucket_explicit_read_ahead",
 			bucketType: BucketTypeFlat,
 			userSetFlags: map[string]any{
 				"file-system.enable-kernel-reader":     true,
@@ -1219,7 +1219,7 @@ func TestRationalize_WithBucketOptimization(t *testing.T) {
 			expectedKernelRd:    true,
 		},
 		{
-			name:         "Rapid bucket default optimization preserves 16 MiB read-ahead and auto-enables kernel reader",
+			name:         "rapid_bucket_default_optimization",
 			bucketType:   BucketTypeZonal,
 			userSetFlags: map[string]any{},
 			setupConfig: func(c *Config) {
@@ -1230,7 +1230,7 @@ func TestRationalize_WithBucketOptimization(t *testing.T) {
 			expectedKernelRd:    true,
 		},
 		{
-			name:       "Rapid bucket with explicit read-ahead preserves user value",
+			name:       "rapid_bucket_explicit_read_ahead",
 			bucketType: BucketTypeZonal,
 			userSetFlags: map[string]any{
 				"file-system.max-read-ahead-kb": 8192,

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -929,3 +929,346 @@ func TestResolveOnlyDir(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveKernelReadAhead(t *testing.T) {
+	testCases := []struct {
+		name                string
+		userSetFlags        map[string]any
+		nilViper            bool
+		enableKernelReader  bool
+		initialReadAheadKb  int64
+		requestSizeKb       int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name:                "AC1: kernel reader enabled, read-ahead unset, request size larger than default",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072, // 128 MiB (regional default)
+			requestSizeKb:       261120, // 255 MiB
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name:                "AC1: kernel reader enabled, read-ahead unset, unoptimized startup (0) adjusted to request size",
+			enableKernelReader:  true,
+			initialReadAheadKb:  0,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name:                "AC1: kernel reader enabled, read-ahead unset, startup default request size (1024)",
+			enableKernelReader:  true,
+			initialReadAheadKb:  0,
+			requestSizeKb:       1024,
+			expectedReadAheadKb: 1024,
+		},
+		{
+			name:                "AC2: kernel reader enabled, read-ahead explicitly set lower than request size",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 1024},
+			enableKernelReader:  true,
+			initialReadAheadKb:  1024,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 1024,
+		},
+		{
+			name:                "AC2: kernel reader enabled, read-ahead explicitly set to 0",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 0},
+			enableKernelReader:  true,
+			initialReadAheadKb:  0,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name:                "AC2: kernel reader enabled, read-ahead explicitly set higher than request size",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 524288},
+			enableKernelReader:  true,
+			initialReadAheadKb:  524288,
+			requestSizeKb:       16384,
+			expectedReadAheadKb: 524288,
+		},
+		{
+			name:                "AC3: kernel reader enabled, request size equal to default read-ahead",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       131072,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "AC3: kernel reader enabled, request size smaller than default read-ahead (16 MiB default)",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072, // 128 MiB
+			requestSizeKb:       16384,  // 16 MiB
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "AC3: kernel reader enabled, request size explicitly small (8 MiB)",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       8192,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "AC3: kernel reader enabled, request size unset / 0",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       0,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "AC4: kernel reader disabled, request size larger than default read-ahead",
+			enableKernelReader:  false,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "AC4: kernel reader disabled, startup initial read-ahead 0",
+			enableKernelReader:  false,
+			initialReadAheadKb:  0,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name:                "Rapid: rapid defaults preserved (16 MiB read-ahead, 1 MiB request size)",
+			enableKernelReader:  true,
+			initialReadAheadKb:  16384, // 16 MiB rapid default
+			requestSizeKb:       1024,  // 1 MiB rapid default
+			expectedReadAheadKb: 16384,
+		},
+		{
+			name:                "Rapid: explicit read-ahead preserved on rapid bucket",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 4096},
+			enableKernelReader:  true,
+			initialReadAheadKb:  4096,
+			requestSizeKb:       1024,
+			expectedReadAheadKb: 4096,
+		},
+		{
+			name:                "Rapid: explicit read-ahead lower than request size preserved on rapid bucket",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 512},
+			enableKernelReader:  true,
+			initialReadAheadKb:  512,
+			requestSizeKb:       1024,
+			expectedReadAheadKb: 512,
+		},
+		{
+			name:                "Rapid: explicit read-ahead higher than default preserved on rapid bucket",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 32768},
+			enableKernelReader:  true,
+			initialReadAheadKb:  32768,
+			requestSizeKb:       1024,
+			expectedReadAheadKb: 32768,
+		},
+		{
+			name:                "Edge Case: nil viper does not panic and applies auto-adjustment",
+			nilViper:            true,
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 261120,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var v *viper.Viper
+			if !tc.nilViper {
+				v = viper.New()
+				for key, val := range tc.userSetFlags {
+					v.Set(key, val)
+				}
+			}
+
+			c := &Config{
+				FileSystem: FileSystemConfig{
+					EnableKernelReader:   tc.enableKernelReader,
+					MaxReadAheadKb:       tc.initialReadAheadKb,
+					FuseMaxRequestSizeKb: tc.requestSizeKb,
+				},
+			}
+
+			resolveKernelReadAhead(v, c)
+
+			assert.Equal(t, tc.expectedReadAheadKb, c.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalize_KernelReadAhead(t *testing.T) {
+	testCases := []struct {
+		name                string
+		userSetFlags        map[string]any
+		enableKernelReader  bool
+		initialReadAheadKb  int64
+		requestSizeKb       int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name:                "Rationalize adjusts read-ahead when kernel reader enabled and request size > default",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name:                "Rationalize preserves explicit read-ahead even if lower than request size",
+			userSetFlags:        map[string]any{"file-system.max-read-ahead-kb": 2048},
+			enableKernelReader:  true,
+			initialReadAheadKb:  2048,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 2048,
+		},
+		{
+			name:                "Rationalize preserves default read-ahead when request size <= default",
+			enableKernelReader:  true,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       16384,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "Rationalize does not override read-ahead when kernel reader is disabled",
+			enableKernelReader:  false,
+			initialReadAheadKb:  131072,
+			requestSizeKb:       261120,
+			expectedReadAheadKb: 131072,
+		},
+		{
+			name:                "Rationalize preserves rapid bucket defaults",
+			enableKernelReader:  true,
+			initialReadAheadKb:  16384,
+			requestSizeKb:       1024,
+			expectedReadAheadKb: 16384,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			for key, val := range tc.userSetFlags {
+				v.Set(key, val)
+			}
+
+			c := &Config{
+				FileSystem: FileSystemConfig{
+					EnableKernelReader:   tc.enableKernelReader,
+					MaxReadAheadKb:       tc.initialReadAheadKb,
+					FuseMaxRequestSizeKb: tc.requestSizeKb,
+				},
+			}
+
+			err := Rationalize(v, c, []string{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedReadAheadKb, c.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalize_WithBucketOptimization(t *testing.T) {
+	testCases := []struct {
+		name                string
+		bucketType          BucketType
+		userSetFlags        map[string]any
+		setupConfig         func(c *Config)
+		expectedReadAheadKb int64
+		expectedRequestKb   int64
+		expectedKernelRd    bool
+	}{
+		{
+			name:       "Standard bucket with kernel reader and large request size (255 MiB) auto-adjusts read-ahead",
+			bucketType: BucketTypeFlat,
+			userSetFlags: map[string]any{
+				"file-system.enable-kernel-reader":     true,
+				"file-system.fuse-max-request-size-kb": 261120,
+			},
+			setupConfig: func(c *Config) {
+				c.FileSystem.EnableKernelReader = true
+				c.FileSystem.FuseMaxRequestSizeKb = 261120
+			},
+			expectedReadAheadKb: 261120,
+			expectedRequestKb:   261120,
+			expectedKernelRd:    true,
+		},
+		{
+			name:       "Standard bucket with kernel reader and default request size preserves 128 MiB default read-ahead",
+			bucketType: BucketTypeFlat,
+			userSetFlags: map[string]any{
+				"file-system.enable-kernel-reader": true,
+			},
+			setupConfig: func(c *Config) {
+				c.FileSystem.EnableKernelReader = true
+			},
+			expectedReadAheadKb: 131072, // 128 MiB
+			expectedRequestKb:   16384,  // 16 MiB
+			expectedKernelRd:    true,
+		},
+		{
+			name:       "Standard bucket with explicit read-ahead preserves user value despite large request size",
+			bucketType: BucketTypeFlat,
+			userSetFlags: map[string]any{
+				"file-system.enable-kernel-reader":     true,
+				"file-system.fuse-max-request-size-kb": 261120,
+				"file-system.max-read-ahead-kb":        4096,
+			},
+			setupConfig: func(c *Config) {
+				c.FileSystem.EnableKernelReader = true
+				c.FileSystem.FuseMaxRequestSizeKb = 261120
+				c.FileSystem.MaxReadAheadKb = 4096
+			},
+			expectedReadAheadKb: 4096,
+			expectedRequestKb:   261120,
+			expectedKernelRd:    true,
+		},
+		{
+			name:         "Rapid bucket default optimization preserves 16 MiB read-ahead and auto-enables kernel reader",
+			bucketType:   BucketTypeZonal,
+			userSetFlags: map[string]any{},
+			setupConfig: func(c *Config) {
+				c.FileSystem.FuseMaxRequestSizeKb = int64(StorageClassRapid.DefaultFuseMaxRequestSizeKb())
+			},
+			expectedReadAheadKb: 16384, // 16 MiB
+			expectedRequestKb:   1024,  // 1 MiB
+			expectedKernelRd:    true,
+		},
+		{
+			name:       "Rapid bucket with explicit read-ahead preserves user value",
+			bucketType: BucketTypeZonal,
+			userSetFlags: map[string]any{
+				"file-system.max-read-ahead-kb": 8192,
+			},
+			setupConfig: func(c *Config) {
+				c.FileSystem.MaxReadAheadKb = 8192
+				c.FileSystem.FuseMaxRequestSizeKb = int64(StorageClassRapid.DefaultFuseMaxRequestSizeKb())
+			},
+			expectedReadAheadKb: 8192,
+			expectedRequestKb:   1024,
+			expectedKernelRd:    true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			for key, val := range tc.userSetFlags {
+				v.Set(key, val)
+			}
+
+			c := &Config{}
+			tc.setupConfig(c)
+
+			// Step 1: Apply bucket-type optimizations
+			optimizedFlags := c.ApplyOptimizations(v, &OptimizationInput{BucketType: tc.bucketType})
+
+			// Step 2: Rationalize
+			var optFlagNames []string
+			for k := range optimizedFlags {
+				optFlagNames = append(optFlagNames, k)
+			}
+			err := Rationalize(v, c, optFlagNames)
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKernelRd, c.FileSystem.EnableKernelReader)
+			assert.Equal(t, tc.expectedRequestKb, c.FileSystem.FuseMaxRequestSizeKb)
+			assert.Equal(t, tc.expectedReadAheadKb, c.FileSystem.MaxReadAheadKb)
+		})
+	}
+}

--- a/cfg/validate.go
+++ b/cfg/validate.go
@@ -136,6 +136,13 @@ func isValidFuseMaxWriteSizeKb(writeSizeKb int64) error {
 	return nil
 }
 
+func isValidMaxReadAheadKb(readAheadKb int64) error {
+	if readAheadKb < 0 {
+		return fmt.Errorf("invalid value for max-read-ahead-kb: %d; must be >= 0 (0 for system default)", readAheadKb)
+	}
+	return nil
+}
+
 // isTTLInSecsValid return nil error if ttlInSecs is valid.
 func isTTLInSecsValid(secs int64) error {
 	if secs < -1 {
@@ -385,6 +392,12 @@ func ValidateConfig(v *viper.Viper, config *Config) error {
 	if v.IsSet("file-system.fuse-max-write-size-kb") {
 		if err = isValidFuseMaxWriteSizeKb(config.FileSystem.FuseMaxWriteSizeKb); err != nil {
 			return fmt.Errorf("error parsing fuse-max-write-size-kb config: %w", err)
+		}
+	}
+
+	if v.IsSet("file-system.max-read-ahead-kb") {
+		if err = isValidMaxReadAheadKb(config.FileSystem.MaxReadAheadKb); err != nil {
+			return fmt.Errorf("error parsing max-read-ahead-kb config: %w", err)
 		}
 	}
 

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -1589,3 +1589,42 @@ func Test_isValidFuseMaxWriteSizeKb_ErrorScenarios(t *testing.T) {
 		})
 	}
 }
+
+func Test_is_valid_max_read_ahead_kb_valid(t *testing.T) {
+	testCases := []struct {
+		name        string
+		readAheadKb int64
+	}{
+		{"valid_zero", 0},
+		{"valid_1_kb", 1},
+		{"valid_1024_kb", 1024},
+		{"valid_261120_kb", 261120},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxReadAheadKb(tc.readAheadKb)
+
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func Test_is_valid_max_read_ahead_kb_error(t *testing.T) {
+	testCases := []struct {
+		name        string
+		readAheadKb int64
+	}{
+		{"invalid_negative_one", -1},
+		{"invalid_negative_ten", -10},
+		{"invalid_negative_large", -1024},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := isValidMaxReadAheadKb(tc.readAheadKb)
+
+			assert.Error(t, err)
+		})
+	}
+}

--- a/cfg/validate_test.go
+++ b/cfg/validate_test.go
@@ -1590,7 +1590,7 @@ func Test_isValidFuseMaxWriteSizeKb_ErrorScenarios(t *testing.T) {
 	}
 }
 
-func Test_is_valid_max_read_ahead_kb_valid(t *testing.T) {
+func TestIsValidMaxReadAheadKbValid(t *testing.T) {
 	testCases := []struct {
 		name        string
 		readAheadKb int64
@@ -1610,7 +1610,7 @@ func Test_is_valid_max_read_ahead_kb_valid(t *testing.T) {
 	}
 }
 
-func Test_is_valid_max_read_ahead_kb_error(t *testing.T) {
+func TestIsValidMaxReadAheadKbError(t *testing.T) {
 	testCases := []struct {
 		name        string
 		readAheadKb int64

--- a/cmd/config_rationalization_test.go
+++ b/cmd/config_rationalization_test.go
@@ -131,7 +131,7 @@ func getMountInfoForTest(t *testing.T, args []string) (*mountInfo, error) {
 	return &info, nil
 }
 
-func Test_rationalize_kernel_read_ahead_cli_flags(t *testing.T) {
+func TestRationalizeKernelReadAheadCliFlags(t *testing.T) {
 	testCases := []struct {
 		name                string
 		args                []string
@@ -201,7 +201,7 @@ func Test_rationalize_kernel_read_ahead_cli_flags(t *testing.T) {
 	}
 }
 
-func Test_rationalize_kernel_read_ahead_disabled(t *testing.T) {
+func TestRationalizeKernelReadAheadDisabled(t *testing.T) {
 	testCases := []struct {
 		name                string
 		args                []string
@@ -243,7 +243,7 @@ func Test_rationalize_kernel_read_ahead_disabled(t *testing.T) {
 	}
 }
 
-func Test_rationalize_kernel_read_ahead_config_file(t *testing.T) {
+func TestRationalizeKernelReadAheadConfigFile(t *testing.T) {
 	testCases := []struct {
 		name                string
 		yamlContent         string
@@ -318,7 +318,7 @@ func Test_rationalize_kernel_read_ahead_config_file(t *testing.T) {
 	}
 }
 
-func Test_rationalize_kernel_read_ahead_config_vs_cli(t *testing.T) {
+func TestRationalizeKernelReadAheadConfigVsCli(t *testing.T) {
 	testCases := []struct {
 		name                string
 		yamlContent         string
@@ -410,7 +410,7 @@ func Test_rationalize_kernel_read_ahead_config_vs_cli(t *testing.T) {
 	}
 }
 
-func Test_rationalize_kernel_read_ahead_viper_is_set(t *testing.T) {
+func TestRationalizeKernelReadAheadViperIsSet(t *testing.T) {
 	testCases := []struct {
 		name          string
 		yamlContent   string
@@ -418,17 +418,17 @@ func Test_rationalize_kernel_read_ahead_viper_is_set(t *testing.T) {
 		expectedIsSet bool
 	}{
 		{
-			name:          "cli_flag_zero_is_set",
+			name:          "cli_flag_is_set_with_value_zero",
 			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=0"},
 			expectedIsSet: true,
 		},
 		{
-			name:          "cli_flag_one_is_set",
+			name:          "cli_flag_is_set_with_value_one",
 			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=1"},
 			expectedIsSet: true,
 		},
 		{
-			name: "config_file_zero_is_set",
+			name: "config_file_is_set_with_value_zero",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   max-read-ahead-kb: 0
@@ -436,7 +436,7 @@ func Test_rationalize_kernel_read_ahead_viper_is_set(t *testing.T) {
 			expectedIsSet: true,
 		},
 		{
-			name: "config_file_one_is_set",
+			name: "config_file_is_set_with_value_one",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   max-read-ahead-kb: 1
@@ -444,17 +444,17 @@ func Test_rationalize_kernel_read_ahead_viper_is_set(t *testing.T) {
 			expectedIsSet: true,
 		},
 		{
-			name:          "only_enable_kernel_reader_not_set",
+			name:          "cli_flag_is_not_set_with_only_enable_kernel_reader",
 			cliArgs:       []string{"--enable-kernel-reader"},
 			expectedIsSet: false,
 		},
 		{
-			name:          "only_fuse_max_request_size_not_set",
+			name:          "cli_flag_is_not_set_with_only_fuse_max_request_size",
 			cliArgs:       []string{"--fuse-max-request-size-kb=261120"},
 			expectedIsSet: false,
 		},
 		{
-			name:          "no_flags_not_set",
+			name:          "no_flags_set",
 			cliArgs:       []string{},
 			expectedIsSet: false,
 		},

--- a/cmd/config_rationalization_test.go
+++ b/cmd/config_rationalization_test.go
@@ -131,7 +131,7 @@ func getMountInfoForTest(t *testing.T, args []string) (*mountInfo, error) {
 	return &info, nil
 }
 
-func TestRationalizeKernelReadAhead_CLIFlags(t *testing.T) {
+func Test_rationalize_kernel_read_ahead_cli_flags(t *testing.T) {
 	testCases := []struct {
 		name                string
 		args                []string
@@ -140,49 +140,49 @@ func TestRationalizeKernelReadAhead_CLIFlags(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name:                "enable-kernel-reader flag alone adjusts to default request size (1024 KiB)",
+			name:                "default_request_size",
 			args:                []string{"--enable-kernel-reader"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   1024,
 			expectedReadAheadKb: 1024,
 		},
 		{
-			name:                "enable-kernel-reader with large request size (255 MiB) adjusts read-ahead to 261120 KiB",
+			name:                "large_request_size",
 			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "enable-kernel-reader with large request size and explicit read-ahead preserves user value (4096 KiB)",
+			name:                "explicit_read_ahead_preserved",
 			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=4096"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 4096,
 		},
 		{
-			name:                "enable-kernel-reader with large request size and explicit read-ahead 0 preserves 0 KiB",
+			name:                "explicit_zero_preserved",
 			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=0"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "enable-kernel-reader with large request size and explicit read-ahead 1 preserves 1 KiB",
+			name:                "explicit_one_preserved",
 			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=1"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 1,
 		},
 		{
-			name:                "Single-hyphen flags convert correctly and auto-adjust read-ahead",
+			name:                "single_hyphen_auto_adjusts",
 			args:                []string{"-enable-kernel-reader", "-fuse-max-request-size-kb=261120"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name:                "Single-hyphen flags preserve explicit max-read-ahead-kb=0",
+			name:                "single_hyphen_preserves_zero",
 			args:                []string{"-enable-kernel-reader", "-fuse-max-request-size-kb=261120", "-max-read-ahead-kb=0"},
 			expectedKernelRd:    true,
 			expectedRequestKb:   261120,
@@ -201,7 +201,7 @@ func TestRationalizeKernelReadAhead_CLIFlags(t *testing.T) {
 	}
 }
 
-func TestRationalizeKernelReadAhead_DisabledKernelReader(t *testing.T) {
+func Test_rationalize_kernel_read_ahead_disabled(t *testing.T) {
 	testCases := []struct {
 		name                string
 		args                []string
@@ -210,21 +210,21 @@ func TestRationalizeKernelReadAhead_DisabledKernelReader(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name:                "Disabled kernel reader with large request size does not adjust read-ahead (remains 0)",
+			name:                "implicit_disabled_large_request_size",
 			args:                []string{"--fuse-max-request-size-kb=261120"},
 			expectedKernelRd:    false,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "Explicitly disabled kernel reader with large request size preserves read-ahead at 0",
+			name:                "explicit_disabled_large_request_size",
 			args:                []string{"--enable-kernel-reader=false", "--fuse-max-request-size-kb=261120"},
 			expectedKernelRd:    false,
 			expectedRequestKb:   261120,
 			expectedReadAheadKb: 0,
 		},
 		{
-			name:                "Explicitly disabled kernel reader preserves explicit user read-ahead (2048 KiB)",
+			name:                "explicit_disabled_preserves_read_ahead",
 			args:                []string{"--enable-kernel-reader=false", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=2048"},
 			expectedKernelRd:    false,
 			expectedRequestKb:   261120,
@@ -243,7 +243,7 @@ func TestRationalizeKernelReadAhead_DisabledKernelReader(t *testing.T) {
 	}
 }
 
-func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
+func Test_rationalize_kernel_read_ahead_config_file(t *testing.T) {
 	testCases := []struct {
 		name                string
 		yamlContent         string
@@ -252,7 +252,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name: "Config file enables kernel reader and sets large request size -> read-ahead adjusts to 261120",
+			name: "config_file_large_request_size",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -262,7 +262,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 0 -> 0 preserved",
+			name: "config_file_explicit_zero_preserved",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -273,7 +273,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 			expectedReadAheadKb: 0,
 		},
 		{
-			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 1 -> 1 preserved",
+			name: "config_file_explicit_one_preserved",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -284,7 +284,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 			expectedReadAheadKb: 1,
 		},
 		{
-			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 4096 -> 4096 preserved",
+			name: "config_file_explicit_read_ahead_preserved",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -295,7 +295,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 			expectedReadAheadKb: 4096,
 		},
 		{
-			name: "Config file disables kernel reader -> read-ahead remains 0 despite large request size",
+			name: "config_file_disabled_remains_zero",
 			yamlContent: `file-system:
   enable-kernel-reader: false
   fuse-max-request-size-kb: 261120
@@ -318,7 +318,7 @@ func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
 	}
 }
 
-func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
+func Test_rationalize_kernel_read_ahead_config_vs_cli(t *testing.T) {
 	testCases := []struct {
 		name                string
 		yamlContent         string
@@ -328,7 +328,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 		expectedReadAheadKb int64
 	}{
 		{
-			name: "Config file sets explicit read-ahead (2048); CLI sets large request size (261120) -> 2048 preserved",
+			name: "config_explicit_read_ahead_cli_large_request",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   max-read-ahead-kb: 2048
@@ -339,7 +339,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 			expectedReadAheadKb: 2048,
 		},
 		{
-			name: "Config file sets large request size (261120); CLI sets explicit read-ahead (8192) -> 8192 preserved",
+			name: "config_large_request_cli_explicit_read_ahead",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -350,7 +350,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 			expectedReadAheadKb: 8192,
 		},
 		{
-			name: "Config file sets explicit read-ahead (4096); CLI overrides with max-read-ahead-kb=0 -> 0 preserved",
+			name: "config_explicit_read_ahead_cli_override_zero",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -362,7 +362,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 			expectedReadAheadKb: 0,
 		},
 		{
-			name: "Config file sets explicit read-ahead (0); CLI overrides with max-read-ahead-kb=8192 -> 8192 preserved",
+			name: "config_explicit_zero_cli_override_read_ahead",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -374,7 +374,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 			expectedReadAheadKb: 8192,
 		},
 		{
-			name: "Config file disables kernel reader; CLI flag enables it -> auto-adjusts to 261120",
+			name: "config_disabled_cli_enabled",
 			yamlContent: `file-system:
   enable-kernel-reader: false
   fuse-max-request-size-kb: 261120
@@ -385,7 +385,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 			expectedReadAheadKb: 261120,
 		},
 		{
-			name: "Config file enables kernel reader; CLI flag disables it -> read-ahead remains 0",
+			name: "config_enabled_cli_disabled",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   fuse-max-request-size-kb: 261120
@@ -410,7 +410,7 @@ func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
 	}
 }
 
-func TestRationalizeKernelReadAhead_ViperIsSet(t *testing.T) {
+func Test_rationalize_kernel_read_ahead_viper_is_set(t *testing.T) {
 	testCases := []struct {
 		name          string
 		yamlContent   string
@@ -418,17 +418,17 @@ func TestRationalizeKernelReadAhead_ViperIsSet(t *testing.T) {
 		expectedIsSet bool
 	}{
 		{
-			name:          "CLI flag --max-read-ahead-kb=0 marks Viper IsSet as true",
+			name:          "cli_flag_zero_is_set",
 			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=0"},
 			expectedIsSet: true,
 		},
 		{
-			name:          "CLI flag --max-read-ahead-kb=1 marks Viper IsSet as true",
+			name:          "cli_flag_one_is_set",
 			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=1"},
 			expectedIsSet: true,
 		},
 		{
-			name: "Config file max-read-ahead-kb: 0 marks Viper IsSet as true",
+			name: "config_file_zero_is_set",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   max-read-ahead-kb: 0
@@ -436,7 +436,7 @@ func TestRationalizeKernelReadAhead_ViperIsSet(t *testing.T) {
 			expectedIsSet: true,
 		},
 		{
-			name: "Config file max-read-ahead-kb: 1 marks Viper IsSet as true",
+			name: "config_file_one_is_set",
 			yamlContent: `file-system:
   enable-kernel-reader: true
   max-read-ahead-kb: 1
@@ -444,17 +444,17 @@ func TestRationalizeKernelReadAhead_ViperIsSet(t *testing.T) {
 			expectedIsSet: true,
 		},
 		{
-			name:          "Only --enable-kernel-reader does NOT mark max-read-ahead-kb as IsSet",
+			name:          "only_enable_kernel_reader_not_set",
 			cliArgs:       []string{"--enable-kernel-reader"},
 			expectedIsSet: false,
 		},
 		{
-			name:          "Only --fuse-max-request-size-kb does NOT mark max-read-ahead-kb as IsSet",
+			name:          "only_fuse_max_request_size_not_set",
 			cliArgs:       []string{"--fuse-max-request-size-kb=261120"},
 			expectedIsSet: false,
 		},
 		{
-			name:          "No flags does NOT mark max-read-ahead-kb as IsSet",
+			name:          "no_flags_not_set",
 			cliArgs:       []string{},
 			expectedIsSet: false,
 		},

--- a/cmd/config_rationalization_test.go
+++ b/cmd/config_rationalization_test.go
@@ -15,11 +15,13 @@
 package cmd
 
 import (
+	"fmt"
 	"math"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRationalizeMetadataCache(t *testing.T) {
@@ -108,6 +110,367 @@ func TestRationalizeCloudMetricsExportIntervalSecs(t *testing.T) {
 			if assert.NoError(t, err) {
 				assert.Equal(t, tc.expected, c.Metrics.CloudMetricsExportIntervalSecs)
 			}
+		})
+	}
+}
+
+func getMountInfoForTest(t *testing.T, args []string) (*mountInfo, error) {
+	t.Helper()
+	var info mountInfo
+	cmd, err := newRootCmd(func(mi *mountInfo, _, _ string) error {
+		info = *mi
+		return nil
+	})
+	require.NoError(t, err)
+	cmdArgs := append([]string{"gcsfuse"}, args...)
+	cmdArgs = append(cmdArgs, "a")
+	cmd.SetArgs(convertToPosixArgs(cmdArgs, cmd))
+	if err = cmd.Execute(); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func TestRationalizeKernelReadAhead_CLIFlags(t *testing.T) {
+	testCases := []struct {
+		name                string
+		args                []string
+		expectedKernelRd    bool
+		expectedRequestKb   int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name:                "enable-kernel-reader flag alone adjusts to default request size (1024 KiB)",
+			args:                []string{"--enable-kernel-reader"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   1024,
+			expectedReadAheadKb: 1024,
+		},
+		{
+			name:                "enable-kernel-reader with large request size (255 MiB) adjusts read-ahead to 261120 KiB",
+			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name:                "enable-kernel-reader with large request size and explicit read-ahead preserves user value (4096 KiB)",
+			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=4096"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 4096,
+		},
+		{
+			name:                "enable-kernel-reader with large request size and explicit read-ahead 0 preserves 0 KiB",
+			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=0"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name:                "enable-kernel-reader with large request size and explicit read-ahead 1 preserves 1 KiB",
+			args:                []string{"--enable-kernel-reader", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=1"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 1,
+		},
+		{
+			name:                "Single-hyphen flags convert correctly and auto-adjust read-ahead",
+			args:                []string{"-enable-kernel-reader", "-fuse-max-request-size-kb=261120"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name:                "Single-hyphen flags preserve explicit max-read-ahead-kb=0",
+			args:                []string{"-enable-kernel-reader", "-fuse-max-request-size-kb=261120", "-max-read-ahead-kb=0"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := getMountInfoForTest(t, tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKernelRd, info.config.FileSystem.EnableKernelReader)
+			assert.Equal(t, tc.expectedRequestKb, info.config.FileSystem.FuseMaxRequestSizeKb)
+			assert.Equal(t, tc.expectedReadAheadKb, info.config.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalizeKernelReadAhead_DisabledKernelReader(t *testing.T) {
+	testCases := []struct {
+		name                string
+		args                []string
+		expectedKernelRd    bool
+		expectedRequestKb   int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name:                "Disabled kernel reader with large request size does not adjust read-ahead (remains 0)",
+			args:                []string{"--fuse-max-request-size-kb=261120"},
+			expectedKernelRd:    false,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name:                "Explicitly disabled kernel reader with large request size preserves read-ahead at 0",
+			args:                []string{"--enable-kernel-reader=false", "--fuse-max-request-size-kb=261120"},
+			expectedKernelRd:    false,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name:                "Explicitly disabled kernel reader preserves explicit user read-ahead (2048 KiB)",
+			args:                []string{"--enable-kernel-reader=false", "--fuse-max-request-size-kb=261120", "--max-read-ahead-kb=2048"},
+			expectedKernelRd:    false,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 2048,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			info, err := getMountInfoForTest(t, tc.args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKernelRd, info.config.FileSystem.EnableKernelReader)
+			assert.Equal(t, tc.expectedRequestKb, info.config.FileSystem.FuseMaxRequestSizeKb)
+			assert.Equal(t, tc.expectedReadAheadKb, info.config.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalizeKernelReadAhead_ConfigFile(t *testing.T) {
+	testCases := []struct {
+		name                string
+		yamlContent         string
+		expectedKernelRd    bool
+		expectedRequestKb   int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name: "Config file enables kernel reader and sets large request size -> read-ahead adjusts to 261120",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+`,
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 0 -> 0 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+  max-read-ahead-kb: 0
+`,
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 1 -> 1 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+  max-read-ahead-kb: 1
+`,
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 1,
+		},
+		{
+			name: "Config file enables kernel reader with explicit max-read-ahead-kb: 4096 -> 4096 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+  max-read-ahead-kb: 4096
+`,
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 4096,
+		},
+		{
+			name: "Config file disables kernel reader -> read-ahead remains 0 despite large request size",
+			yamlContent: `file-system:
+  enable-kernel-reader: false
+  fuse-max-request-size-kb: 261120
+`,
+			expectedKernelRd:    false,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := createTempConfigFile(t, tc.yamlContent)
+			info, err := getMountInfoForTest(t, []string{fmt.Sprintf("--config-file=%s", cfgPath)})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKernelRd, info.config.FileSystem.EnableKernelReader)
+			assert.Equal(t, tc.expectedRequestKb, info.config.FileSystem.FuseMaxRequestSizeKb)
+			assert.Equal(t, tc.expectedReadAheadKb, info.config.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalizeKernelReadAhead_ConfigFileVsCLIFlags(t *testing.T) {
+	testCases := []struct {
+		name                string
+		yamlContent         string
+		cliArgs             []string
+		expectedKernelRd    bool
+		expectedRequestKb   int64
+		expectedReadAheadKb int64
+	}{
+		{
+			name: "Config file sets explicit read-ahead (2048); CLI sets large request size (261120) -> 2048 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  max-read-ahead-kb: 2048
+`,
+			cliArgs:             []string{"--fuse-max-request-size-kb=261120"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 2048,
+		},
+		{
+			name: "Config file sets large request size (261120); CLI sets explicit read-ahead (8192) -> 8192 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+`,
+			cliArgs:             []string{"--max-read-ahead-kb=8192"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 8192,
+		},
+		{
+			name: "Config file sets explicit read-ahead (4096); CLI overrides with max-read-ahead-kb=0 -> 0 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+  max-read-ahead-kb: 4096
+`,
+			cliArgs:             []string{"--max-read-ahead-kb=0"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+		{
+			name: "Config file sets explicit read-ahead (0); CLI overrides with max-read-ahead-kb=8192 -> 8192 preserved",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+  max-read-ahead-kb: 0
+`,
+			cliArgs:             []string{"--max-read-ahead-kb=8192"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 8192,
+		},
+		{
+			name: "Config file disables kernel reader; CLI flag enables it -> auto-adjusts to 261120",
+			yamlContent: `file-system:
+  enable-kernel-reader: false
+  fuse-max-request-size-kb: 261120
+`,
+			cliArgs:             []string{"--enable-kernel-reader"},
+			expectedKernelRd:    true,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 261120,
+		},
+		{
+			name: "Config file enables kernel reader; CLI flag disables it -> read-ahead remains 0",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  fuse-max-request-size-kb: 261120
+`,
+			cliArgs:             []string{"--enable-kernel-reader=false"},
+			expectedKernelRd:    false,
+			expectedRequestKb:   261120,
+			expectedReadAheadKb: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfgPath := createTempConfigFile(t, tc.yamlContent)
+			args := append([]string{fmt.Sprintf("--config-file=%s", cfgPath)}, tc.cliArgs...)
+			info, err := getMountInfoForTest(t, args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedKernelRd, info.config.FileSystem.EnableKernelReader)
+			assert.Equal(t, tc.expectedRequestKb, info.config.FileSystem.FuseMaxRequestSizeKb)
+			assert.Equal(t, tc.expectedReadAheadKb, info.config.FileSystem.MaxReadAheadKb)
+		})
+	}
+}
+
+func TestRationalizeKernelReadAhead_ViperIsSet(t *testing.T) {
+	testCases := []struct {
+		name          string
+		yamlContent   string
+		cliArgs       []string
+		expectedIsSet bool
+	}{
+		{
+			name:          "CLI flag --max-read-ahead-kb=0 marks Viper IsSet as true",
+			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=0"},
+			expectedIsSet: true,
+		},
+		{
+			name:          "CLI flag --max-read-ahead-kb=1 marks Viper IsSet as true",
+			cliArgs:       []string{"--enable-kernel-reader", "--max-read-ahead-kb=1"},
+			expectedIsSet: true,
+		},
+		{
+			name: "Config file max-read-ahead-kb: 0 marks Viper IsSet as true",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  max-read-ahead-kb: 0
+`,
+			expectedIsSet: true,
+		},
+		{
+			name: "Config file max-read-ahead-kb: 1 marks Viper IsSet as true",
+			yamlContent: `file-system:
+  enable-kernel-reader: true
+  max-read-ahead-kb: 1
+`,
+			expectedIsSet: true,
+		},
+		{
+			name:          "Only --enable-kernel-reader does NOT mark max-read-ahead-kb as IsSet",
+			cliArgs:       []string{"--enable-kernel-reader"},
+			expectedIsSet: false,
+		},
+		{
+			name:          "Only --fuse-max-request-size-kb does NOT mark max-read-ahead-kb as IsSet",
+			cliArgs:       []string{"--fuse-max-request-size-kb=261120"},
+			expectedIsSet: false,
+		},
+		{
+			name:          "No flags does NOT mark max-read-ahead-kb as IsSet",
+			cliArgs:       []string{},
+			expectedIsSet: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var args []string
+			if tc.yamlContent != "" {
+				cfgPath := createTempConfigFile(t, tc.yamlContent)
+				args = append(args, fmt.Sprintf("--config-file=%s", cfgPath))
+			}
+			args = append(args, tc.cliArgs...)
+			info, err := getMountInfoForTest(t, args)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedIsSet, info.viperConfig.IsSet("file-system.max-read-ahead-kb"))
 		})
 	}
 }

--- a/cmd/config_validation_test.go
+++ b/cmd/config_validation_test.go
@@ -221,6 +221,21 @@ func TestValidateCliFlag(t *testing.T) {
 			args:    []string{"--fuse-max-write-size-kb=2048"},
 			wantErr: true,
 		},
+		{
+			name:    "valid_max_read_ahead_kb",
+			args:    []string{"--max-read-ahead-kb=1024"},
+			wantErr: false,
+		},
+		{
+			name:    "valid_zero_max_read_ahead_kb",
+			args:    []string{"--max-read-ahead-kb=0"},
+			wantErr: false,
+		},
+		{
+			name:    "invalid_negative_max_read_ahead_kb",
+			args:    []string{"--max-read-ahead-kb=-10"},
+			wantErr: true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1336,6 +1336,7 @@ func TestArgsParsing_FileSystemFlags(t *testing.T) {
 					ExperimentalODirect:  false,
 					Uid:                  -1,
 					EnableKernelReader:   true,
+					MaxReadAheadKb:       1024,
 				},
 			},
 		},


### PR DESCRIPTION
### Description
When kernel reader is enabled and a user sets a large `fuse-max-request-size-kb` (e.g. 255 MiB), GCSFuse kernel read calls were previously limited to 128 MiB for regional buckets due to constraints from the `max-read-ahead-kb` default.

This change:
- Automatically adjusts `max-read-ahead-kb` to `max(max-read-ahead-kb, fuse-max-request-size-kb)` when `enable-kernel-reader` is enabled and the user did not explicitly set `max-read-ahead-kb`.
- Preserves explicit user configuration of `max-read-ahead-kb` (via CLI or config file) even if lower than `fuse-max-request-size-kb`.
- Retains existing default read-ahead values when `fuse-max-request-size-kb` is lower than the default or unset.
- Leaves `max-read-ahead-kb` unchanged when the kernel reader is disabled.

### Link to the issue in case of a bug fix.
b/558219582

### Testing details
1. Manual - Verified compilation, format, and static analysis via `make build` and `golangci-lint`.
2. Unit tests - Added unit tests
3. Integration tests - Tested the behavior using Tessellations checkpoint benchmark.

### Any backward incompatible change? If so, please explain.
N/A
