### PR TITLE
feat(flags): support enable-grpc-by-default flag for dynamic gRPC selection

### DIFF
--- a/cfg/config.go
+++ b/cfg/config.go
@@ -658,6 +658,8 @@ type GcsConnectionConfig struct {
 
 	CustomEndpoint string `yaml:"custom-endpoint"`
 
+	EnableGrpcByDefault bool `yaml:"enable-grpc-by-default"`
+
 	EnableHttpDnsCache bool `yaml:"enable-http-dns-cache"`
 
 	ExperimentalEnableJsonRead bool `yaml:"experimental-enable-json-read"`
@@ -1022,6 +1024,12 @@ func BuildFlagSet(flagSet *pflag.FlagSet) error {
 	flagSet.BoolP("enable-google-lib-auth", "", true, "Enable google library authentication method to fetch the credentials")
 
 	if err := flagSet.MarkHidden("enable-google-lib-auth"); err != nil {
+		return err
+	}
+
+	flagSet.BoolP("enable-grpc-by-default", "", false, "If true, enables gRPC protocol by default (e.g. for new GKE deployments).")
+
+	if err := flagSet.MarkHidden("enable-grpc-by-default"); err != nil {
 		return err
 	}
 
@@ -1689,6 +1697,10 @@ func BindFlags(v *viper.Viper, flagSet *pflag.FlagSet) error {
 	}
 
 	if err := v.BindPFlag("enable-google-lib-auth", flagSet.Lookup("enable-google-lib-auth")); err != nil {
+		return err
+	}
+
+	if err := v.BindPFlag("gcs-connection.enable-grpc-by-default", flagSet.Lookup("enable-grpc-by-default")); err != nil {
 		return err
 	}
 

--- a/cfg/config.proto
+++ b/cfg/config.proto
@@ -180,4 +180,5 @@ message Config {
   bool write_finalize_file_for_rapid = 156;
   sint64 write_global_max_blocks = 157;
   sint64 write_max_blocks_per_file = 158;
+  bool gcs_connection_enable_grpc_by_default = 159;
 }

--- a/cfg/constants.go
+++ b/cfg/constants.go
@@ -99,6 +99,8 @@ const (
 	//parallel-downloads enablement.
 	FileCacheParallelDownloadsConfigKey = "file-cache.enable-parallel-downloads"
 	maxSupportedStatCacheMaxSizeMB      = util.MaxMiBsInUint64
+	// ClientProtocolConfigKey is the Viper configuration key for the client protocol.
+	ClientProtocolConfigKey = "gcs-connection.client-protocol"
 )
 
 // CacheUtilMinimumAlignSizeForWriting is the minimum buffer size used for memory-aligned

--- a/cfg/params.yaml
+++ b/cfg/params.yaml
@@ -734,6 +734,15 @@ params:
       To specify a custom storage endpoint, ensure it supports the same resources as the default storage.googleapis.com:443 and includes the port number.
     default: ""
 
+  - config-path: "gcs-connection.enable-grpc-by-default"
+    proto-tag: 159
+    flag-name: "enable-grpc-by-default"
+    type: "bool"
+    usage: >-
+      If true, enables gRPC protocol by default (e.g. for new GKE deployments).
+    default: false
+    hide-flag: true
+
   - config-path: "gcs-connection.enable-http-dns-cache"
     proto-tag: 73
     flag-name: "enable-http-dns-cache"

--- a/cfg/rationalize.go
+++ b/cfg/rationalize.go
@@ -188,6 +188,20 @@ func resolveKernelReadAhead(v *viper.Viper, c *Config) {
 	c.FileSystem.MaxReadAheadKb = max(c.FileSystem.MaxReadAheadKb, c.FileSystem.FuseMaxRequestSizeKb)
 }
 
+// resolveClientProtocol dynamically selects gRPC protocol when EnableGrpcByDefault
+// is enabled. If client-protocol was explicitly specified by the user (via CLI
+// flag or config file), it is always honored.
+func resolveClientProtocol(v *viper.Viper, c *GcsConnectionConfig) {
+	// If client-protocol is explicitly set by the user, honor the user's explicit configuration.
+	if v != nil && v.IsSet(ClientProtocolConfigKey) {
+		return
+	}
+
+	if c.EnableGrpcByDefault {
+		c.ClientProtocol = GRPC
+	}
+}
+
 // Rationalize updates the config fields based on the values of other fields.
 func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	var err error
@@ -211,6 +225,7 @@ func Rationalize(v *viper.Viper, c *Config, optimizedFlags []string) error {
 	resolveGCSRetriesConfig(&c.GcsRetries)
 	resolveOnlyDir(c)
 	resolveKernelReadAhead(v, c)
+	resolveClientProtocol(v, &c.GcsConnection)
 
 	return nil
 }

--- a/cfg/rationalize_test.go
+++ b/cfg/rationalize_test.go
@@ -1267,3 +1267,73 @@ func TestRationalizeWithBucketOptimization(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveClientProtocol(t *testing.T) {
+	testCases := []struct {
+		name             string
+		config           *Config
+		userSetFlags     map[string]any
+		expectedProtocol Protocol
+	}{
+		{
+			name: "enable-grpc-by-default is false and client does not pass protocol",
+			config: &Config{
+				GcsConnection: GcsConnectionConfig{
+					ClientProtocol:      HTTP1,
+					EnableGrpcByDefault: false,
+				},
+			},
+			expectedProtocol: HTTP1,
+		},
+		{
+			name: "enable-grpc-by-default is true and client does not pass protocol",
+			config: &Config{
+				GcsConnection: GcsConnectionConfig{
+					ClientProtocol:      HTTP1,
+					EnableGrpcByDefault: true,
+				},
+			},
+			expectedProtocol: GRPC,
+		},
+		{
+			name: "enable-grpc-by-default is true and client passes http1",
+			config: &Config{
+				GcsConnection: GcsConnectionConfig{
+					ClientProtocol:      HTTP1,
+					EnableGrpcByDefault: true,
+				},
+			},
+			userSetFlags: map[string]any{
+				ClientProtocolConfigKey: "http1",
+			},
+			expectedProtocol: HTTP1,
+		},
+		{
+			name: "enable-grpc-by-default is false and client passes grpc",
+			config: &Config{
+				GcsConnection: GcsConnectionConfig{
+					ClientProtocol:      GRPC,
+					EnableGrpcByDefault: false,
+				},
+			},
+			userSetFlags: map[string]any{
+				ClientProtocolConfigKey: "grpc",
+			},
+			expectedProtocol: GRPC,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := viper.New()
+			for k, val := range tc.userSetFlags {
+				v.Set(k, val)
+			}
+
+			err := Rationalize(v, tc.config, []string{})
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedProtocol, tc.config.GcsConnection.ClientProtocol)
+		})
+	}
+}


### PR DESCRIPTION
### Description
- Added hidden CLI flag `--enable-grpc-by-default` (and config parameter `gcs-connection.enable-grpc-by-default`, default `false`) to consume the signal from the GKE GCSFuse CSI Driver (cl/973240436).
- When `--enable-grpc-by-default` is set, GCSFuse switches `ClientProtocol` to `grpc`.
- Preserves explicit customer overrides (e.g. `--client-protocol=http1`, `http2`, `grpc`, or `httpmtls`).
- Safely retains `http1` default for existing clusters / non-GKE setups where the flag is omitted/false.

### Link to the issue in case of a bug fix.
b/556501118

### Testing details
1. Manual - Verified CLI flag parsing and resolution across permutations with compiled `gcsfuse` binary mounts.
2. Unit tests - Added unit test coverage:
   - `cfg/rationalize_test.go`: Added `TestResolveClientProtocol` covering all 4 non-redundant scenarios (`enable-grpc-by-default` true/false with explicit user override or omitted).
   - Ran `go test ./cfg/...` and `go test ./cmd/...` (all passed).
3. Integration tests - Ran full test suite across packages.

### Any backward incompatible change? If so, please explain.
No