### PR TITLE
test(cache): fix race condition in Test_SequentialReadToRandom

### DIFF
--- a/internal/cache/file/cache_handle_test.go
+++ b/internal/cache/file/cache_handle_test.go
@@ -693,14 +693,49 @@ func (cht *cacheHandleTest) Test_Read_ChangeCacheOrder() {
 	assert.Equal(cht.T(), newObjectName, evictedEntries[0].(data.FileInfo).Key.ObjectName)
 }
 
+type blockingBucket struct {
+	gcs.Bucket
+	blockChan chan struct{}
+}
+
+func (b *blockingBucket) NewReaderWithReadHandle(ctx context.Context, req *gcs.ReadObjectRequest) (gcs.StorageReader, error) {
+	if req.Range != nil && req.Range.Start > 0 {
+		select {
+		case <-b.blockChan:
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return b.Bucket.NewReaderWithReadHandle(ctx, req)
+}
+
 func (cht *cacheHandleTest) Test_SequentialReadToRandom() {
+	blockChan := make(chan struct{})
+	defer close(blockChan)
+
+	fileCacheConfig := &cfg.FileCacheConfig{EnableCrc: true, EnableParallelDownloads: false}
+	cht.cacheHandle.fileDownloadJob = downloader.NewJob(
+		cht.object,
+		&blockingBucket{Bucket: cht.bucket, blockChan: blockChan},
+		cht.cache,
+		DefaultSequentialReadSizeMb,
+		cht.fileSpec,
+		func() {},
+		fileCacheConfig,
+		semaphore.NewWeighted(math.MaxInt64),
+		metrics.NewNoopMetrics(),
+		tracing.NewNoopTracer(),
+		1,
+	)
+	cht.cacheHandle.fileDownloadJob.ReadChunkSize = int64(util.MiB)
+
 	dst := make([]byte, ReadContentSize)
 	firstReqOffset := int64(0)
 	cht.cacheHandle.isSequential.Store(true)
 	cht.cacheHandle.cacheFileForRangeRead = true
 	// Since, it's a sequential read, hence will wait to download till requested offset.
 	_, cacheHit, err := cht.cacheHandle.Read(context.Background(), cht.bucket, cht.object, firstReqOffset, dst)
-	assert.Nil(cht.T(), nil, err)
+	assert.Nil(cht.T(), err)
 	jobStatus := cht.cacheHandle.fileDownloadJob.GetStatus()
 	assert.GreaterOrEqual(cht.T(), jobStatus.Offset, firstReqOffset)
 	assert.False(cht.T(), cacheHit)


### PR DESCRIPTION
### Description
Fixes a race condition in `TestBucketHandleTestSuite/Test_SequentialReadToRandom` in `internal/cache/file/cache_handle_test.go`.

When the sequential read at offset 0 finishes downloading chunk 0 (1 MiB), the background download goroutine continues downloading the rest of the object. Because `TestObjectSize` is 1200 KiB, only 176 KiB remains to be downloaded, which can complete before the subsequent random read at `secondReqOffset = 1196032` is issued. When this happens, the requested range is already cached, causing the read to succeed from cache instead of falling back to GCS (`util.ErrFallbackToGCS`), failing the test assertions.

This change introduces a `blockingBucket` wrapper for the test that allows the initial chunk (`Range.Start == 0`) to proceed normally, but pauses subsequent chunk reads (`Range.Start > 0`) until the test completes. It also fixes an assertion bug (`assert.Nil(cht.T(), nil, err)` -> `assert.Nil(cht.T(), err)`).

### Link to the issue in case of a bug fix.
b/562083993

### Testing details
1. Manual - Reproduced failure with simulated delay before second read; verified clean pass with `blockingBucket`.
2. Unit tests - Ran `go test -v -run TestBucketHandleTestSuite/Test_SequentialReadToRandom ./internal/cache/file -count=500` (500/500 passed). Ran all unit tests in `./internal/cache/file` and `make build`.
3. Integration tests - N/A

### Any backward incompatible change? If so, please explain.
N/A
