### PR TITLE
feat(metrics): Add metadata_cache size metric gen code

### DIFF
--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -235,7 +235,7 @@ type MetricHandle interface {
 	// MetadataCacheReadCount - Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence).
 	MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail)
 
-	// MetadataCacheSize - The total size of the entries in the metadata cache
+	// MetadataCacheSize - The total memory size (in bytes) of the entries in the metadata cache
 	MetadataCacheSize(inc int64, entryStatus EntryStatus)
 
 	// ReadBlockSizes - The cumulative distribution of read block sizes across different bucket boundaries

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -208,14 +208,8 @@ type MetricHandle interface {
 	// FsOpsLatency - The cumulative distribution of file system operation latencies
 	FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp)
 
-	// FsReadBytesCount - The cumulative number of bytes read from GCS fuse by kernel
-	FsReadBytesCount(inc int64)
-
 	// FsStreamingWriteFallbackCount - The cumulative number of streaming write fallbacks with reason attached
 	FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason)
-
-	// FsWriteBytesCount - The cumulative number of bytes written to GCS fuse by kernel
-	FsWriteBytesCount(inc int64)
 
 	// GcsDownloadBytesCount - The cumulative number of bytes downloaded from GCS along with type - Sequential/Random
 	GcsDownloadBytesCount(inc int64, readType ReadType)

--- a/metrics/metric_handle.go
+++ b/metrics/metric_handle.go
@@ -208,8 +208,14 @@ type MetricHandle interface {
 	// FsOpsLatency - The cumulative distribution of file system operation latencies
 	FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp)
 
+	// FsReadBytesCount - The cumulative number of bytes read from GCS fuse by kernel
+	FsReadBytesCount(inc int64)
+
 	// FsStreamingWriteFallbackCount - The cumulative number of streaming write fallbacks with reason attached
 	FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason)
+
+	// FsWriteBytesCount - The cumulative number of bytes written to GCS fuse by kernel
+	FsWriteBytesCount(inc int64)
 
 	// GcsDownloadBytesCount - The cumulative number of bytes downloaded from GCS along with type - Sequential/Random
 	GcsDownloadBytesCount(inc int64, readType ReadType)
@@ -234,6 +240,9 @@ type MetricHandle interface {
 
 	// MetadataCacheReadCount - Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence).
 	MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail)
+
+	// MetadataCacheSize - The total size of the entries in the metadata cache
+	MetadataCacheSize(inc int64, entryStatus EntryStatus)
 
 	// ReadBlockSizes - The cumulative distribution of read block sizes across different bucket boundaries
 	ReadBlockSizes(ctx context.Context, value int64)

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -276,8 +276,9 @@
     - not_found
 
 - metric-name: "metadata_cache/size"
-  description: "The total size of the entries in the metadata cache"
+  description: "The total memory size (in bytes) of the entries in the metadata cache"
   type: "int_up_down_counter"
+  unit: "By"
   attributes:
   - attribute-name: entry_status
     attribute-type: string

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -140,11 +140,6 @@
     attribute-type: string
     values: *fs_ops_list
 
-- metric-name: "fs/read_bytes_count"
-  description: "The cumulative number of bytes read from GCS fuse by kernel"
-  unit: "By"
-  type: "int_counter"
-
 - metric-name: "fs/streaming_write_fallback_count"
   description: "The cumulative number of streaming write fallbacks with reason attached"
   type: "int_counter"
@@ -164,11 +159,6 @@
     - "existing_file"
     - "concurrency_limit_breached"
     - "other" # tracks any other errors not from above
-
-- metric-name: "fs/write_bytes_count"
-  description: "The cumulative number of bytes written to GCS fuse by kernel"
-  unit: "By"
-  type: "int_counter"
 
 - metric-name: "gcs/download_bytes_count"
   description: "The cumulative number of bytes downloaded from GCS along with type - Sequential/Random"

--- a/metrics/metrics.yaml
+++ b/metrics/metrics.yaml
@@ -140,6 +140,11 @@
     attribute-type: string
     values: *fs_ops_list
 
+- metric-name: "fs/read_bytes_count"
+  description: "The cumulative number of bytes read from GCS fuse by kernel"
+  unit: "By"
+  type: "int_counter"
+
 - metric-name: "fs/streaming_write_fallback_count"
   description: "The cumulative number of streaming write fallbacks with reason attached"
   type: "int_counter"
