### PR TITLE
fix(cd): resolve RHEL 9 package conflict and early exit timeout in e2…

### DIFF
--- a/tools/cd_scripts/e2e_test.sh
+++ b/tools/cd_scripts/e2e_test.sh
@@ -190,6 +190,76 @@ sudo -u starterscriptuser bash -c '
 set -e
 # Print commands and their arguments as they are executed.
 
+# Declare an associative array to store the exit status of different test runs.
+declare -A exit_status
+
+function gather_test_logs() {
+  if [[ -n "$TEST_LOGS_FILE" && -f "$TEST_LOGS_FILE" ]]; then
+    readarray -t test_logs_array < "$TEST_LOGS_FILE"
+    rm "$TEST_LOGS_FILE"
+    for test_log_file in "${test_logs_array[@]}"
+    do
+      log_file=${test_log_file}
+      if [[ -f "$log_file" ]]; then
+        if [[ "$test_log_file" == *"hns"* ]]; then
+          output_file="$HOME/logs-hns.txt"
+        elif [[ "$test_log_file" == *"zonal"* ]]; then
+          output_file="$HOME/logs-zonal.txt"
+        else
+          output_file="$HOME/logs.txt"
+        fi
+
+        echo "=== Log for ${test_log_file} ===" >> "$output_file"
+        cat "$log_file" >> "$output_file"
+        echo "=========================================" >> "$output_file"
+      fi
+    done
+  fi
+}
+
+# Function to log test results and upload them to GCS based on exit status.
+# Arguments: $1 = name of the associative array containing testcase exit statuses.
+function log_based_on_exit_status() {
+  if [[ "$#" -ne 1 ]]; then
+    echo "Incorrect number of arguments passed, Expecting <EXIT_STATUS_ARRAY_NAME>"
+    exit 1
+  fi
+  gather_test_logs
+  local -n exit_status_array=$1
+
+  # If exit_status is empty (e.g. early failure before tests ran), mark default testcase as failed so logs are uploaded.
+  if [[ "${#exit_status_array[@]}" -eq 0 ]]; then
+    if [[ "$RUN_ON_ZB_ONLY" == "true" ]]; then
+      exit_status_array["zonal"]=1
+    else
+      exit_status_array["flat"]=1
+    fi
+  fi
+
+  for testcase in "${!exit_status_array[@]}"
+    do
+        local logfile=""
+        local successfile=""
+        if [[ "$testcase" == "flat" ]]; then
+          logfile="$HOME/logs.txt"
+          successfile="$HOME/success.txt"
+        else
+          logfile="$HOME/logs-$testcase.txt"
+          successfile="$HOME/success-$testcase.txt"
+        fi
+        if [[ "${exit_status_array["$testcase"]}" != 0 ]];
+        then
+            echo "Test failures detected in $testcase bucket." &>> $logfile
+        else
+            touch $successfile
+            gcloud storage cp $successfile gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
+        fi
+    gcloud storage cp $logfile gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
+    done
+
+    gcloud storage cp -R "$KOKORO_ARTIFACTS_DIR" gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
+}
+
 function cleanup() {
     echo "Performing cleanup..."
     #Log results based on the collected exit statuses.
@@ -303,7 +373,7 @@ else
     fi
 
     sudo yum makecache
-    sudo yum -y update
+    sudo yum -y update --allowerasing
 
     #Install fuse
     sudo yum -y install fuse
@@ -610,62 +680,6 @@ function run_e2e_tests() {
   return $overall_exit_code
 }
 
-function gather_test_logs() {
-  readarray -t test_logs_array < "$TEST_LOGS_FILE"
-  rm "$TEST_LOGS_FILE"
-  for test_log_file in "${test_logs_array[@]}"
-  do
-    log_file=${test_log_file}
-    if [[ -f "$log_file" ]]; then
-      if [[ "$test_log_file" == *"hns"* ]]; then
-        output_file="$HOME/logs-hns.txt"
-      elif [[ "$test_log_file" == *"zonal"* ]]; then
-        output_file="$HOME/logs-zonal.txt"
-      else
-        output_file="$HOME/logs.txt"
-      fi
-
-      echo "=== Log for ${test_log_file} ===" >> "$output_file"
-      cat "$log_file" >> "$output_file"
-      echo "=========================================" >> "$output_file"
-    fi
-  done
-}
-
-# Function to log test results and upload them to GCS based on exit status.
-# Arguments: $1 = name of the associative array containing testcase exit statuses.
-function log_based_on_exit_status() {
-  if [[ "$#" -ne 1 ]]; then
-    echo "Incorrect number of arguments passed, Expecting <EXIT_STATUS_ARRAY_NAME>"
-    exit 1
-  fi
-  gather_test_logs
-  local -n exit_status_array=$1
-
-  for testcase in "${!exit_status_array[@]}"
-    do
-        local logfile=""
-        local successfile=""
-        if [[ "$testcase" == "flat" ]]; then
-          logfile="$HOME/logs.txt"
-          successfile="$HOME/success.txt"
-        else
-          logfile="$HOME/logs-$testcase.txt"
-          successfile="$HOME/success-$testcase.txt"
-        fi
-        if [[ "${exit_status_array["$testcase"]}" != 0 ]];
-        then
-            echo "Test failures detected in $testcase bucket." &>> $logfile
-        else
-            touch $successfile
-            gcloud storage cp $successfile gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
-        fi
-    gcloud storage cp $logfile gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
-    done
-
-    gcloud storage cp -R "$KOKORO_ARTIFACTS_DIR" gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
-}
-
 # Function to run emulator-based E2E tests and log results.
 function run_e2e_tests_for_emulator_and_log() {
   ./tools/integration_tests/emulator_tests/emulator_tests.sh true > ~/logs-emulator.txt
@@ -680,8 +694,6 @@ function run_e2e_tests_for_emulator_and_log() {
     gcloud storage cp ~/logs-emulator.txt gs://${BUCKET_NAME_TO_USE}/v${VERSION}/${VM_INSTANCE_NAME}/
 }
 
-# Declare an associative array to store the exit status of different test runs.
-declare -A exit_status
 if [[ "$RUN_LIGHT_TEST" == "true" ]]; then
     light_test_dir_non_parallel=("monitoring")
     light_test_dir_parallel=()


### PR DESCRIPTION
### Description
During the Louhi release pipeline (`gcs_fuse_release_flow_1`), RHEL 9 VM test stages (`test rpm on rhel 9 amd64` and `test rpm package on rhel 9 arm64`) were aborting during early VM setup and subsequently hanging for the maximum 4-hour timeout.

This was observed during oncall for a v3.8.1 patch release where an early setup crash hung Louhi with zero log visibility.

**Root Causes:**
1. `sudo yum -y update` fails on base RHEL 9 images due to package dependency conflicts between `python-unversioned-command` and `python3`. Under `set -e`, the script immediately aborts.
2. When the script aborts, the `EXIT` trap invokes `cleanup() -> log_based_on_exit_status()`. Because this function and `gather_test_logs()` were defined at the bottom of the script, they did not exist in memory yet, crashing cleanup (`command not found`) and preventing log markers from uploading to GCS. Consequently, Louhi's wait step endlessly polled GCS until hitting the 4-hour timeout.

**Fixes:**
- Added `--allowerasing` to `sudo yum -y update` to bypass RHEL 9 package conflicts.
- Moved `declare -A exit_status`, `gather_test_logs()`, and `log_based_on_exit_status()` above `cleanup()` and the `trap cleanup EXIT` handler.
- Added file existence guard in `gather_test_logs()` (`if [[ -n "$TEST_LOGS_FILE" && -f "$TEST_LOGS_FILE" ]]`) to prevent unbound redirection errors if invoked prior to `TEST_LOGS_FILE` creation.
- Added default failure status in `log_based_on_exit_status()` when `exit_status` is empty, ensuring that early crashes upload failure log markers (`logs.txt` or `logs-zonal.txt`) to GCS immediately, allowing Louhi to fail fast instead of hanging.

### Link to the issue in case of a bug fix : [Link](https://b.corp.google.com/issues/507380436)

### Testing details
1. Manual - N/A.
2. Unit tests - N/A (CD shell script change).
3. Integration tests - N/A.

### Any backward incompatible change? If so, please explain.
N/A
