### PR TITLE
fix(internal/storage): prevent mock call race on context timeout in stalling control client

### DIFF
--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -42,13 +42,15 @@ type stallingStorageControlClient struct {
 }
 
 func (s *stallingStorageControlClient) stall(ctx context.Context, stallDuration *time.Duration) error {
-	if stallDuration != nil && *stallDuration > 0 {
-		timer := time.NewTimer(*stallDuration)
-		defer timer.Stop()
-		select {
-		case <-timer.C:
-		case <-ctx.Done():
-		}
+	if stallDuration == nil || *stallDuration <= 0 {
+		return ctx.Err()
+	}
+
+	timer := time.NewTimer(*stallDuration)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+	case <-ctx.Done():
 	}
 	return ctx.Err()
 }

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -42,16 +42,12 @@ type stallingStorageControlClient struct {
 }
 
 func (s *stallingStorageControlClient) stall(ctx context.Context, stallDuration *time.Duration) error {
-	if err := ctx.Err(); err != nil {
-		return err
-	}
 	if stallDuration != nil && *stallDuration > 0 {
 		timer := time.NewTimer(*stallDuration)
 		defer timer.Stop()
 		select {
 		case <-timer.C:
 		case <-ctx.Done():
-			return ctx.Err()
 		}
 	}
 	return ctx.Err()

--- a/internal/storage/control_client_wrapper_test.go
+++ b/internal/storage/control_client_wrapper_test.go
@@ -41,57 +41,53 @@ type stallingStorageControlClient struct {
 	stallDurationForFolderAPIs       *time.Duration
 }
 
-func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
-	if s.stallDurationForGetStorageLayout != nil {
+func (s *stallingStorageControlClient) stall(ctx context.Context, stallDuration *time.Duration) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if stallDuration != nil && *stallDuration > 0 {
+		timer := time.NewTimer(*stallDuration)
+		defer timer.Stop()
 		select {
-		case <-time.After(*s.stallDurationForGetStorageLayout):
+		case <-timer.C:
 		case <-ctx.Done():
-			return nil, ctx.Err()
+			return ctx.Err()
 		}
+	}
+	return ctx.Err()
+}
+
+func (s *stallingStorageControlClient) GetStorageLayout(ctx context.Context, req *controlpb.GetStorageLayoutRequest, opts ...gax.CallOption) (*controlpb.StorageLayout, error) {
+	if err := s.stall(ctx, s.stallDurationForGetStorageLayout); err != nil {
+		return nil, err
 	}
 	return s.wrapped.GetStorageLayout(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) DeleteFolder(ctx context.Context, req *controlpb.DeleteFolderRequest, opts ...gax.CallOption) error {
-	if s.stallDurationForFolderAPIs != nil {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return ctx.Err()
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return err
 	}
 	return s.wrapped.DeleteFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) GetFolder(ctx context.Context, req *controlpb.GetFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.GetFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) RenameFolder(ctx context.Context, req *controlpb.RenameFolderRequest, opts ...gax.CallOption) (*control.RenameFolderOperation, error) {
-	if s.stallDurationForFolderAPIs != nil {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.RenameFolder(ctx, req, opts...)
 }
 
 func (s *stallingStorageControlClient) CreateFolder(ctx context.Context, req *controlpb.CreateFolderRequest, opts ...gax.CallOption) (*controlpb.Folder, error) {
-	if s.stallDurationForFolderAPIs != nil {
-		select {
-		case <-time.After(*s.stallDurationForFolderAPIs):
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		}
+	if err := s.stall(ctx, s.stallDurationForFolderAPIs); err != nil {
+		return nil, err
 	}
 	return s.wrapped.CreateFolder(ctx, req, opts...)
 }


### PR DESCRIPTION
### Description
Fixes test flakiness in `TestControlClientWrapperTestSuite` timeout tests. In `stallingStorageControlClient`, Go's `select` between timer and `ctx.Done()` could choose the timer when both are ready, which could happen if due to CPU pressure, when the select clause is executed, the timer would have expired as well, forwarding calls to `MockStorageControlClient` unexpectedly.

Replaced inlined `select` blocks with a unified `stall()` helper that checks `ctx.Err()` and exits early on timeout/cancellation without invoking the underlying mock.

### Link to the issue in case of a bug fix.
b/553889914

### Testing details
1. Manual - `make build`
2. Unit tests -
   - `go test -v -count=50 ./internal/storage -run TestControlClientWrapperTestSuite`
   - `go test ./internal/storage`
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A