@@ -159,6 +164,11 @@
     - "existing_file"
     - "concurrency_limit_breached"
     - "other" # tracks any other errors not from above
+
+- metric-name: "fs/write_bytes_count"
+  description: "The cumulative number of bytes written to GCS fuse by kernel"
+  unit: "By"
+  type: "int_counter"
 
 - metric-name: "gcs/download_bytes_count"
   description: "The cumulative number of bytes downloaded from GCS along with type - Sequential/Random"
@@ -274,6 +284,16 @@
     - found
     - ttl_expired
     - not_found
+
+- metric-name: "metadata_cache/size"
+  description: "The total size of the entries in the metadata cache"
+  type: "int_up_down_counter"
+  attributes:
+  - attribute-name: entry_status
+    attribute-type: string
+    values:
+    - positive
+    - negative
 
 - metric-name: "read/block_sizes"
   description: "The cumulative distribution of read block sizes across different bucket boundaries"

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -39,12 +39,8 @@ func (*noopMetrics) FsOpsErrorCount(inc int64, fsErrorCategory FsErrorCategory, 
 
 func (*noopMetrics) FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp) {}
 
-func (*noopMetrics) FsReadBytesCount(inc int64) {}
-
 func (*noopMetrics) FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason) {
 }
-
-func (*noopMetrics) FsWriteBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 

--- a/metrics/noop_metrics.go
+++ b/metrics/noop_metrics.go
@@ -39,8 +39,12 @@ func (*noopMetrics) FsOpsErrorCount(inc int64, fsErrorCategory FsErrorCategory, 
 
 func (*noopMetrics) FsOpsLatency(ctx context.Context, latency time.Duration, fsOp FsOp) {}
 
+func (*noopMetrics) FsReadBytesCount(inc int64) {}
+
 func (*noopMetrics) FsStreamingWriteFallbackCount(inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason) {
 }
+
+func (*noopMetrics) FsWriteBytesCount(inc int64) {}
 
 func (*noopMetrics) GcsDownloadBytesCount(inc int64, readType ReadType) {}
 
@@ -59,6 +63,8 @@ func (*noopMetrics) GcsRetryCount(inc int64, retryErrorCategory RetryErrorCatego
 
 func (*noopMetrics) MetadataCacheReadCount(inc int64, cacheHit bool, entryStatus EntryStatus, lookupDetail LookupDetail) {
 }
+
+func (*noopMetrics) MetadataCacheSize(inc int64, entryStatus EntryStatus) {}
 
 func (*noopMetrics) ReadBlockSizes(ctx context.Context, value int64) {}
 

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -587,6 +587,8 @@ var (
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAttrSet                         = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "found")))
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAttrSet                      = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "not_found")))
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAttrSet                    = metric.WithAttributeSet(attribute.NewSet(attribute.Bool("cache_hit", false), attribute.String("entry_status", "positive"), attribute.String("lookup_detail", "ttl_expired")))
+	metadataCacheSizeEntryStatusNegativeAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("entry_status", "negative")))
+	metadataCacheSizeEntryStatusPositiveAttrSet                                                            = metric.WithAttributeSet(attribute.NewSet(attribute.String("entry_status", "positive")))
 	testUpdownCounterWithAttrsRequestTypeAttr1AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr1")))
 	testUpdownCounterWithAttrsRequestTypeAttr2AttrSet                                                      = metric.WithAttributeSet(attribute.NewSet(attribute.String("request_type", "attr2")))
 )
