### PR TITLE
test(integration): disable inactive_stream_timeout for zonal buckets

### DIFF
--- a/tools/integration_tests/test_config.yaml
+++ b/tools/integration_tests/test_config.yaml
@@ -865,7 +865,7 @@ inactive_stream_timeout:
         compatible:
           flat: true
           hns: true
-          zonal: true
+          zonal: false
         run: TestTimeoutEnabledSuite
         run_on_gke: true
       - flags:


### PR DESCRIPTION
### Description
`inactive_stream_timeout` is not a valid test package for Zonal buckets because Zonal buckets default to `enable-kernel-reader: true`. This default behavior bypasses the userspace idle stream cleanup mechanism that this test suite is designed to validate. 

This PR updates `test_config.yaml` to set `zonal: false` for `inactive_stream_timeout` so that GKE E2E tests will properly skip it on Zonal buckets, allowing the test harness override (`enable-kernel-reader: false`) to be safely removed.

GCSFuse CI/CD already [skips](https://github.com/GoogleCloudPlatform/gcsfuse/blob/master/tools/integration_tests/improved_run_e2e_tests.sh#L386) this test package explicitly for zonal, hence it is safe to remove .

### Link to the issue in case of a bug fix.
http://b/497815422

### Testing details
1. Manual - NA
2. Unit tests - NA
3. Integration tests - Not needed as the test is anyways skipped for zonal in the cd script.

### Any backward incompatible change? If so, please explain.
None.