@@ -1040,6 +1042,7 @@ type otelMetrics struct {
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                      *atomic.Int64
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                        *atomic.Int64
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                     *atomic.Int64
+	fsReadBytesCountAtomic                                                                                *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic           *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                       *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                              *atomic.Int64
@@ -1060,6 +1063,7 @@ type otelMetrics struct {
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic             *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                    *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic               *atomic.Int64
+	fsWriteBytesCountAtomic                                                                               *atomic.Int64
 	gcsDownloadBytesCountReadTypeBufferedAtomic                                                           *atomic.Int64
 	gcsDownloadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
 	gcsDownloadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
@@ -1110,6 +1114,8 @@ type otelMetrics struct {
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic                         *atomic.Int64
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic                      *atomic.Int64
 	metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic                    *atomic.Int64
+	metadataCacheSizeEntryStatusNegativeAtomic                                                            *atomic.Int64
+	metadataCacheSizeEntryStatusPositiveAtomic                                                            *atomic.Int64
 	testUpdownCounterAtomic                                                                               *atomic.Int64
 	testUpdownCounterWithAttrsRequestTypeAttr1Atomic                                                      *atomic.Int64
 	testUpdownCounterWithAttrsRequestTypeAttr2Atomic                                                      *atomic.Int64
@@ -2259,6 +2265,15 @@ func (o *otelMetrics) FsOpsLatency(
 	}
 }
 
+func (o *otelMetrics) FsReadBytesCount(
+	inc int64) {
+	if inc < 0 {
+		logger.Errorf("Counter metric fs/read_bytes_count received a negative increment: %d", inc)
+		return
+	}
+	o.fsReadBytesCountAtomic.Add(inc)
+}
+
 func (o *otelMetrics) FsStreamingWriteFallbackCount(
 	inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason) {
 	if inc < 0 {
@@ -2340,6 +2355,15 @@ func (o *otelMetrics) FsStreamingWriteFallbackCount(
 		updateUnrecognizedAttribute(string(openMode))
 		return
 	}
+}
+
+func (o *otelMetrics) FsWriteBytesCount(
+	inc int64) {
+	if inc < 0 {
+		logger.Errorf("Counter metric fs/write_bytes_count received a negative increment: %d", inc)
+		return
+	}
+	o.fsWriteBytesCountAtomic.Add(inc)
 }
 
 func (o *otelMetrics) GcsDownloadBytesCount(
@@ -2622,6 +2646,19 @@ func (o *otelMetrics) MetadataCacheReadCount(
 			updateUnrecognizedAttribute(string(entryStatus))
 			return
 		}
+	}
+}
+
+func (o *otelMetrics) MetadataCacheSize(
+	inc int64, entryStatus EntryStatus) {
+	switch entryStatus {
+	case EntryStatusNegativeAttr:
+		o.metadataCacheSizeEntryStatusNegativeAtomic.Add(inc)
+	case EntryStatusPositiveAttr:
+		o.metadataCacheSizeEntryStatusPositiveAtomic.Add(inc)
+	default:
+		updateUnrecognizedAttribute(string(entryStatus))
+		return
 	}
 }
 
@@ -3115,6 +3152,8 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic atomic.Int64
 
+	var fsReadBytesCountAtomic atomic.Int64
+
 	var fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
@@ -3135,6 +3174,8 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic atomic.Int64
+
+	var fsWriteBytesCountAtomic atomic.Int64
 
 	var gcsDownloadBytesCountReadTypeBufferedAtomic,
 		gcsDownloadBytesCountReadTypeParallelAtomic,
@@ -3192,6 +3233,9 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic atomic.Int64
+
+	var metadataCacheSizeEntryStatusNegativeAtomic,
+		metadataCacheSizeEntryStatusPositiveAtomic atomic.Int64
 
 	var testUpdownCounterAtomic atomic.Int64
 
@@ -3687,7 +3731,15 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metric.WithUnit("us"),
 		metric.WithExplicitBucketBoundaries(50, 100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000, 20000000, 50000000, 100000000, 200000000, 500000000))
 
-	_, err8 := meter.Int64ObservableCounter("fs/streaming_write_fallback_count",
+	_, err8 := meter.Int64ObservableCounter("fs/read_bytes_count",
+		metric.WithDescription("The cumulative number of bytes read from GCS fuse by kernel"),
+		metric.WithUnit("By"),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &fsReadBytesCountAtomic)
+			return nil
+		}))
+
+	_, err9 := meter.Int64ObservableCounter("fs/streaming_write_fallback_count",
 		metric.WithDescription("The cumulative number of streaming write fallbacks with reason attached"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3714,7 +3766,15 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err9 := meter.Int64ObservableCounter("gcs/download_bytes_count",
+	_, err10 := meter.Int64ObservableCounter("fs/write_bytes_count",
+		metric.WithDescription("The cumulative number of bytes written to GCS fuse by kernel"),
+		metric.WithUnit("By"),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			conditionallyObserve(obsrv, &fsWriteBytesCountAtomic)
+			return nil
+		}))
+
+	_, err11 := meter.Int64ObservableCounter("gcs/download_bytes_count",
 		metric.WithDescription("The cumulative number of bytes downloaded from GCS along with type - Sequential/Random"),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3725,7 +3785,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err10 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3733,7 +3793,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err11 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3744,7 +3804,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err12 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3753,7 +3813,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3779,12 +3839,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err14 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err15 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3793,7 +3853,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err16 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3818,12 +3878,21 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err17 := meter.Int64Histogram("read/block_sizes",
+	_, err19 := meter.Int64ObservableUpDownCounter("metadata_cache/size",
+		metric.WithDescription("The total size of the entries in the metadata cache"),
+		metric.WithUnit(""),
+		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
+			observeUpDownCounter(obsrv, &metadataCacheSizeEntryStatusNegativeAtomic, metadataCacheSizeEntryStatusNegativeAttrSet)
+			observeUpDownCounter(obsrv, &metadataCacheSizeEntryStatusPositiveAtomic, metadataCacheSizeEntryStatusPositiveAttrSet)
+			return nil
+		}))
+
+	readBlockSizes, err20 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err18 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3831,7 +3900,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err19 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err22 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3840,7 +3909,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21, err22}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4289,7 +4358,8 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic:                   &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic:                     &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic:                  &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic,
-		fsOpsLatency: fsOpsLatency,
+		fsOpsLatency:           fsOpsLatency,
+		fsReadBytesCountAtomic: &fsReadBytesCountAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:           &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                       &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                              &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
@@ -4310,10 +4380,11 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
-		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                           &gcsDownloadBytesCountReadTypeBufferedAtomic,
-		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
-		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
-		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
+		fsWriteBytesCountAtomic:                                                            &fsWriteBytesCountAtomic,
+		gcsDownloadBytesCountReadTypeBufferedAtomic:                                        &gcsDownloadBytesCountReadTypeBufferedAtomic,
+		gcsDownloadBytesCountReadTypeParallelAtomic:                                        &gcsDownloadBytesCountReadTypeParallelAtomic,
+		gcsDownloadBytesCountReadTypeRandomAtomic:                                          &gcsDownloadBytesCountReadTypeRandomAtomic,
+		gcsDownloadBytesCountReadTypeSequentialAtomic:                                      &gcsDownloadBytesCountReadTypeSequentialAtomic,
 		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
 		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,
@@ -4361,6 +4432,8 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic:      &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic:   &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailNotFoundAtomic,
 		metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic: &metadataCacheReadCountCacheHitFalseEntryStatusPositiveLookupDetailTtlExpiredAtomic,
+		metadataCacheSizeEntryStatusNegativeAtomic:                                         &metadataCacheSizeEntryStatusNegativeAtomic,
+		metadataCacheSizeEntryStatusPositiveAtomic:                                         &metadataCacheSizeEntryStatusPositiveAtomic,
 		readBlockSizes:          readBlockSizes,
 		testUpdownCounterAtomic: &testUpdownCounterAtomic,
 		testUpdownCounterWithAttrsRequestTypeAttr1Atomic: &testUpdownCounterWithAttrsRequestTypeAttr1Atomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -1042,7 +1042,6 @@ type otelMetrics struct {
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic                                      *atomic.Int64
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic                                        *atomic.Int64
 	fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic                                     *atomic.Int64
-	fsReadBytesCountAtomic                                                                                *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic           *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic                       *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic                              *atomic.Int64
@@ -1063,7 +1062,6 @@ type otelMetrics struct {
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic             *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic                    *atomic.Int64
 	fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic               *atomic.Int64
-	fsWriteBytesCountAtomic                                                                               *atomic.Int64
 	gcsDownloadBytesCountReadTypeBufferedAtomic                                                           *atomic.Int64
 	gcsDownloadBytesCountReadTypeParallelAtomic                                                           *atomic.Int64
 	gcsDownloadBytesCountReadTypeRandomAtomic                                                             *atomic.Int64
@@ -2265,15 +2263,6 @@ func (o *otelMetrics) FsOpsLatency(
 	}
 }
 
-func (o *otelMetrics) FsReadBytesCount(
-	inc int64) {
-	if inc < 0 {
-		logger.Errorf("Counter metric fs/read_bytes_count received a negative increment: %d", inc)
-		return
-	}
-	o.fsReadBytesCountAtomic.Add(inc)
-}
-
 func (o *otelMetrics) FsStreamingWriteFallbackCount(
 	inc int64, openMode OpenMode, writeFallbackReason WriteFallbackReason) {
 	if inc < 0 {
@@ -2355,15 +2344,6 @@ func (o *otelMetrics) FsStreamingWriteFallbackCount(
 		updateUnrecognizedAttribute(string(openMode))
 		return
 	}
-}
-
-func (o *otelMetrics) FsWriteBytesCount(
-	inc int64) {
-	if inc < 0 {
-		logger.Errorf("Counter metric fs/write_bytes_count received a negative increment: %d", inc)
-		return
-	}
-	o.fsWriteBytesCountAtomic.Add(inc)
 }
 
 func (o *otelMetrics) GcsDownloadBytesCount(
@@ -3152,8 +3132,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic atomic.Int64
 
-	var fsReadBytesCountAtomic atomic.Int64
-
 	var fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
@@ -3174,8 +3152,6 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic atomic.Int64
-
-	var fsWriteBytesCountAtomic atomic.Int64
 
 	var gcsDownloadBytesCountReadTypeBufferedAtomic,
 		gcsDownloadBytesCountReadTypeParallelAtomic,
@@ -3731,15 +3707,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		metric.WithUnit("us"),
 		metric.WithExplicitBucketBoundaries(50, 100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000, 1000000, 2000000, 5000000, 10000000, 20000000, 50000000, 100000000, 200000000, 500000000))
 
-	_, err8 := meter.Int64ObservableCounter("fs/read_bytes_count",
-		metric.WithDescription("The cumulative number of bytes read from GCS fuse by kernel"),
-		metric.WithUnit("By"),
-		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &fsReadBytesCountAtomic)
-			return nil
-		}))
-
-	_, err9 := meter.Int64ObservableCounter("fs/streaming_write_fallback_count",
+	_, err8 := meter.Int64ObservableCounter("fs/streaming_write_fallback_count",
 		metric.WithDescription("The cumulative number of streaming write fallbacks with reason attached"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3766,15 +3734,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err10 := meter.Int64ObservableCounter("fs/write_bytes_count",
-		metric.WithDescription("The cumulative number of bytes written to GCS fuse by kernel"),
-		metric.WithUnit("By"),
-		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
-			conditionallyObserve(obsrv, &fsWriteBytesCountAtomic)
-			return nil
-		}))
-
-	_, err11 := meter.Int64ObservableCounter("gcs/download_bytes_count",
+	_, err9 := meter.Int64ObservableCounter("gcs/download_bytes_count",
 		metric.WithDescription("The cumulative number of bytes downloaded from GCS along with type - Sequential/Random"),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3785,7 +3745,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err12 := meter.Int64ObservableCounter("gcs/read_bytes_count",
+	_, err10 := meter.Int64ObservableCounter("gcs/read_bytes_count",
 		metric.WithDescription("The cumulative number of bytes read from GCS objects."),
 		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3793,7 +3753,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err13 := meter.Int64ObservableCounter("gcs/read_count",
+	_, err11 := meter.Int64ObservableCounter("gcs/read_count",
 		metric.WithDescription("Specifies the number of gcs reads made along with type - Sequential/Random"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3804,7 +3764,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err14 := meter.Int64ObservableCounter("gcs/reader_count",
+	_, err12 := meter.Int64ObservableCounter("gcs/reader_count",
 		metric.WithDescription("The cumulative number of GCS object readers opened or closed."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3813,7 +3773,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err15 := meter.Int64ObservableCounter("gcs/request_count",
+	_, err13 := meter.Int64ObservableCounter("gcs/request_count",
 		metric.WithDescription("The cumulative number of GCS requests processed along with the GCS method."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3839,12 +3799,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	gcsRequestLatencies, err16 := meter.Int64Histogram("gcs/request_latencies",
+	gcsRequestLatencies, err14 := meter.Int64Histogram("gcs/request_latencies",
 		metric.WithDescription("The cumulative distribution of the GCS request latencies."),
 		metric.WithUnit("ms"),
 		metric.WithExplicitBucketBoundaries(100, 200, 400, 800, 1500, 3000, 5000, 10000, 20000, 50000, 100000, 200000, 500000))
 
-	_, err17 := meter.Int64ObservableCounter("gcs/retry_count",
+	_, err15 := meter.Int64ObservableCounter("gcs/retry_count",
 		metric.WithDescription("The cumulative number of retry requests made to GCS."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3853,7 +3813,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err18 := meter.Int64ObservableCounter("metadata_cache/read_count",
+	_, err16 := meter.Int64ObservableCounter("metadata_cache/read_count",
 		metric.WithDescription("Total number of read requests to the metadata cache. Use attributes to analyze hit/miss ratios, entry types, and specific lookup outcomes (e.g., expiration vs. total absence)."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3878,7 +3838,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err19 := meter.Int64ObservableUpDownCounter("metadata_cache/size",
+	_, err17 := meter.Int64ObservableUpDownCounter("metadata_cache/size",
 		metric.WithDescription("The total size of the entries in the metadata cache"),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3887,12 +3847,12 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	readBlockSizes, err20 := meter.Int64Histogram("read/block_sizes",
+	readBlockSizes, err18 := meter.Int64Histogram("read/block_sizes",
 		metric.WithDescription("The cumulative distribution of read block sizes across different bucket boundaries"),
 		metric.WithUnit("By"),
 		metric.WithExplicitBucketBoundaries(0, 8192, 16384, 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304, 8388608, 16777216, 33554432, 67108864, 134217728))
 
-	_, err21 := meter.Int64ObservableUpDownCounter("test/updown_counter",
+	_, err19 := meter.Int64ObservableUpDownCounter("test/updown_counter",
 		metric.WithDescription("Test metric for updown counters."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3900,7 +3860,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	_, err22 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
+	_, err20 := meter.Int64ObservableUpDownCounter("test/updown_counter_with_attrs",
 		metric.WithDescription("Test metric for updown counters with attributes."),
 		metric.WithUnit(""),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
@@ -3909,7 +3869,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 			return nil
 		}))
 
-	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20, err21, err22}
+	errs := []error{err0, err1, err2, err3, err4, err5, err6, err7, err8, err9, err10, err11, err12, err13, err14, err15, err16, err17, err18, err19, err20}
 	if err := errors.Join(errs...); err != nil {
 		return nil, err
 	}
@@ -4358,8 +4318,7 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic:                   &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpSyncFileAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic:                     &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpUnlinkAtomic,
 		fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic:                  &fsOpsErrorCountFsErrorCategoryTOOMANYOPENFILESFsOpWriteFileAtomic,
-		fsOpsLatency:           fsOpsLatency,
-		fsReadBytesCountAtomic: &fsReadBytesCountAtomic,
+		fsOpsLatency: fsOpsLatency,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic:           &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonConcurrencyLimitBreachedAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic:                       &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic:                              &fsStreamingWriteFallbackCountOpenModeOtherWriteFallbackReasonOtherAtomic,
@@ -4380,11 +4339,10 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic:             &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonExistingFileAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic:                    &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOtherAtomic,
 		fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic:               &fsStreamingWriteFallbackCountOpenModeWriteOnlyAppendWriteFallbackReasonOutOfOrderAtomic,
-		fsWriteBytesCountAtomic:                                                            &fsWriteBytesCountAtomic,
-		gcsDownloadBytesCountReadTypeBufferedAtomic:                                        &gcsDownloadBytesCountReadTypeBufferedAtomic,
-		gcsDownloadBytesCountReadTypeParallelAtomic:                                        &gcsDownloadBytesCountReadTypeParallelAtomic,
-		gcsDownloadBytesCountReadTypeRandomAtomic:                                          &gcsDownloadBytesCountReadTypeRandomAtomic,
-		gcsDownloadBytesCountReadTypeSequentialAtomic:                                      &gcsDownloadBytesCountReadTypeSequentialAtomic,
+		gcsDownloadBytesCountReadTypeBufferedAtomic:                                                           &gcsDownloadBytesCountReadTypeBufferedAtomic,
+		gcsDownloadBytesCountReadTypeParallelAtomic:                                                           &gcsDownloadBytesCountReadTypeParallelAtomic,
+		gcsDownloadBytesCountReadTypeRandomAtomic:                                                             &gcsDownloadBytesCountReadTypeRandomAtomic,
+		gcsDownloadBytesCountReadTypeSequentialAtomic:                                                         &gcsDownloadBytesCountReadTypeSequentialAtomic,
 		gcsReadBytesCountAtomic:                                                            &gcsReadBytesCountAtomic,
 		gcsReadCountReadTypeParallelAtomic:                                                 &gcsReadCountReadTypeParallelAtomic,
 		gcsReadCountReadTypeRandomAtomic:                                                   &gcsReadCountReadTypeRandomAtomic,

--- a/metrics/otel_metrics.go
+++ b/metrics/otel_metrics.go
@@ -3839,8 +3839,8 @@ func NewOTelMetrics(ctx context.Context, workers int, bufferSize int) (*otelMetr
 		}))
 
 	_, err17 := meter.Int64ObservableUpDownCounter("metadata_cache/size",
-		metric.WithDescription("The total size of the entries in the metadata cache"),
-		metric.WithUnit(""),
+		metric.WithDescription("The total memory size (in bytes) of the entries in the metadata cache"),
+		metric.WithUnit("By"),
 		metric.WithInt64Callback(func(_ context.Context, obsrv metric.Int64Observer) error {
 			observeUpDownCounter(obsrv, &metadataCacheSizeEntryStatusNegativeAtomic, metadataCacheSizeEntryStatusNegativeAttrSet)
 			observeUpDownCounter(obsrv, &metadataCacheSizeEntryStatusPositiveAtomic, metadataCacheSizeEntryStatusPositiveAttrSet)

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4570,6 +4570,31 @@ func TestFsOpsLatency(t *testing.T) {
 	}
 }
 
+func TestFsReadBytesCount(t *testing.T) {
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
+
+	m.FsReadBytesCount(1024)
+	m.FsReadBytesCount(2048)
+	waitForMetricsProcessing()
+
+	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok := metrics["fs/read_bytes_count"]
+	require.True(t, ok, "fs/read_bytes_count metric not found")
+	s := attribute.NewSet()
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
+
+	// Test negative increment
+	m.FsReadBytesCount(-100)
+	waitForMetricsProcessing()
+
+	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok = metrics["fs/read_bytes_count"]
+	require.True(t, ok, "fs/read_bytes_count metric not found after negative increment")
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
+}
+
 func TestFsStreamingWriteFallbackCount(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -4799,6 +4824,31 @@ func TestFsStreamingWriteFallbackCount(t *testing.T) {
 			assert.Equal(t, expectedMap, metric)
 		})
 	}
+}
+
+func TestFsWriteBytesCount(t *testing.T) {
+	ctx := context.Background()
+	encoder := attribute.DefaultEncoder()
+	m, rd := setupOTel(ctx, t)
+
+	m.FsWriteBytesCount(1024)
+	m.FsWriteBytesCount(2048)
+	waitForMetricsProcessing()
+
+	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok := metrics["fs/write_bytes_count"]
+	require.True(t, ok, "fs/write_bytes_count metric not found")
+	s := attribute.NewSet()
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
+
+	// Test negative increment
+	m.FsWriteBytesCount(-100)
+	waitForMetricsProcessing()
+
+	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
+	metric, ok = metrics["fs/write_bytes_count"]
+	require.True(t, ok, "fs/write_bytes_count metric not found after negative increment")
+	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
 }
 
 func TestGcsDownloadBytesCount(t *testing.T) {
@@ -5698,6 +5748,75 @@ func TestMetadataCacheReadCount(t *testing.T) {
 				return
 			}
 			require.True(t, ok, "metadata_cache/read_count metric not found")
+			expectedMap := make(map[string]int64)
+			for k, v := range tc.expected {
+				expectedMap[k.Encoded(encoder)] = v
+			}
+			assert.Equal(t, expectedMap, metric)
+		})
+	}
+}
+
+func TestMetadataCacheSize(t *testing.T) {
+	tests := []struct {
+		name     string
+		f        func(m *otelMetrics)
+		expected map[attribute.Set]int64
+	}{
+		{
+			name: "entry_status_negative",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheSize(5, "negative")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("entry_status", "negative")): 5,
+			},
+		},
+		{
+			name: "entry_status_positive",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheSize(5, "positive")
+			},
+			expected: map[attribute.Set]int64{
+				attribute.NewSet(attribute.String("entry_status", "positive")): 5,
+			},
+		}, {
+			name: "multiple_attributes_summed",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheSize(5, "negative")
+				m.MetadataCacheSize(2, "positive")
+				m.MetadataCacheSize(3, "negative")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("entry_status", "negative")): 8,
+				attribute.NewSet(attribute.String("entry_status", "positive")): 2,
+			},
+		},
+		{
+			name: "negative_increment",
+			f: func(m *otelMetrics) {
+				m.MetadataCacheSize(-5, "negative")
+				m.MetadataCacheSize(2, "negative")
+			},
+			expected: map[attribute.Set]int64{attribute.NewSet(attribute.String("entry_status", "negative")): -3},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			encoder := attribute.DefaultEncoder()
+			m, rd := setupOTel(ctx, t)
+
+			tc.f(m)
+			waitForMetricsProcessing()
+
+			metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
+			metric, ok := metrics["metadata_cache/size"]
+			if len(tc.expected) == 0 {
+				assert.False(t, ok, "metadata_cache/size metric should not be found")
+				return
+			}
+			require.True(t, ok, "metadata_cache/size metric not found")
 			expectedMap := make(map[string]int64)
 			for k, v := range tc.expected {
 				expectedMap[k.Encoded(encoder)] = v

--- a/metrics/otel_metrics_test.go
+++ b/metrics/otel_metrics_test.go
@@ -4570,31 +4570,6 @@ func TestFsOpsLatency(t *testing.T) {
 	}
 }
 
-func TestFsReadBytesCount(t *testing.T) {
-	ctx := context.Background()
-	encoder := attribute.DefaultEncoder()
-	m, rd := setupOTel(ctx, t)
-
-	m.FsReadBytesCount(1024)
-	m.FsReadBytesCount(2048)
-	waitForMetricsProcessing()
-
-	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok := metrics["fs/read_bytes_count"]
-	require.True(t, ok, "fs/read_bytes_count metric not found")
-	s := attribute.NewSet()
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
-
-	// Test negative increment
-	m.FsReadBytesCount(-100)
-	waitForMetricsProcessing()
-
-	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok = metrics["fs/read_bytes_count"]
-	require.True(t, ok, "fs/read_bytes_count metric not found after negative increment")
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
-}
-
 func TestFsStreamingWriteFallbackCount(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -4824,31 +4799,6 @@ func TestFsStreamingWriteFallbackCount(t *testing.T) {
 			assert.Equal(t, expectedMap, metric)
 		})
 	}
-}
-
-func TestFsWriteBytesCount(t *testing.T) {
-	ctx := context.Background()
-	encoder := attribute.DefaultEncoder()
-	m, rd := setupOTel(ctx, t)
-
-	m.FsWriteBytesCount(1024)
-	m.FsWriteBytesCount(2048)
-	waitForMetricsProcessing()
-
-	metrics := gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok := metrics["fs/write_bytes_count"]
-	require.True(t, ok, "fs/write_bytes_count metric not found")
-	s := attribute.NewSet()
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Positive increments should be summed.")
-
-	// Test negative increment
-	m.FsWriteBytesCount(-100)
-	waitForMetricsProcessing()
-
-	metrics = gatherNonZeroCounterMetrics(ctx, t, rd)
-	metric, ok = metrics["fs/write_bytes_count"]
-	require.True(t, ok, "fs/write_bytes_count metric not found after negative increment")
-	assert.Equal(t, map[string]int64{s.Encoded(encoder): 3072}, metric, "Negative increment should not change the metric value.")
 }
 
 func TestGcsDownloadBytesCount(t *testing.T) {


### PR DESCRIPTION
### Description
Add the **metadata_cache/size** metric generated code methods.
The metric is implemented as **int_up_down_counter** metric which functions as gauge for the prometheus or google cloud monitor perspective. 

### Link to the issue in case of a bug fix.
b/511997897 

### Testing details
1. Manual - NA
2. Unit tests - Auto generated tests are added.
3. Integration tests - NA

### Any backward incompatible change? If so, please explain.
N/A